### PR TITLE
feat(rules): mandate <design-ref> for FE tasks + PNG-read mandatory (L-002)

### DIFF
--- a/commands/vg/_shared/vg-executor-rules.md
+++ b/commands/vg/_shared/vg-executor-rules.md
@@ -327,15 +327,50 @@ const handleSubmit = async () => {
 };
 ```
 
-## Design fidelity
+## Design fidelity (L-002 lesson reinforcement)
 
-When `<design_context>` is present:
-- READ the screenshot image — this is ground truth for layout
-- READ structural HTML/JSON — this is ground truth for DOM structure
-- READ interactions.md — this maps user actions to handlers
-- Layout + components + spacing MUST match screenshot
-- Interactive behaviors MUST follow interactions.md
-- Do NOT "improve" or reinvent the design — match it exactly
+When the task has `<design-ref>` pointing to a real slug (NOT
+`no-asset:...`), `<design_context>` will be injected listing one or more
+PNG paths under `${PLANNING_DIR}/phases/{phase}/design/screenshots/`.
+
+**MANDATORY workflow before writing any FE code:**
+
+1. **READ each PNG via the Read tool** — vision-capable models (Claude
+   Sonnet/Opus, GPT-4V) see the image directly and extract the structural
+   spec (layout grid, component types, spacing rhythm, copy strings,
+   active states). This step is NOT optional. If you skip it, your output
+   will look generic — `flex items-center justify-center` text-centered
+   stubs instead of the design's AppShell + Sidebar + TopBar + content.
+2. **READ UI-SPEC.md + UI-MAP.md sections** that cover this page (if they
+   exist in the phase dir) — these are the structured token + component
+   tree summaries derived from DESIGN.md.
+3. **READ design/refs/DESIGN.md** for tokens (colors, typography,
+   spacing, shadows) when in doubt — never invent values.
+
+**Output rules:**
+- Layout + component composition + spacing MUST match the screenshot
+  pixel-for-pixel within the per-phase fidelity profile threshold (default
+  SSIM ≥ 0.85 per the design fidelity profile system).
+- Active states, hover states, badge text, copy strings MUST be lifted
+  verbatim from the screenshot when visible.
+- DO NOT invent generic Tailwind utility chains (`flex min-h-screen
+  items-center justify-center` for an authenticated landing page is the
+  L-002 anti-pattern that triggered this rule).
+- Interactive behaviors MUST follow interactions.md / UI-SPEC interactions
+  section.
+- Do NOT "improve" or reinvent the design — match it exactly. If the
+  design says full Sidebar + TopBar + content, you ship Sidebar + TopBar
+  + content even if a simpler "centered card" feels easier.
+
+**Commit citation requirement when `<design-ref>` is set:** include
+`Per design/{slug}.png` in the commit body. The commit-msg hook does not
+yet enforce this (follow-up work), but reviewers grep for it.
+
+**Form B (`<design-ref>no-asset:{reason}>`):** if the task explicitly
+declares no design asset is available, you may proceed without PNG read,
+but you MUST still consult DESIGN.md tokens + UI-SPEC component spec.
+The commit body MUST include `Design: no-asset ({reason})` so the gap is
+visible in review.
 
 ## URL state for list views (R7 — v2.8.4 Phase J — MANDATORY)
 

--- a/commands/vg/_shared/vg-planner-rules.md
+++ b/commands/vg/_shared/vg-planner-rules.md
@@ -73,8 +73,45 @@ profile: {config.profile}
 | `<edits-collection>` | If DB task | Task touches DB collection | Tracks schema impact |
 | `<contract-ref>` | If API task | Contract exists for this endpoint | Line range in API-CONTRACTS.md |
 | `<goals-covered>` | ALWAYS | Every task maps to goals | G-XX IDs from TEST-GOALS.md |
-| `<design-ref>` | If FE task | Design asset exists for this page/component | Slug from design-normalized/ |
+| `<design-ref>` | **MANDATORY for FE tasks** | See Rule 8 below | Slug from manifest.json |
 | `<estimated-loc>` | ALWAYS | Rough LOC delta | Max 250 per task — split if larger |
+
+### Rule 8 — design-ref mandate (L-002 lesson)
+
+A task is an **FE task** if its `<file-path>` matches ANY of these patterns:
+
+- `apps/admin/**`, `apps/merchant/**`, `apps/vendor/**`, `apps/web/**`
+- `packages/ui/src/components/**`, `packages/ui/src/theme/**`
+- File extension `.tsx`, `.jsx`, `.vue`, `.svelte`
+
+For every FE task, you MUST emit ONE of these forms:
+
+```xml
+<!-- Form A — design asset available (preferred): -->
+<design-ref>{slug}</design-ref>
+<!-- where {slug} ∈ phase design/manifest.json screens[].slug array -->
+
+<!-- Form B — design asset NOT available (must be explicit, never silent): -->
+<design-ref>no-asset:{reason}</design-ref>
+<!-- e.g. <design-ref>no-asset:setup-wizard-step3-not-in-pencil-extract</design-ref> -->
+```
+
+**Why mandatory (L-002 lesson):** A real-world Phase 1 build rewrote the
+admin HomePage with generic Tailwind classes (`flex min-h-screen
+items-center justify-center`) without consulting the 20 design PNGs that
+already existed in the phase's design folder, or the UI-SPEC.md /
+UI-MAP.md derived from them. The shipped UI was a single centered card;
+the design called for a full Sidebar + TopBar + content shell. The
+planner schema previously had `<design-ref>` as "If FE task" — the soft
+phrasing let the gap slip through silently. Making it mandatory + adding
+explicit-no-asset (Form B) closes that loophole and forces the gap into
+review-visible debt.
+
+**Validation:** if a phase has `design/manifest.json`, the validator
+(verify-design-ref-coverage) BLOCKs the build when any FE task either
+omits `<design-ref>` entirely OR cites a slug not present in
+`manifest.json[screens][].slug`. Form B's `no-asset:{reason}` is allowed
+but logged to override-debt for review.
 
 ### Wave grouping rules
 


### PR DESCRIPTION
## Summary

- Closes a silent-skip gap where AI-built UI ships generic Tailwind despite the phase having a complete design folder + UI-SPEC.md + UI-MAP.md ready to consume.
- **Layer 1 — `vg-planner-rules.md`:** new Rule 8 makes `<design-ref>` MANDATORY for FE tasks (Form A: slug from manifest.json | Form B: `no-asset:{reason}` explicit gap, never silent).
- **Layer 2 — `vg-executor-rules.md`:** Design fidelity section rewritten — when `<design-ref>` has a real slug, executor MUST Read each PNG via Read tool, cite `Per design/{slug}.png` in commit body. Generic `flex items-center justify-center` for authenticated landing pages explicitly called out as anti-pattern.

## Reproduction (L-002 — captured in downstream project)

A real Phase 1 admin SPA build hit this gap:

- Phase had **20 PNGs** at `design/screenshots/`, full `manifest.json`, **51KB UI-SPEC.md**, **69KB UI-MAP.md**, all generated by `/vg:design-extract`.
- Executor shipped:
  ```tsx
  <main className=\"flex min-h-screen items-center justify-center px-6\">
    <h1 className=\"text-3xl font-semibold\">Printway Admin</h1>
    <a href=\"/users\">Manage users</a>
    …
  </main>
  ```
- Design called for full **Sidebar 240px + TopBar 52px + Quick Actions card grid + Getting Started panel** (matching `merchant-onboarding.png`).
- User feedback: \"giao diện AI làm ra đang bị sơ sài và không bám chính xác vào giao diện đã đề ra sẵn\" (\"the UI AI built is sparse and does not match the prescribed design\").

**Root cause analysis:**
- Planner schema had `<design-ref>` as \"If FE task\" — a soft phrase the planner could (and did) silently omit.
- Executor's existing \"Design fidelity\" section assumed `<design_context>` would arrive but gave no enforcement when it did, and no rule forcing the Read tool over the PNG.
- Pre-existing assets sitting unconsumed: manifest, UI-SPEC, UI-MAP, DESIGN.md tokens.

## Fix details

### Layer 1 — Planner (`commands/vg/_shared/vg-planner-rules.md`)

- Schema row updated: `<design-ref>` from \"If FE task\" → **MANDATORY for FE tasks**.
- New **Rule 8** block defines:
  - **FE task detection** — file path matches `apps/{admin,merchant,vendor,web}/**`, `packages/ui/src/{components,theme}/**`, OR extension `.tsx/.jsx/.vue/.svelte`.
  - **Two emit forms** — Form A: real slug from `manifest.json`; Form B: `no-asset:{reason}` for explicit gaps.
  - **Validation hook** — paired with `verify-design-ref-coverage` validator (catalog entry to land in follow-up) that BLOCKs build when slug missing or not in `manifest.json[screens][].slug`.

### Layer 2 — Executor (`commands/vg/_shared/vg-executor-rules.md`)

- \"Design fidelity\" section replaced (was 7 lines, now 39):
  - **Mandatory workflow** — Read each PNG via Read tool, Read UI-SPEC.md + UI-MAP.md + DESIGN.md tokens BEFORE writing FE code.
  - **Output rules** — match SSIM ≥ profile threshold (default 0.85), lift active states / copy strings verbatim, NO generic Tailwind chains.
  - **Commit citation** — include `Per design/{slug}.png` in commit body.
  - **Form B path** — documented: skip PNG read but still consult tokens, cite `Design: no-asset ({reason})` so gap is review-visible.

## Migration impact

- Existing PLAN.md files with FE tasks but no `<design-ref>`: planner re-emits Form A or Form B at next `/vg:blueprint` run.
- Phases without `design/manifest.json` skip validation (no-op — backwards compatible).
- No breaking change to non-FE tasks (BE, DB, infra, docs unaffected).

## Stats

```
commands/vg/_shared/vg-executor-rules.md | 53 ++++++++++++++++++++++++++------
commands/vg/_shared/vg-planner-rules.md  | 39 ++++++++++++++++++++++-
2 files changed, 82 insertions(+), 10 deletions(-)
```

## Test plan

- [ ] Apply patch on a phase with `design/manifest.json` and verify planner emits `<design-ref>` for every FE task.
- [ ] Apply patch on a phase WITHOUT design assets — verify validator no-ops gracefully.
- [ ] Run a Wave 10-style \"redo\" build on a phase with design assets; confirm executor reads PNGs and produces design-faithful output (SSIM ≥ 0.85 vs reference screenshot).
- [ ] Verify Form B `no-asset:{reason}` appears in override-debt register when used.
- [ ] Backwards compatibility — re-run `/vg:build` on an existing accepted phase; commits with old citations should not be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)