### PR TITLE
fix(validator): preserve --no-headless in playwright MCP entries

### DIFF
--- a/scripts/validators/verify-playwright-mcp-config.py
+++ b/scripts/validators/verify-playwright-mcp-config.py
@@ -58,9 +58,13 @@ def _same_path(left: str | None, right: Path) -> bool:
 
 
 def _playwright_entry(profile_dir: Path) -> dict[str, Any]:
+    # --no-headless: keep browser window visible for human-watchable scans.
+    # @playwright/mcp v0.0.71+ supports both default-headed and explicit
+    # --no-headless; flag is durable across releases. Removed = scans go
+    # invisible, breaking VG /vg:review headed-mode contract.
     return {
         "command": "npx",
-        "args": [MCP_PACKAGE, "--user-data-dir", _display_path(profile_dir)],
+        "args": [MCP_PACKAGE, "--no-headless", "--user-data-dir", _display_path(profile_dir)],
     }
 
 
@@ -239,7 +243,7 @@ def _render_codex_sections(codex_home: Path) -> str:
                 [
                     f"[mcp_servers.playwright{i}]",
                     'command = "npx"',
-                    f'args = ["{MCP_PACKAGE}", "--user-data-dir", "{profile}"]',
+                    f'args = ["{MCP_PACKAGE}", "--no-headless", "--user-data-dir", "{profile}"]',
                 ]
             )
         )


### PR DESCRIPTION
verify-playwright-mcp-config.py's _playwright_entry() and _render_codex_sections() emit MCP server config with only --user-data-dir. When run with --repair (called by /vg:update, install.sh, sync.sh), they overwrite settings.json/config.toml with this bare template — silently stripping any --no-headless flag the user had added manually.

Result: /vg:review Phase 2b Haiku scanners launch invisible browsers, breaking the documented "headed mode" contract in commands/vg/test.md ("Browser mode: HEADED (visible, not headless)").

Fix: bake --no-headless into both Claude and Codex templates so repair preserves the visible-browser invariant.

@playwright/mcp v0.0.71+ documents the flag as durable:
  --headless    run browser in headless mode, headed by default

Existing test_playwright_mcp_config.py assertions still pass — they use _user_data_dir() helper which locates --user-data-dir by name, unaffected by extra flags before it.