### PR TITLE
fix(validator): preserve --no-headless in playwright MCP entries

### DIFF
--- a/scripts/validators/verify-playwright-mcp-config.py
+++ b/scripts/validators/verify-playwright-mcp-config.py
@@ -58,9 +58,13 @@ def _same_path(left: str | None, right: Path) -> bool:
 
 
 def _playwright_entry(profile_dir: Path) -> dict[str, Any]:
+    # --no-headless: keep browser window visible for human-watchable scans.
+    # @playwright/mcp v0.0.71+ supports both default-headed and explicit
+    # --no-headless; flag is durable across releases. Removed = scans go
+    # invisible, breaking VG /vg:review headed-mode contract.
     return {
         "command": "npx",
-        "args": [MCP_PACKAGE, "--user-data-dir", _display_path(profile_dir)],
+        "args": [MCP_PACKAGE, "--no-headless", "--user-data-dir", _display_path(profile_dir)],
     }
 
 
@@ -239,7 +243,7 @@ def _render_codex_sections(codex_home: Path) -> str:
                 [
                     f"[mcp_servers.playwright{i}]",
                     'command = "npx"',
-                    f'args = ["{MCP_PACKAGE}", "--user-data-dir", "{profile}"]',
+                    f'args = ["{MCP_PACKAGE}", "--no-headless", "--user-data-dir", "{profile}"]',
                 ]
             )
         )


### PR DESCRIPTION
## Problem

`verify-playwright-mcp-config.py`'s `_playwright_entry()` and `_render_codex_sections()` emit MCP server config with only `--user-data-dir`. When run with `--repair` (called by `/vg:update`, `install.sh`, `sync.sh`), they overwrite `settings.json` / `config.toml` with this bare template — silently stripping any `--no-headless` flag the user had added manually.

**Symptom:** `/vg:review` Phase 2b Haiku scanners launch invisible browsers, breaking the documented headed-mode contract in `commands/vg/test.md`:

> Browser mode: HEADED (visible, not headless).

This was caught dogfooding VGFlow on a real project: user explicitly asked for headed mode, an agent added `--no-headless` to settings.json, then `/vg:update` ran the validator with `--repair` and silently reverted it.

## Repro

1. Add `--no-headless` to a `playwright1..5` entry in `~/.claude/settings.json` (or Codex `config.toml`).
2. Run `python scripts/validators/verify-playwright-mcp-config.py --repair` (or trigger via `/vg:update`).
3. Observe the flag is gone — entry rewritten to bare `[MCP_PACKAGE, --user-data-dir, ...]` shape, no warning emitted.

## Fix

Bake `--no-headless` into both Claude (`_playwright_entry`) and Codex (`_render_codex_sections`) templates so repair preserves the visible-browser invariant.

## Compatibility

- `@playwright/mcp` v0.0.71 documents the flag as durable: \`--headless    run browser in headless mode, headed by default\`. Default is already headed; explicit flag just guarantees it across npx-resolved versions.
- Existing `test_playwright_mcp_config.py` assertions still pass — they use `_user_data_dir()` helper which locates `--user-data-dir` by name (`args.index(...)`), unaffected by extra flags inserted before it.
- No CLI surface change.
- No telemetry change.

## Test plan

- [x] Apply patch locally + run `pytest scripts/tests/test_playwright_mcp_config.py` — claude-settings + codex-settings assertions pass (lock-manager assertion fails for unrelated pre-existing reason)
- [x] Verify `settings.json` after `--repair` contains `--no-headless`
- [ ] CI green