### PR TITLE
fix(surface-probe): heading format tolerance + api endpoint fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v2.41.5 — surface-probe heading format tolerance + api endpoint fallback chain
+
+External dogfood (PrintwayV3) hit two surface-probe failures during `/vg:review` on a backend-heavy phase (14/21 backend goals routed through `surface-probe.sh`):
+
+### Fixed
+- **`_surface_probe_get_goal_block` strict format** — pre-fix matched only `^## Goal G-XX:` (vgflow canonical). Real-world `TEST-GOALS.md` files written from older templates use `## G-XX —` (em-dash, "Goal" word omitted) or `## G-XX -` (ASCII hyphen). Helper returned empty block → every backend goal classified `SKIPPED|goal_block_not_found` → review fell through to `NOT_SCANNED` → 4c-pre intermediate gate hard-blocked phase even though probes would have passed. Now matches `^## (Goal )?G-XX[^A-Za-z0-9_]` (optional "Goal " word, any non-word separator).
+- **`probe_api` regex too narrow for natural-language criteria** — pre-fix required explicit `<METHOD> <path>` pattern (e.g. `POST /api/v1/foo`) inside the goal's success-criteria bullet list. Real criteria are written in prose: "Endpoint /api/v1/credits/grant tạo credit" (path only) or "Backend trả về 403 với mã credit-overdue" (no endpoint at all). Both cases returned `SKIPPED|no_endpoint_pattern_in_criteria`. Now adds two fallbacks before SKIP:
+  - **Fallback 1** — extract path-only pattern (`/api/...`, `/internal/...`, `/public/...`) from criteria when method is absent. Synthesize `ANY <path>` so downstream frag-extraction stays unchanged.
+  - **Fallback 2** — when criteria has no path either, cross-reference `${phase_dir}/API-CONTRACTS.md` for lines mentioning the goal id (`-B2 -A4` window) and pick the first method+path emitted there. Most projects already declare endpoints in the contract artifact and reference goals by id in surrounding prose.
+- **Dispatcher signature** — `run_surface_probe` now forwards `phase_dir` to `probe_api` (was already forwarding to `probe_integration`); needed so Fallback 2 can locate `API-CONTRACTS.md`.
+
+### Behavior
+- Fully backward-compatible: existing strict-pattern criteria still match in the same code path; fallbacks only fire when the strict regex returns empty. Existing READY/BLOCKED outcomes unchanged.
+- New SKIP message: `SKIPPED|no_endpoint_in_criteria_or_contracts` (was `SKIPPED|no_endpoint_pattern_in_criteria`) — emitted only after all three layers fail.
+
+### Internal
+- Smoke-tested with all three heading formats (`## Goal G-XX:`, `## G-XX —`, `## G-XX -`); block-boundary detection between adjacent goals verified.
+- Smoke-tested both fallback chains with synthetic phases (path-only criteria + API-CONTRACTS cross-ref).
+- Credit: external dogfood report from @vietnhprintway (PrintwayV3 phase 03.4b-merchant-credit, 14 backend goals all SKIPPED before fix).
+
 ## v2.41.4 — Headed-mode preservation in playwright MCP repair (closes PR #56)
 
 ### Fixed

--- a/commands/vg/_shared/lib/surface-probe.sh
+++ b/commands/vg/_shared/lib/surface-probe.sh
@@ -37,10 +37,18 @@ _surface_probe_get_goal_block() {
   local gid="$1"
   local test_goals="$2"
   [ -f "$test_goals" ] || { echo ""; return 1; }
-  # Extract block starting at "## Goal $gid:" until next "## Goal" or EOF
+  # Extract block starting at goal heading until next goal heading or EOF.
+  # Tolerates these heading formats (all observed in real projects):
+  #   ## Goal G-XX: title       (vgflow canonical)
+  #   ## Goal G-XX — title      (em-dash variant)
+  #   ## G-XX — title           (project format, "Goal" word omitted)
+  #   ## G-XX: title
+  #   ## G-XX - title           (ASCII hyphen)
+  # Match logic: heading starts with `^## ` then optional `Goal `, then gid,
+  # then any non-alphanumeric separator (space/colon/em-dash/hyphen/tab).
   awk -v gid="$gid" '
-    $0 ~ "^## Goal " gid ":" { in_block=1; print; next }
-    in_block && /^## Goal / { exit }
+    $0 ~ "^##[ ]+(Goal[ ]+)?" gid "[^A-Za-z0-9_]" { in_block=1; print; next }
+    in_block && $0 ~ "^##[ ]+(Goal[ ]+)?G-[0-9]+[^A-Za-z0-9_]" { exit }
     in_block { print }
   ' "$test_goals"
 }
@@ -65,6 +73,7 @@ _surface_probe_get_criteria() {
 probe_api() {
   local gid="$1"
   local block="$2"
+  local phase_dir="${3:-}"
   local criteria
   criteria=$(_surface_probe_get_criteria "$block")
 
@@ -73,8 +82,34 @@ probe_api() {
   local endpoint_line
   endpoint_line=$(echo "$criteria" | grep -oE '\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[/a-zA-Z0-9][a-zA-Z0-9._/:{}\-]*' | head -1)
 
+  # Fallback 1: criteria written in natural language often omit explicit
+  # method+path. Try path-only patterns (e.g. "/api/v1/credits/grant" or
+  # "/internal/credit/use") that appear without an HTTP verb prefix.
   if [ -z "$endpoint_line" ]; then
-    echo "SKIPPED|no_endpoint_pattern_in_criteria"
+    local path_only
+    path_only=$(echo "$criteria" | grep -oE '/(api|internal|public)/[a-zA-Z0-9._/:{}\-]+' | head -1)
+    if [ -n "$path_only" ]; then
+      # Synthesize a method-agnostic endpoint_line; downstream grep treats
+      # path as the discriminator anyway (frag extraction starts from path).
+      endpoint_line="ANY ${path_only}"
+    fi
+  fi
+
+  # Fallback 2: cross-reference goal_id in API-CONTRACTS.md (when phase_dir
+  # is provided). Real-world TEST-GOALS often defer endpoint shape to the
+  # contract artifact and only reference the goal by id.
+  if [ -z "$endpoint_line" ] && [ -n "$phase_dir" ] && [ -f "${phase_dir}/API-CONTRACTS.md" ]; then
+    local contract_endpoint
+    contract_endpoint=$(grep -B2 -A4 "\b${gid}\b" "${phase_dir}/API-CONTRACTS.md" 2>/dev/null \
+                        | grep -oE '\b(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+[/a-zA-Z0-9][a-zA-Z0-9._/:{}\-]*' \
+                        | head -1)
+    if [ -n "$contract_endpoint" ]; then
+      endpoint_line="$contract_endpoint"
+    fi
+  fi
+
+  if [ -z "$endpoint_line" ]; then
+    echo "SKIPPED|no_endpoint_in_criteria_or_contracts"
     return 0
   fi
 
@@ -334,7 +369,7 @@ run_surface_probe() {
   fi
 
   case "$surface" in
-    api)          probe_api "$gid" "$block" ;;
+    api)          probe_api "$gid" "$block" "$phase_dir" ;;
     data)         probe_data "$gid" "$block" ;;
     integration)  probe_integration "$gid" "$block" "$phase_dir" ;;
     time-driven)  probe_time_driven "$gid" "$block" ;;


### PR DESCRIPTION
## Summary

External dogfood (PrintwayV3 phase `03.4b-merchant-credit`, 14 of 21 goals are backend) hit two `surface-probe.sh` regressions inside `/vg:review` phase 4a — every backend goal classified `NOT_SCANNED`, and the 4c-pre intermediate gate hard-blocked phase exit even though probes would have validated the goals if the helper had matched the inputs.

Two narrow fixes in `commands/vg/_shared/lib/surface-probe.sh`, each gated by an "empty result" check so strict-pattern callers see no behavior change:

1. **Goal heading multi-format tolerance** in `_surface_probe_get_goal_block`. Pre-fix matched only `^## Goal G-XX:` (vgflow canonical). Real `TEST-GOALS.md` files written from older templates use `## G-XX —` (em-dash, "Goal" word omitted) or `## G-XX -` (ASCII hyphen). Helper returned empty block → every probe got `SKIPPED|goal_block_not_found`. Now matches optional `Goal ` prefix + any non-word separator after `gid`.

2. **`probe_api` natural-language criteria fallback chain.** Pre-fix required explicit `<METHOD> <path>` pattern inside the success-criteria bullet list. Real criteria are written in prose:
   - "Endpoint `/api/v1/credits/grant` tạo credit" (path only)
   - "Backend trả về 403 với mã `credit-overdue`" (no endpoint at all)

   Both returned `SKIPPED|no_endpoint_pattern_in_criteria`. Now adds two fallbacks before SKIP:
   - **Fallback 1** — extract path-only (`/api/...`, `/internal/...`, `/public/...`) when method is absent. Synthesize `ANY <path>`; downstream frag extraction stays unchanged.
   - **Fallback 2** — cross-reference goal id in `${phase_dir}/API-CONTRACTS.md` (`-B2 -A4` window) and pick the first method+path. Most projects declare endpoints in the contract artifact and reference goals by id in surrounding prose.

Dispatcher updated to forward `phase_dir` to `probe_api` so Fallback 2 can locate `API-CONTRACTS.md` (`probe_integration` already received it).

## Repro

Before fix, on PrintwayV3 phase 03.4b (14 backend goals):
```
G-04   [critical    ] surface=time-driven    | ✓ READY
G-05   [critical    ] surface=time-driven    | ✓ READY
...
G-07   [critical    ] surface=api            | ↷ SKIPPED  ← criteria has no METHOD path
G-08   [critical    ] surface=api            | ↷ SKIPPED  ← same
G-10   [critical    ] surface=api            | ↷ SKIPPED  ← same
G-21   [nice        ] surface=api            | ↷ SKIPPED  ← same
```

Goal block extraction itself was already broken on the project's `## G-XX —` heading format — the data/time-driven probes only worked because they don't depend on `_surface_probe_get_goal_block` (they grep the whole repo by keyword). The api/integration probes do depend on it, so all api goals routed to SKIP, then fell through to NOT_SCANNED.

After fix, criteria like "Endpoint /api/v1/credits/grant tạo credit" → READY; criteria with zero endpoint info but G-07 referenced from API-CONTRACTS.md `### POST /api/v1/orders` → also READY.

## Test plan

- [x] Heading format A: `## Goal G-01:` (canonical) — block extracted ✓
- [x] Heading format B: `## G-01 —` (em-dash, project format) — block extracted ✓
- [x] Heading format C: `## G-01 -` (ASCII hyphen) — block extracted ✓
- [x] Block boundary: heading B + B2 → first block stops at G-02 heading correctly ✓
- [x] probe_api Fallback 1 (path-only criteria) → READY with handler match ✓
- [x] probe_api Fallback 2 (zero-info criteria + API-CONTRACTS cross-ref) → READY with handler match ✓
- [x] Existing strict-pattern criteria still match in original code path (no regression)

No unit tests added (surface-probe.sh has no existing test fixture); smoke-tested via synthetic phase dirs end-to-end. Happy to add bats/pytest harness as follow-up if maintainer prefers.

## Reporter

External dogfood from `@vietnhprintway` — PrintwayV3 phase 03.4b-merchant-credit, 14 backend goals all SKIPPED before fix, 10/14 transitioned to READY after fix (+ 4 still SKIPPED in subsequent local probe due to insufficient API-CONTRACTS goal-id cross-references — separate dogfood signal, may need follow-up to enrich the contract artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)