### PR TITLE
fix(orchestrator): orphan-run legacy fallback in read/clear_active_run

### DIFF
--- a/scripts/vg-orchestrator/state.py
+++ b/scripts/vg-orchestrator/state.py
@@ -75,9 +75,14 @@ def read_active_run(session_id: str | None = None) -> dict | None:
 
     Resolution order:
       1. .vg/active-runs/{session_id}.json (per-session state)
-      2. Legacy .vg/current-run.json — only when active-runs/ doesn't exist
-         (pre-v2.28.0 install) OR legacy file's session_id matches the
-         requested one (mid-migration safety).
+      2. Legacy .vg/current-run.json fallback — fires when the per-session
+         file is missing AND the legacy snapshot is compatible:
+            - legacy has no session_id (pre-v2.24 install), OR
+            - legacy session_id matches `sid` exactly, OR
+            - legacy session_id is the "unknown" sentinel (orphan run
+              written by a subshell with no CLAUDE_SESSION_ID; the Stop
+              hook must still be able to read + clean it up using the
+              real session_id).
       3. None.
     """
     sid = session_id or _session_id_from_env() or "unknown"
@@ -86,15 +91,22 @@ def read_active_run(session_id: str | None = None) -> dict | None:
     if run:
         return run
 
-    # Legacy fallback. Only when active-runs/ hasn't been populated yet, OR
-    # the legacy snapshot belongs to the same session (or has no session_id
-    # to compare against — pre-v2.24 install).
-    if not ACTIVE_RUNS_DIR.exists():
-        legacy = _read_json(LEGACY_CURRENT_RUN)
-        if legacy:
-            legacy_sid = legacy.get("session_id")
-            if not sid or not legacy_sid or sid == legacy_sid:
-                return legacy
+    # The pre-v2.28 guard `if not ACTIVE_RUNS_DIR.exists()` was too strict:
+    # once the per-session directory existed, orphan-written legacy
+    # snapshots became unreachable from any session that did not share
+    # their sid, even though they still represented a real active run.
+    # Symptom: Stop hook firing run-complete with the real Claude session_id
+    # reported "No active run to complete" while run-status (called from
+    # the same subshell that wrote the run with sid="unknown") saw the
+    # legacy snapshot via list_active_runs aggregation. Same physical
+    # file, divergent readers — the symmetry break blocked run-complete
+    # cleanup. Drop the directory guard; rely on the per-session lookup
+    # at line 85 to take precedence whenever the per-session file exists.
+    legacy = _read_json(LEGACY_CURRENT_RUN)
+    if legacy:
+        legacy_sid = legacy.get("session_id")
+        if not legacy_sid or legacy_sid == sid or legacy_sid == "unknown":
+            return legacy
 
     return None
 
@@ -112,7 +124,9 @@ def write_active_run(run: dict, session_id: str | None = None) -> None:
 
 def clear_active_run(session_id: str | None = None) -> None:
     """Clear per-session active run + the latest-snapshot mirror if it
-    belongs to that session (or session unknown — best-effort).
+    belongs to that session, or to an orphan (sid="unknown"), or has
+    no session_id (pre-v2.24 install). Symmetric with read_active_run
+    so a run that was readable from a given sid is also clearable.
     """
     sid = session_id or _session_id_from_env() or "unknown"
     try:
@@ -123,11 +137,18 @@ def clear_active_run(session_id: str | None = None) -> None:
     legacy = _read_json(LEGACY_CURRENT_RUN)
     if legacy:
         legacy_sid = legacy.get("session_id")
-        if not sid or not legacy_sid or legacy_sid == sid:
+        if not legacy_sid or legacy_sid == sid or legacy_sid == "unknown":
             try:
                 LEGACY_CURRENT_RUN.unlink()
             except FileNotFoundError:
                 pass
+            # Best-effort: orphan run also lives under active-runs/unknown.json
+            # if the per-session writer used "unknown" as sid. Clear it too.
+            if legacy_sid == "unknown" and sid != "unknown":
+                try:
+                    _active_run_path("unknown").unlink()
+                except FileNotFoundError:
+                    pass
 
 
 def list_active_runs() -> list[dict]:


### PR DESCRIPTION
## Summary

External dogfood (`/vg:review 3.4b` on PrintwayV3) hit a `run-status` / `run-complete` symmetry break: a bash subshell wrote the active run with `sid="unknown"` (no `CLAUDE_SESSION_ID` inherited), then the Stop hook fired `run-complete` with the real Claude session id and got:

```
⛔ No active run to complete.
```

Even though `run-status` — called from the same subshell that wrote the run — printed:

```json
{
  "this_session": null,
  "current_run": {"run_id": "18459ef8-...", "command": "vg:review", "phase": "3.4b", ...}
}
```

Same physical `.vg/current-run.json`, divergent readers.

## Root cause

`read_active_run` gated its legacy-snapshot fallback behind `if not ACTIVE_RUNS_DIR.exists()`. Once `.vg/active-runs/` existed (post-v2.28 install), every reader with a `sid` that did not match the orphan write was forced to `None` — even though the legacy snapshot still authoritatively represented the run.

`run-status` happens to see the orphan via `list_active_runs` aggregation (which still walks the legacy file when active-runs/ is empty under the requested sid). `run-complete` goes through `read_current_run` → `read_active_run` → `None` and drops out.

## Fix

1. **`read_active_run`** — drop the directory-exists guard. Always check the legacy snapshot when the per-session file is missing. Accept the legacy entry when its `session_id` is `None` (pre-v2.24 install), matches `sid` exactly, OR equals the sentinel `"unknown"` (orphan run written without session context).
2. **`clear_active_run`** — mirror the same condition so a run that was readable from a given sid is also clearable from it. Also clean up the orphan's per-session file (`active-runs/unknown.json`) when a non-`"unknown"` session clears the legacy mirror — otherwise the orphan lingers forever.

The per-session lookup at line 85 still takes precedence whenever the real per-session file exists, so this change cannot introduce cross-session leakage between two genuinely concurrent sessions.

## Test plan

- [x] **Smoke**: `unset CLAUDE_SESSION_ID; vg-orchestrator run-start vg:test 99.99 'orphan'` writes to `active-runs/unknown.json` + `current-run.json`. Then `CLAUDE_SESSION_ID=real-session vg-orchestrator run-status` returns the run via legacy fallback (was returning `null` before fix).
- [x] **Cleanup symmetry**: `CLAUDE_SESSION_ID=real-session vg-orchestrator run-abort --reason X` clears both `current-run.json` AND `active-runs/unknown.json` (was leaking `unknown.json` before fix).
- [ ] **No cross-session leak**: real session A writes its own per-session file → real session B reads with its sid → still gets `None` (per-session file wins, legacy fallback only fires when per-session file is absent). _Not added as automated test; covered by the line 85 lookup-precedence reasoning in the docstring._

## Reporter

External dogfood from `@vietnhprintway` — same dogfood session as #58 / #60. Bug surfaced when `/vg:review 3.4b` orchestrator was driven from a bash subshell while the Stop hook fired in the parent Claude Code session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)