### PR TITLE
fix(vg-test): codegen rule 2.5 — login uses id selectors, not label regex (i18n fix)

### DIFF
--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -1839,6 +1839,33 @@ fi
    **NEVER use dynamic IDs as selectors** (e.g., `data-id="site_9872"`, `#row-abc123`).
    These break when data changes. Prefer: `getByRole('row').first()`, `getByText('site name')`,
    or `nth(0)` index. If goal_sequence recorded a dynamic ID, the pre-codegen gate above BLOCKS execution — re-run /vg:review to re-record.
+2.5. **Login flow uses id-based selectors, NOT label regex (i18n-stable, fix Bug-6)** — Forms in i18n projects use translated labels. `getByLabel(/password/i)` works for English but FAILS for Vietnamese ("Mật khẩu"), Spanish ("Contraseña"), etc. Codegen MUST emit a project-local login helper that uses `<input id>` selectors:
+
+   ```typescript
+   // apps/<role>/e2e/utils/login.ts (project-owned helper)
+   import type { Page } from '@playwright/test';
+   export async function loginAsAdmin(page: Page, creds?: { email?: string; password?: string; baseURL?: string }) {
+     const email = creds?.email ?? process.env.ADMIN_EMAIL ?? 'admin@example.local';
+     const password = creds?.password ?? process.env.ADMIN_PASSWORD ?? '';
+     const baseURL = creds?.baseURL ?? process.env.ADMIN_URL ?? 'http://localhost:3001';
+     await page.goto(`${baseURL}/login`);
+     // ID selectors are stable across i18n translations
+     await page.locator('#login-email').fill(email);  // matches FormLabel htmlFor="login-email"
+     await page.locator('#login-password').fill(password);
+     await page.locator('form button[type="submit"]').click();
+     await page.waitForURL((url) => !url.toString().includes('/login'), { timeout: 10000 });
+   }
+   ```
+
+   Generated specs import + call this helper:
+   ```typescript
+   import { loginAsAdmin } from '../utils/login';
+   test.beforeEach(async ({ page }) => { await loginAsAdmin(page); });
+   ```
+
+   **Why:** PrintwayV3 dogfood (Phase 3.4b /vg:test 2026-04-30) saw 5/5 codegen specs fail at password field because Vietnamese label "Mật khẩu" didn't match `/password/i`. After helper switch to id selectors → 2/5 passed before rate limit, demonstrating fix works.
+
+   **When goal_sequence DOES record selectors** (review captured them via Haiku): use those verbatim. The helper is the fallback when goal_sequence is empty (codegen-from-CRUD-SURFACES path) AND for the universal beforeEach login step.
 3. **Assertions from TEST-GOALS** — each `test()` block maps to a success criterion. Never invent assertions beyond what TEST-GOALS specifies.
 4. **Steps from goal_sequences** — each `do` step becomes a Playwright action, each `assert` step becomes an `expect()`. Nearly 1:1 mapping.
 5. **Web-first assertions** — use `expect(locator).toHaveText()`, `expect(locator).toBeVisible()` with auto-retry. Never use single-shot checks.


### PR DESCRIPTION
## Summary

Adds Rule 2.5 to `/vg:test` codegen rules: generated Playwright specs MUST use id-based selectors (`#login-email`, `#login-password`) for login, NOT `getByLabel(/password/i)` regex.

## Why

`getByLabel(/password/i)` only matches English labels. i18n projects translate FormLabel text (Vietnamese: \"Mật khẩu\", Spanish: \"Contraseña\", etc.) and tests fail with TimeoutError at password field — login never completes, ALL downstream specs fail.

## Discovery

PrintwayV3 dogfood Phase 3.4b /vg:test (2026-04-30): 5/5 generated specs failed at password fill because project labels are Vietnamese. After switching to id-based helper:
- 2/5 specs PASSED (g-14, g-15) before API rate limit
- 3 remaining specs only need `.first()` refinement (multi-element strict mode), login itself succeeded
- Demonstrates fix works

## Pattern

This is bug class 6 of 6 critical bugs surfaced during PrintwayV3 dogfood — all share root cause \"shipped code without runtime coordination\". CrossAI catches syntax/imports but not reachability. Encoding the lesson as an explicit codegen rule prevents recurrence cross-project.

## Implementation

Project owns login helper (`apps/<role>/e2e/utils/login.ts`); codegen rule documents the pattern + when to apply (universal beforeEach + structural fallback path; respect goal_sequences selectors when captured by /vg:review).

## Test plan

- [x] Verified pattern works in PrintwayV3 (g-14 + g-15 PASS post-fix)
- [ ] Apply to next phase using /vg:test → confirm Rule 2.5 followed by codegen
- [ ] Cross-stack verification (test rule on English-default project to ensure no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)