### PR TITLE
fix(crossai-loop): import timezone alongside datetime

### DIFF
--- a/scripts/vg-build-crossai-loop.py
+++ b/scripts/vg-build-crossai-loop.py
@@ -50,7 +50,7 @@ import re
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()


### PR DESCRIPTION
## Summary

- `scripts/vg-build-crossai-loop.py` line 577 calls `datetime.now(timezone.utc)` but line 53 only imports `datetime`, leaving `timezone` unbound.
- Triggers `NameError: name 'timezone' is not defined` on first invocation of the CrossAI build-verify loop.
- Bug shipped in v2.28.0 (when `_resolve_active_run` was added with `datetime.now(timezone.utc)` but the import wasn't updated) and persists through v2.44.0.

## Reproduce on dogfood project

```bash
python3 .claude/scripts/vg-build-crossai-loop.py \
    --phase 3.3 --iteration 1 --max-iterations 5
```

```
Traceback (most recent call last):
  File ".../scripts/vg-build-crossai-loop.py", line 637, in <module>
    sys.exit(main())
             ^^^^^^
  File ".../scripts/vg-build-crossai-loop.py", line 577, in main
    "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
                              ^^^^^^^^
NameError: name 'timezone' is not defined
```

Hit during PrintwayV3 phase 3.3 `/vg:build` step 11 CrossAI loop (3rd attempt to satisfy `build-crossai-required` validator at run-complete). Without this fix, `/vg:build` cannot reach a clean terminal state — the loop never produces a `build.crossai_iteration_started` event, so `run-complete` perpetually blocks.

## Fix

```diff
-from datetime import datetime
+from datetime import datetime, timezone
```

One-line change, no semantic shift, makes the existing `datetime.now(timezone.utc)` call work as intended.

## Test plan

- [x] `python3 -m py_compile scripts/vg-build-crossai-loop.py` exits 0
- [x] Re-run loop on PrintwayV3 phase 3.3 — emits `build.crossai_iteration_started` + `build.crossai_iteration_complete` events; loop exits 0/1/2 per BLOCK count instead of crashing.
- [ ] CI smoke test (if present in main).

## Discovered while

Dogfooding /vg:build → /vg:review → /vg:roam pipeline on PrintwayV3 phase 3.3 (33 goals, 10 build waves, 32 commits). Multi-CLI session race on `.vg/current-run.json` made this bug particularly painful: every retry hit the NameError before any telemetry could land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)