### PR TITLE
fix(validators): resolve run_id per session, close current-run.json race

### DIFF
--- a/scripts/validators/_common.py
+++ b/scripts/validators/_common.py
@@ -125,3 +125,112 @@ def find_phase_dir(phase: str):
                 return bare_norm
 
     return None
+
+
+def read_active_run_id(repo_root=None, command_filter: str | None = None) -> str | None:
+    """Resolve the active run_id for the CURRENT session.
+
+    Closes the multi-session current-run.json race: when two Claude sessions
+    run /vg:* commands concurrently (e.g. session A doing /vg:build 3.3 while
+    session B starts /vg:blueprint 3.5), each `vg-orchestrator run-start`
+    overwrites .vg/current-run.json. Validators that read that file raw end up
+    seeing the OTHER session's run_id and report "no evidence" / "no active
+    run" / wrong-phase outcomes during run-complete.
+
+    Resolution mirrors vg-orchestrator.state.read_active_run +
+    vg-build-crossai-loop._resolve_active_run (4-tier, in order):
+
+      1. Per-session file: ``.vg/active-runs/{session_id}.json`` keyed by
+         CLAUDE_SESSION_ID / CLAUDE_CODE_SESSION_ID env. Authoritative.
+      2. Legacy snapshot: ``.vg/current-run.json``. Trusted only when its
+         session_id matches the env, is empty, or is the "unknown" sentinel
+         (orphan run from a subshell with no session env). Stale-pointer
+         from foreign session falls through to step 3.
+      3. SQLite ``runs`` table: most recent open row whose session_id matches
+         the env, optionally filtered by ``command_filter`` prefix
+         (e.g. "vg:build" / "vg:review"). This handles run-abort + chicken-
+         and-egg cases where current-run.json was cleared mid-flow.
+      4. None.
+
+    Args:
+      repo_root:        Path to repo root. Defaults to $VG_REPO_ROOT or cwd.
+      command_filter:   Optional command prefix for DB fallback (no LIKE wildcards
+                        needed; the function appends ``%``). When set, only matches
+                        runs whose ``command`` column starts with this string.
+
+    Returns:
+      run_id string, or None when nothing matches the current session.
+    """
+    import os
+    import sqlite3
+    from pathlib import Path as _Path
+
+    if repo_root is None:
+        repo_root = _Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    else:
+        repo_root = _Path(repo_root)
+
+    sid = (
+        os.environ.get("CLAUDE_SESSION_ID")
+        or os.environ.get("CLAUDE_CODE_SESSION_ID")
+        or ""
+    )
+    safe_sid = "".join(c for c in sid if c.isalnum() or c in "-_") or ""
+
+    # 1. Per-session active-run file
+    if safe_sid:
+        per = repo_root / ".vg" / "active-runs" / f"{safe_sid}.json"
+        if per.exists():
+            try:
+                run = json.loads(per.read_text(encoding="utf-8"))
+                rid = run.get("run_id")
+                if rid:
+                    return rid
+            except Exception:
+                pass
+
+    # 2. Legacy snapshot — trust only when compatible with the current session
+    legacy = repo_root / ".vg" / "current-run.json"
+    if legacy.exists():
+        try:
+            run = json.loads(legacy.read_text(encoding="utf-8"))
+            legacy_sid = run.get("session_id") or ""
+            compatible = (
+                not sid
+                or not legacy_sid
+                or legacy_sid == sid
+                or legacy_sid == "unknown"
+            )
+            if compatible:
+                rid = run.get("run_id")
+                if rid:
+                    return rid
+        except Exception:
+            pass
+
+    # 3. SQLite fallback — most recent open run for this session
+    if sid:
+        try:
+            db_path = repo_root / ".vg" / "events.db"
+            if db_path.exists():
+                conn = sqlite3.connect(str(db_path), timeout=2.0)
+                try:
+                    where = ["session_id = ?", "completed_at IS NULL"]
+                    params: list[Any] = [sid]
+                    if command_filter:
+                        where.append("command LIKE ?")
+                        params.append(f"{command_filter}%")
+                    row = conn.execute(
+                        "SELECT run_id FROM runs WHERE "
+                        + " AND ".join(where)
+                        + " ORDER BY started_at DESC LIMIT 1",
+                        params,
+                    ).fetchone()
+                    if row:
+                        return row[0]
+                finally:
+                    conn.close()
+        except Exception:
+            pass
+
+    return None

--- a/scripts/validators/build-crossai-required.py
+++ b/scripts/validators/build-crossai-required.py
@@ -30,11 +30,10 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _common import Evidence, Output, timer, emit_and_exit, find_phase_dir  # noqa: E402
+from _common import Evidence, Output, timer, emit_and_exit, find_phase_dir, read_active_run_id  # noqa: E402
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
 DB_PATH = REPO_ROOT / ".vg" / "events.db"
-CURRENT_RUN_FILE = REPO_ROOT / ".vg" / "current-run.json"
 
 TERMINAL_EVENTS = {
     "build.crossai_loop_complete",
@@ -44,11 +43,16 @@ TERMINAL_EVENTS = {
 
 
 def _read_current_run_id() -> str | None:
-    try:
-        return json.loads(CURRENT_RUN_FILE.read_text(encoding="utf-8")
-                          )["run_id"]
-    except Exception:
-        return None
+    """Resolve the current /vg:build run_id with multi-session safety.
+
+    Pre-fix: read .vg/current-run.json directly, racing with concurrent
+    sessions (issue: validator saw foreign run_id when another session
+    overwrote the global pointer mid-loop). Now defers to the shared
+    helper that prefers per-session active-run file > matching legacy
+    snapshot > SQLite events.db query for an open vg:build row in this
+    session.
+    """
+    return read_active_run_id(repo_root=REPO_ROOT, command_filter="vg:build")
 
 
 def _count_events_in_run(run_id: str, event_types: set[str]) -> dict[str, int]:

--- a/scripts/validators/build-graphify-required.py
+++ b/scripts/validators/build-graphify-required.py
@@ -18,12 +18,11 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer, read_active_run_id  # noqa: E402
 
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
 DB_PATH = REPO_ROOT / ".vg" / "events.db"
-CURRENT_RUN_FILE = REPO_ROOT / ".vg" / "current-run.json"
 
 
 def _section_value(config: str, section: str, key: str, default: str = "") -> str:
@@ -76,10 +75,12 @@ def _graphify_importable() -> bool:
 
 
 def _read_current_run_id() -> str | None:
-    try:
-        return json.loads(CURRENT_RUN_FILE.read_text(encoding="utf-8"))["run_id"]
-    except Exception:
-        return None
+    """Resolve current /vg:build run_id with multi-session safety.
+
+    See _common.read_active_run_id for the 4-tier resolution; closes the
+    .vg/current-run.json overwrite race when concurrent sessions run /vg:*.
+    """
+    return read_active_run_id(repo_root=REPO_ROOT, command_filter="vg:build")
 
 
 def _count_graphify_events(run_id: str) -> int:

--- a/scripts/validators/verify-artifact-freshness.py
+++ b/scripts/validators/verify-artifact-freshness.py
@@ -214,18 +214,51 @@ def main() -> int:
 
     repo_root = _resolve_repo_root()
 
-    # Resolve run_id from current-run.json if not supplied
+    # Resolve run_id with multi-session safety: prefer per-session active-run
+    # file (.vg/active-runs/{session_id}.json) over the global current-run.json
+    # snapshot when CLAUDE_SESSION_ID is set. Without this guard, a concurrent
+    # session's run-start will have overwritten the global pointer and we'd
+    # validate the wrong run_id.
     run_id = args.run_id
     if not run_id:
-        current = repo_root / ".vg" / "current-run.json"
-        if current.exists():
-            try:
-                run_id = json.loads(current.read_text(encoding="utf-8")).get("run_id")
-            except json.JSONDecodeError:
-                pass
+        sid = (
+            os.environ.get("CLAUDE_SESSION_ID")
+            or os.environ.get("CLAUDE_CODE_SESSION_ID")
+            or ""
+        )
+        safe_sid = "".join(c for c in sid if c.isalnum() or c in "-_") or ""
+        # 1. Per-session
+        if safe_sid:
+            per = repo_root / ".vg" / "active-runs" / f"{safe_sid}.json"
+            if per.exists():
+                try:
+                    run_id = json.loads(per.read_text(encoding="utf-8")).get("run_id")
+                except (json.JSONDecodeError, OSError):
+                    pass
+        # 2. Legacy snapshot — trust only when session matches or is absent
+        if not run_id:
+            current = repo_root / ".vg" / "current-run.json"
+            if current.exists():
+                try:
+                    snap = json.loads(current.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    snap = None
+                if snap:
+                    legacy_sid = snap.get("session_id") or ""
+                    compatible = (
+                        not sid
+                        or not legacy_sid
+                        or legacy_sid == sid
+                        or legacy_sid == "unknown"
+                    )
+                    if compatible:
+                        run_id = snap.get("run_id")
     if not run_id:
-        print("⛔ No --run-id and .vg/current-run.json unavailable.",
-              file=sys.stderr)
+        print(
+            "⛔ No --run-id and no per-session/legacy run pointer "
+            "(.vg/active-runs/{session_id}.json or .vg/current-run.json).",
+            file=sys.stderr,
+        )
         return 2
 
     paths = [args.path] if args.path else [

--- a/scripts/validators/verify-clean-failure-state.py
+++ b/scripts/validators/verify-clean-failure-state.py
@@ -45,13 +45,43 @@ def _resolve_repo_root() -> Path:
 
 
 def _load_current_run(repo_root: Path) -> Optional[dict]:
-    path = repo_root / ".vg" / "current-run.json"
-    if not path.exists():
-        return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
+    """Resolve current run with multi-session safety.
+
+    Order: per-session active-run file (CLAUDE_SESSION_ID env) → legacy
+    .vg/current-run.json (only when session matches or absent). Closes the
+    overwrite race when concurrent sessions emit run-start (e.g. session A
+    /vg:build while session B /vg:blueprint).
+    """
+    sid = (
+        os.environ.get("CLAUDE_SESSION_ID")
+        or os.environ.get("CLAUDE_CODE_SESSION_ID")
+        or ""
+    )
+    safe_sid = "".join(c for c in sid if c.isalnum() or c in "-_") or ""
+
+    if safe_sid:
+        per = repo_root / ".vg" / "active-runs" / f"{safe_sid}.json"
+        if per.exists():
+            try:
+                return json.loads(per.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    legacy = repo_root / ".vg" / "current-run.json"
+    if legacy.exists():
+        try:
+            run = json.loads(legacy.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        legacy_sid = run.get("session_id") or ""
+        compatible = (
+            not sid
+            or not legacy_sid
+            or legacy_sid == sid
+            or legacy_sid == "unknown"
+        )
+        return run if compatible else None
+    return None
 
 
 def _check_lock(repo_root: Path, run_id: str) -> list[dict]:

--- a/tests/test_validator_active_run_resolver.py
+++ b/tests/test_validator_active_run_resolver.py
@@ -1,0 +1,138 @@
+"""Tests for _common.read_active_run_id — the multi-session run_id resolver
+introduced to close the .vg/current-run.json overwrite race.
+
+Exercises all 4 resolution tiers + the foreign-session fall-through.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "validators"))
+
+import _common  # noqa: E402
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    """Create a minimal .vg/ tree under tmp_path."""
+    vg = tmp_path / ".vg"
+    vg.mkdir(parents=True, exist_ok=True)
+    (vg / "active-runs").mkdir(exist_ok=True)
+    return tmp_path
+
+
+def _clear_session_env(monkeypatch):
+    monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+
+
+def test_returns_none_when_repo_empty(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    _clear_session_env(monkeypatch)
+    assert _common.read_active_run_id(repo_root=tmp_path) is None
+
+
+def test_legacy_snapshot_with_no_session_field_is_trusted(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    _clear_session_env(monkeypatch)
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-legacy"}), encoding="utf-8"
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-legacy"
+
+
+def test_legacy_snapshot_with_matching_session_is_trusted(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-mine", "session_id": "session-A"}),
+        encoding="utf-8",
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-mine"
+
+
+def test_legacy_snapshot_from_foreign_session_falls_through(tmp_path, monkeypatch):
+    """The bug this resolver fixes: foreign session overwrote the global
+    pointer — pre-fix validators read the wrong run_id.
+    """
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    # Foreign session B's run_id is in legacy snapshot
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-foreign", "session_id": "session-B"}),
+        encoding="utf-8",
+    )
+    # No per-session file, no DB → resolver returns None (NOT rid-foreign)
+    assert _common.read_active_run_id(repo_root=tmp_path) is None
+
+
+def test_per_session_file_beats_legacy_snapshot(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    (tmp_path / ".vg" / "active-runs" / "session-A.json").write_text(
+        json.dumps({"run_id": "rid-mine", "command": "vg:build"}),
+        encoding="utf-8",
+    )
+    # Even with a foreign legacy snapshot, per-session wins
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-foreign", "session_id": "session-B"}),
+        encoding="utf-8",
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-mine"
+
+
+def test_unknown_sentinel_in_legacy_is_trusted(tmp_path, monkeypatch):
+    """Subshells without CLAUDE_SESSION_ID write 'unknown' — Stop hook
+    must still see the run via legacy fallback.
+    """
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-orphan", "session_id": "unknown"}),
+        encoding="utf-8",
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-orphan"
+
+
+def test_session_id_with_non_alphanumeric_is_normalized(tmp_path, monkeypatch):
+    """Filename safety: session ids with /, ., :, etc. must be sanitized
+    before being used as a filename component.
+    """
+    _setup_repo(tmp_path)
+    # Real Claude session ids look like UUIDs (alphanumeric + dash) but
+    # tests cover hostile input too. Underscore + dash are allowed; dots and
+    # slashes get stripped.
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "abc.def/ghi-jkl_mno")
+    safe_sid = "abcdefghi-jkl_mno"  # dots + slashes stripped
+    (tmp_path / ".vg" / "active-runs" / f"{safe_sid}.json").write_text(
+        json.dumps({"run_id": "rid-sanitized"}), encoding="utf-8"
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-sanitized"
+
+
+def test_empty_run_id_in_per_session_falls_through(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    # Per-session file exists but no run_id field
+    (tmp_path / ".vg" / "active-runs" / "session-A.json").write_text(
+        json.dumps({"command": "vg:build"}), encoding="utf-8"
+    )
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-legacy", "session_id": "session-A"}),
+        encoding="utf-8",
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-legacy"
+
+
+def test_corrupt_json_falls_through(tmp_path, monkeypatch):
+    _setup_repo(tmp_path)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "session-A")
+    (tmp_path / ".vg" / "active-runs" / "session-A.json").write_text(
+        "not-json{", encoding="utf-8"
+    )
+    (tmp_path / ".vg" / "current-run.json").write_text(
+        json.dumps({"run_id": "rid-legacy", "session_id": "session-A"}),
+        encoding="utf-8",
+    )
+    assert _common.read_active_run_id(repo_root=tmp_path) == "rid-legacy"


### PR DESCRIPTION
## Summary

- 4 validators (build-crossai-required, build-graphify-required, verify-clean-failure-state, verify-artifact-freshness) read `.vg/current-run.json` raw to determine which `run_id` to evaluate.
- v2.28.0 introduced `.vg/active-runs/{session_id}.json` as the per-session authority but only `vg-build-crossai-loop._resolve_active_run` + `vg-orchestrator.state.read_active_run` were updated to consume it.
- When two Claude sessions run `/vg:*` concurrently, every `run-start` overwrites `current-run.json` → validators evaluate the FOREIGN session's run_id during `run-complete` → spurious BLOCKs (no events / wrong phase).

## Reproduce on dogfood

```
Session A:  /vg:build 3.3            # registers run 62acbdb4 (session A)
Session B:  /vg:blueprint 3.5        # overwrites current-run.json with run 9fc7f818 (session B)
Session A:  emit build.completed → run-complete
            ↳ build-crossai-required reads current-run.json → sees 9fc7f818
            ↳ counts iteration_started events for 9fc7f818 → 0 → BLOCK
```

This was hit 4 times in this session while bringing PrintwayV3 phase 3.3 through `/vg:build`, `/vg:review`, `/vg:roam`. Workaround was to manually restore the pointer mid-burst between `emit-event` and `run-complete` — fragile and unreliable.

## Fix

Add `read_active_run_id(repo_root, command_filter)` helper to `scripts/validators/_common.py`. Mirrors the 4-tier resolution already used by `_resolve_active_run` in `vg-build-crossai-loop.py`:

1. **Per-session file**: `.vg/active-runs/{session_id}.json` (authoritative when `CLAUDE_SESSION_ID` / `CLAUDE_CODE_SESSION_ID` set).
2. **Legacy snapshot**: `.vg/current-run.json` — trusted only when its `session_id` matches the env, is empty, or is the `"unknown"` sentinel (orphan run from a subshell without session env). Foreign-session pointers **fall through**.
3. **SQLite events.db**: most recent open `runs` row for this session, optionally filtered by `command_filter` prefix (e.g. `vg:build`, `vg:review`).
4. None.

`verify-clean-failure-state.py` and `verify-artifact-freshness.py` use the same logic inlined (they don't share `Output`/`timer` with other validators — keeping their import surface minimal).

## Test plan

- [x] 9 unit tests in `tests/test_validator_active_run_resolver.py`:
  - empty repo → None
  - legacy snapshot with no `session_id` → trusted
  - legacy snapshot matching session → trusted
  - legacy from foreign session → fall through (None when no DB)
  - per-session beats legacy
  - `unknown` sentinel in legacy → trusted (orphan recovery)
  - non-alphanumeric session id → sanitized for filename
  - empty `run_id` in per-session → falls through
  - corrupt JSON → falls through
- [x] All 4 modified validators compile clean (`python3 -m py_compile`).
- [x] `build-crossai-required.py --phase test` returns clean PASS JSON shape (no regression on happy path).
- [ ] CI smoke (if present in main).

## Files changed

```
scripts/validators/_common.py                    | +109   (new helper)
scripts/validators/build-crossai-required.py     |  +/-   (use helper)
scripts/validators/build-graphify-required.py    |  +/-   (use helper)
scripts/validators/verify-clean-failure-state.py |  +/-   (inline equivalent)
scripts/validators/verify-artifact-freshness.py  |  +/-   (inline equivalent)
tests/test_validator_active_run_resolver.py      | +144   (new file, 9 tests)
```

## Related

- v2.28.0 introduced multi-tenant active-run state (`scripts/vg-orchestrator/state.py:read_active_run`).
- This PR completes the migration for the validator path.
- Companion PR #68 fixes the `timezone` import bug in `vg-build-crossai-loop.py` that was masking this issue (loop crashed before the validator could be triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)