### PR TITLE
fix: fail-closed validators + matrix-evidence-link (closes Phase 3.2 dogfood gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,87 @@
 # Changelog
 
+## v2.45.0 — fail-closed validators + matrix-evidence-link (PR fix/fail-closed-validators-coverage-fabrication)
+
+Closes the largest dogfood-found false-positive class to date: validators
+silently passing on format mismatch / regex miss / parse failure. PrintwayV3
+Phase 3.2 review claimed 65/67 goals READY while RUNTIME-MAP showed 27
+sequences recorded (10 passed, 11 blocked, 6 deferred-structural) and 40
+goals never replayed. User reported admin topup approve/flag forms
+crashing in browser — validators that should have caught this all returned
+PASS or WARN.
+
+### Fixed — `verify-runtime-map-coverage.py` parses markdown TEST-GOALS
+
+Validator was YAML-frontmatter-only. Phase 3.2 used `## Goal G-XX:` markdown
+headers → 0 goals parsed → return 0 with "(no parseable goals — passing)".
+Now: tries YAML first, falls back to markdown parser supporting `## Goal G-XX:`
++ `**Field:** value` lines. **FAIL CLOSED** if neither format matches —
+previously silently passed.
+
+### Fixed — `verify-runtime-map-crud-depth.py` mutation vocabulary
+
+`MUTATION_WORD_RE` only matched create/update/delete/submit/save. Admin
+state-transition verbs (approve/reject/flag/reset/enable/etc.) bypassed the
+gate, so `goal_sequence` with only a list-render step satisfied "depth"
+checks for mutation goals. Expanded vocabulary to cover: approve, reject,
+flag, unflag, enable, disable, activate, deactivate, reset, cancel,
+archive, restore, publish, lock, unlock, freeze, unfreeze, suspend, resume,
+verify, confirm, deny, assign, unassign, transfer, upload, download +
+Vietnamese (duyệt, từ chối, đánh dấu, mở khóa, kích hoạt, vô hiệu, hủy,
+chuyển).
+
+### Added — `verify-matrix-evidence-link.py` validator
+
+Cross-checks GOAL-COVERAGE-MATRIX.md status verdicts against the runtime
+evidence they claim to summarize (RUNTIME-MAP.json goal_sequences[].result).
+
+Catches three fabrication classes:
+- `matrix_status_without_runtime_sequence` — matrix=READY but no sequence entry
+- `matrix_status_with_empty_sequence` — sequence shell with 0 steps
+- `matrix_status_contradicts_runtime_result` — matrix=READY but result=blocked
+
+Statuses that legitimately don't need runtime evidence: INFRA_PENDING,
+UNREACHABLE, DEFERRED. All others require non-empty sequence with result in
+{passed, ready, ok, deferred-structural}.
+
+Wired into `commands/vg/review.md` end-of-step block — runs before
+`vg-orchestrator run-complete`. Phase 3.2 dogfood: 55 mismatches (40 missing
++ 11 contradicts + 4 empty).
+
+### Fixed — `verify-contract-runtime.py` accepts level-3 endpoint headers
+
+Regex `^##\s+METHOD /path` only matched level-2 headers. Phase 3.2
+API-CONTRACTS.md used `### POST /api/v1/...` (level 3) under group headers
+(level 2) → 0 endpoints parsed → WARN "empty_contract" → silently passed.
+Now: matches `##` / `###` / `####` headers. **FAIL CLOSED** on empty
+contract (was WARN).
+
+### Patched — `commands/vg/test.md` removed silent CRUD fallback
+
+Branching table v2.32.1 said: `READY + missing goal_sequences[G-XX] + CRUD
+match → Sinh structural spec from CRUD-SURFACES.md`. Phase 3.2 dogfood:
+this fallback turned 40 goals (review never replayed) into list-render
+.spec.ts with no mutation evidence → /vg:test PASS while production
+buttons crashed.
+
+New default: `READY + missing seq` → BLOCK with re-review hint. Legacy
+fallback preserved behind `--allow-structural-fallback` flag (logs
+override-debt). The `matrix-evidence-link` validator at review-exit now
+catches the mismatch upstream, so this fallback should rarely be reached.
+
+### Architecture rule (added to skill prose)
+
+> Validators MUST fail-closed on parse error / format drift / regex miss.
+> Returning PASS/WARN when the validator cannot enforce its invariant
+> means the gate has been silently bypassed. The default for unparseable
+> input is BLOCK with a hint to fix the format.
+
+This PR converts 4 validators from fail-open to fail-closed and adds 1
+new content-aware validator (matrix-evidence-link). The pattern can be
+extended to other validators showing similar silent-pass behavior.
+
+---
+
 ## v2.44.0 — verdict-aware Next + review.method axis + agents + test-id stack (PR #67)
 
 Bundles 5 reporter-internal milestones (v2.43.1 → v2.43.5) into a single minor release: 1612 insertions, 83 deletions, 18 files. Built on top of v2.43.2's i18n login fix.

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -5808,6 +5808,26 @@ if [ "$COMP_RC" -ne 0 ] && [ "$COMP_SEV" = "block" ]; then
   exit 1
 fi
 
+# v2.45 fail-closed-validators PR: matrix↔runtime evidence cross-check.
+# Phase 3.2 dogfood found GOAL-COVERAGE-MATRIX.md fabricating READY status
+# even when goal_sequences[].result == "blocked" or sequence missing entirely.
+# This validator catches the fabrication BEFORE review exits, so /vg:test
+# never sees a lying matrix.
+MATRIX_LINK_VAL=".claude/scripts/validators/verify-matrix-evidence-link.py"
+if [ -f "$MATRIX_LINK_VAL" ]; then
+  ${PYTHON_BIN:-python3} "$MATRIX_LINK_VAL" --phase-dir "$PHASE_DIR" --severity block
+  MATRIX_LINK_RC=$?
+  if [ "$MATRIX_LINK_RC" -ne 0 ]; then
+    echo "⛔ Review matrix-evidence-link gate failed."
+    echo "   GOAL-COVERAGE-MATRIX.md asserts goal status that runtime evidence does not support."
+    echo "   Fix path:"
+    echo "     1. Re-run /vg:review ${PHASE_NUMBER} --retry-failed (record real sequences)"
+    echo "     2. OR reclassify goals to UNREACHABLE/INFRA_PENDING/DEFERRED with justification"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.matrix_evidence_link_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
 RUN_RC=$?
 if [ $RUN_RC -ne 0 ]; then

--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -1659,15 +1659,35 @@ they use the `<goal>-<control>-{filter|pagination}-<group>` slug pattern
 established by `enumerateFilterFiles` / `enumeratePaginationFiles`. The
 manual codegen path emits `<phase>-goal-<group>.spec.ts` instead.
 
-**v2.32.1 CRUD structural fallback (fixes #47/#48 false pass):**
+**v2.32.1 CRUD structural fallback (fixes #47/#48 false pass) — DEPRECATED v2.45:**
+
+> ⛔ **v2.45 fail-closed-validators PR:** This fallback is no longer the
+> default. Phase 3.2 dogfood found that 40/67 goals trượt vào fallback path,
+> turning review coverage gaps (no goal_sequence recorded) into list-only
+> .spec.ts that passed test gate while production buttons (Approve/Reject/
+> Flag) crashed. The fallback hid the underlying review bug instead of
+> surfacing it.
+>
+> **New rule:** A `READY` matrix Status without a corresponding non-empty
+> `goal_sequences[G-XX]` MUST BLOCK codegen with the message:
+> `"Goal G-XX READY trong matrix nhưng RUNTIME-MAP không có sequence — re-run /vg:review --retry-failed hoặc reclassify goal."`
+>
+> The validator `matrix-evidence-link` runs at review-exit and now blocks
+> matrix↔runtime mismatches BEFORE the run reaches /vg:test, so this
+> fallback should rarely be reachable. If reached, it indicates the
+> matrix-evidence-link validator was skipped or overridden — investigate
+> rather than silently fall back.
+
+**Legacy fallback (preserved behind `--allow-structural-fallback` flag for
+emergency unblocks only; logs override-debt entry):**
 
 If a `READY` UI goal has no `RUNTIME-MAP.json.goal_sequences[G-XX]` but
-`CRUD-SURFACES.md` contains a matching resource, codegen MUST generate a
-non-skipped structural Playwright spec from the CRUD contract. This is the
-only allowed fallback for legacy/static review artifacts; never emit
-`test.skip()` for this case.
+`CRUD-SURFACES.md` contains a matching resource, codegen MAY generate a
+non-skipped structural Playwright spec from the CRUD contract. This is now
+opt-in — never emit `test.skip()` for this case but also never auto-trigger
+the fallback.
 
-Fallback rules:
+Fallback rules (when `--allow-structural-fallback` is set):
 - Applies only to non-mutation goals. Any goal with meaningful
   `Mutation evidence` still requires a real per-goal runtime sequence with
   POST/PUT/PATCH/DELETE + persistence proof.
@@ -1684,8 +1704,9 @@ Fallback rules:
   sequence exists: confirm dialog/sheet text and destructive affordance.
 - Header must include `// STRUCTURAL_FROM_CRUD_SURFACES: true` and
   `// Source: CRUD-SURFACES.md + TEST-GOALS.md`.
-- If no CRUD resource matches, BLOCK codegen with a clear message; do not
-  generate a skeleton.
+- Operator MUST acknowledge structural-fallback debt via override-debt entry
+  citing the goals being downgraded. Resolution: re-run /vg:review at next
+  pipeline pass to record real sequences.
 
 **Pre-codegen Gate — Dynamic ID scan (HARD BLOCK — tightened 2026-04-17):**
 
@@ -1776,12 +1797,14 @@ PY
 
 | Status | Action |
 |---|---|
-| `READY` | Sinh full spec happy path (logic existing bên dưới). |
-| `READY` + missing `goal_sequences[G-XX]` + CRUD match | Sinh structural spec from `CRUD-SURFACES.md`; never `.skip()`. Mutation goals excluded and blocked by CRUD depth gate. |
+| `READY` (+ non-empty `goal_sequences[G-XX]`) | Sinh full spec happy path (logic existing bên dưới). |
+| `READY` + missing `goal_sequences[G-XX]` | **⛔ BLOCK** — không tạo structural spec yếu. Báo error cho operator: "Goal G-XX READY trong matrix nhưng RUNTIME-MAP không có sequence. Re-run /vg:review --retry-failed hoặc reclassify goal. KHÔNG dùng /vg:test làm fallback cho review miss." Đây là điểm fail-closed thay cho fallback "structural spec from CRUD-SURFACES" cũ — fallback đó che dấu review coverage gap (phase 3.2 dogfood: 40 goals trượt vào fallback path mà không có mutation evidence). |
 | `MANUAL` | Sinh **skeleton** với `test.skip(...)` + comment "manual verify in UAT + verification_strategy: {strategy}". Có placeholder để user fill sau. |
 | `DEFERRED` | **Skip entirely** — không tạo file .spec.ts (phase target chưa deploy). Log `[skip-deferred] {gid} depends_on_phase: {X}`. |
 | `INFRA_PENDING` | Sinh skeleton `.skip()` với comment "requires infra {deps} — re-run --sandbox". |
 | `BLOCKED` / `UNREACHABLE` | KHÔNG tới đây — review 100% gate đã chặn. Nếu gặp → log error, skip goal. |
+
+**v2.45 fail-closed fix:** Trước đây `READY + missing seq + CRUD match` rơi vào fallback "structural spec from CRUD-SURFACES.md" — đường này dùng list metadata thay cho mutation evidence. Phase 3.2 dogfood cho thấy fallback này biến lỗ hổng review (40/67 goals chưa replay) thành .spec.ts list-render thuần — test PASS nhưng nút Approve/Reject vẫn lỗi production. Fix: bắt buộc re-review thay vì fallback yếu. Validator `matrix-evidence-link` chạy ở review-exit sẽ chặn matrix-runtime mismatch trước khi tới /vg:test.
 
 **Skeleton template cho MANUAL / INFRA_PENDING:**
 

--- a/scripts/validators/verify-contract-runtime.py
+++ b/scripts/validators/verify-contract-runtime.py
@@ -45,9 +45,13 @@ from _i18n import t  # noqa: E402 — B8.0: localized user-facing messages
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
 
-# API-CONTRACTS.md endpoint header: `## POST /auth/register` (case-insensitive method)
+# API-CONTRACTS.md endpoint header: `## POST /auth/register` OR `### POST /...`
+# (case-insensitive method). v2.45 fail-closed PR: relaxed to accept ## / ### / ####
+# because Phase 3.2 dogfood used level-3 headers ("### POST /api/v1/...") under a
+# level-2 group header ("## Topup Endpoints"), and the previous level-2-only regex
+# parsed 0 endpoints + warned silently.
 ENDPOINT_HEADER_RE = re.compile(
-    r"^##\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(/\S+)\s*$",
+    r"^#{2,4}\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(/\S+)\s*$",
     re.MULTILINE | re.IGNORECASE,
 )
 
@@ -284,7 +288,13 @@ def main() -> None:
 
         endpoints = parse_contract_endpoints(contracts_path)
         if not endpoints:
-            out.warn(Evidence(
+            # FAIL CLOSED (v2.45 PR fix/fail-closed-validators): API-CONTRACTS.md
+            # exists but no `## METHOD /path` / `### METHOD /path` headers parsed.
+            # Previously WARN — passed silently when contract format drifted.
+            # If the contract is genuinely empty (non-feature profile), the file
+            # shouldn't exist; the early return above handles that case. Reaching
+            # here means file exists but format is wrong → BLOCK.
+            out.add(Evidence(
                 type="empty_contract",
                 message=t("contract_runtime.empty_contract.message"),
                 actual=str(contracts_path.relative_to(REPO_ROOT)),

--- a/scripts/validators/verify-matrix-evidence-link.py
+++ b/scripts/validators/verify-matrix-evidence-link.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+verify-matrix-evidence-link.py — fail-closed-validators PR (Phase 3.2 dogfood)
+
+Cross-checks GOAL-COVERAGE-MATRIX.md verdicts against the runtime evidence
+they claim to summarize (RUNTIME-MAP.json goal_sequences[]).
+
+Catches the false-positive class where /vg:review writes Status=READY
+into the matrix even though:
+  (a) goal_sequences[G-XX] is missing entirely (review never replayed it), or
+  (b) goal_sequences[G-XX].result == "blocked" (replay observed a failure)
+
+Phase 3.2 evidence: matrix said 65/67 READY but RUNTIME-MAP showed
+40 goals with no sequence + 11 goals with result=blocked. Coverage stats
+in RUNTIME-MAP.coverage block also lied (goals_passed_or_runtime_ready=65
+vs reality=10). All silent. This validator stops the lie at review-exit.
+
+Allowed Status values that DON'T require a runtime sequence:
+  - INFRA_PENDING — goal needs infra not available, deferred to UAT
+  - UNREACHABLE   — code not in repo
+  - DEFERRED      — phase target not yet deployed
+
+Any other Status (READY, MANUAL_VERIFIED, etc.) requires a non-empty
+goal_sequences entry whose result is "passed" / "ready" / "ok".
+
+Usage:
+  verify-matrix-evidence-link.py --phase-dir <path>
+  verify-matrix-evidence-link.py --phase <number>
+
+Exit codes:
+  0 — matrix and runtime evidence agree
+  1 — mismatch found OR matrix unparseable (fail-closed)
+  2 — config error (matrix or runtime-map missing)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+
+# Matrix table row: `| G-10 | critical | ui | READY | evidence text |`
+MATRIX_ROW_RE = re.compile(
+    r"^\|\s*(G-[A-Z0-9-]+)\s*\|"          # goal id
+    r"\s*([^|]*?)\s*\|"                    # priority
+    r"\s*([^|]*?)\s*\|"                    # surface
+    r"\s*([A-Z_]+(?:[-/][A-Za-z_]+)?)\s*\|" # status
+    r"\s*([^|]*?)\s*\|",                   # evidence
+    re.MULTILINE,
+)
+
+STATUSES_WITHOUT_RUNTIME = {"INFRA_PENDING", "UNREACHABLE", "DEFERRED"}
+RUNTIME_PASS_RESULTS = {"passed", "ready", "ok", "deferred-structural"}
+
+
+def parse_matrix(matrix_path: Path) -> list[dict]:
+    """Return list of {goal_id, priority, surface, status, evidence}."""
+    if not matrix_path.is_file():
+        return []
+    text = matrix_path.read_text(encoding="utf-8", errors="replace")
+    rows: list[dict] = []
+    for m in MATRIX_ROW_RE.finditer(text):
+        gid = m.group(1).strip().upper()
+        if not gid.startswith("G-"):
+            continue
+        rows.append({
+            "goal_id": gid,
+            "priority": m.group(2).strip(),
+            "surface": m.group(3).strip().lower(),
+            "status": m.group(4).strip().upper(),
+            "evidence": m.group(5).strip(),
+        })
+    return rows
+
+
+def load_runtime_map(rmap_path: Path) -> dict:
+    if not rmap_path.is_file():
+        return {}
+    try:
+        return json.loads(rmap_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--phase-dir")
+    g.add_argument("--phase")
+    ap.add_argument("--severity", choices=["warn", "block"], default="block")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    output = Output(validator="matrix-evidence-link")
+
+    with timer(output):
+        if args.phase_dir:
+            phase_dir = Path(args.phase_dir).resolve()
+        else:
+            phase_dir = find_phase_dir(args.phase)
+            if not phase_dir:
+                print(f"⛔ Phase dir not found for phase={args.phase}", file=sys.stderr)
+                return 2
+
+        if not phase_dir.is_dir():
+            print(f"⛔ Phase dir not found: {phase_dir}", file=sys.stderr)
+            return 2
+
+        matrix_path = phase_dir / "GOAL-COVERAGE-MATRIX.md"
+        rmap_path = phase_dir / "RUNTIME-MAP.json"
+
+        if not matrix_path.is_file():
+            print(f"⛔ GOAL-COVERAGE-MATRIX.md missing in {phase_dir}", file=sys.stderr)
+            return 2
+        if not rmap_path.is_file():
+            print(f"⛔ RUNTIME-MAP.json missing in {phase_dir}", file=sys.stderr)
+            return 2
+
+        rows = parse_matrix(matrix_path)
+        if not rows:
+            # FAIL CLOSED — matrix exists but no rows could be parsed.
+            output.add(Evidence(
+                type="matrix_unparseable",
+                message=(
+                    "GOAL-COVERAGE-MATRIX.md exists but no goal rows could be "
+                    "parsed (expected `| G-XX | priority | surface | STATUS | evidence |` "
+                    "table rows)."
+                ),
+                file=str(matrix_path),
+                fix_hint=(
+                    "Re-run /vg:review so the matrix is regenerated with valid "
+                    "table rows, or check matrix manually for table format drift."
+                ),
+            ))
+            print(output.to_json() if args.json else output.evidence[-1].message)
+            return 1 if args.severity == "block" else 0
+
+        rmap = load_runtime_map(rmap_path)
+        sequences = rmap.get("goal_sequences") or {}
+
+        for row in rows:
+            gid = row["goal_id"]
+            status = row["status"]
+
+            if status in STATUSES_WITHOUT_RUNTIME:
+                continue
+
+            seq = sequences.get(gid)
+            if not isinstance(seq, dict):
+                output.add(Evidence(
+                    type="matrix_status_without_runtime_sequence",
+                    message=(
+                        f"{gid}: matrix Status={status} but no goal_sequences[{gid}] "
+                        f"entry in RUNTIME-MAP.json"
+                    ),
+                    file=str(matrix_path),
+                    expected=f"goal_sequences[{gid}].steps non-empty with result in {sorted(RUNTIME_PASS_RESULTS)}",
+                    actual="missing entry",
+                    fix_hint=(
+                        f"Re-run /vg:review {phase_dir.name} so the goal is replayed, "
+                        f"OR change matrix Status to UNREACHABLE/INFRA_PENDING/DEFERRED "
+                        f"with a justification."
+                    ),
+                ))
+                continue
+
+            steps = seq.get("steps") or []
+            result = (seq.get("result") or seq.get("status") or "").lower()
+
+            if not steps:
+                output.add(Evidence(
+                    type="matrix_status_with_empty_sequence",
+                    message=(
+                        f"{gid}: matrix Status={status} but goal_sequences[{gid}].steps "
+                        f"is empty (review recorded a sequence shell but never replayed it)"
+                    ),
+                    file=str(matrix_path),
+                    expected="steps[].length > 0",
+                    actual=f"steps={len(steps)}, result={result or 'unset'}",
+                    fix_hint=f"Re-run /vg:review {phase_dir.name} --retry-failed",
+                ))
+                continue
+
+            if result and result not in RUNTIME_PASS_RESULTS:
+                # Most common: matrix=READY, result=blocked
+                output.add(Evidence(
+                    type="matrix_status_contradicts_runtime_result",
+                    message=(
+                        f"{gid}: matrix Status={status} but RUNTIME-MAP "
+                        f"goal_sequences[{gid}].result={result!r} (review observed "
+                        f"a failure but matrix wrote a success status)"
+                    ),
+                    file=str(matrix_path),
+                    expected=f"matrix Status reflects runtime result {result!r}",
+                    actual=f"Status={status} contradicts result={result!r}",
+                    fix_hint=(
+                        f"Either fix the underlying issue and re-run /vg:review {phase_dir.name} "
+                        f"--retry-failed (so result becomes 'passed'), OR change matrix Status "
+                        f"to BLOCKED/UNREACHABLE per the actual failure."
+                    ),
+                ))
+
+        if not output.evidence:
+            output.evidence.append(Evidence(
+                type="matrix_evidence_link_ok",
+                message=(
+                    f"Matrix evidence link OK — {len(rows)} matrix rows verified "
+                    f"against {len(sequences)} goal_sequences entries."
+                ),
+            ))
+
+    if args.json:
+        print(output.to_json())
+    else:
+        if output.verdict == "BLOCK":
+            print(f"⛔ Matrix evidence link: {len(output.evidence)} mismatch(es)")
+            for e in output.evidence:
+                print(f"   [{e.type}] {e.message}")
+                if e.fix_hint:
+                    print(f"     hint: {e.fix_hint}")
+        else:
+            print(f"✓ {output.evidence[0].message}")
+
+    if output.verdict == "BLOCK" and args.severity == "block":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validators/verify-runtime-map-coverage.py
+++ b/scripts/validators/verify-runtime-map-coverage.py
@@ -9,13 +9,23 @@ Hard invariant: every UI-surface goal in TEST-GOALS.md has BOTH:
 Catches the verdict-gate gap where review claims PASS but RUNTIME-MAP
 has empty elements / no replay steps (issue #51 root cause).
 
+Supports two TEST-GOALS.md formats:
+  - YAML frontmatter blocks (`--- ... ---`)
+  - Markdown headers (`## Goal G-XX: title` + `**Field:** value` lines)
+
+v2.45 fail-closed-validators (PR fix/fail-closed-validators-coverage-fabrication):
+  - Added markdown parser for `## Goal G-XX` format. Previously YAML-only —
+    Phase 3.2 used markdown and validator silently passed on 0 parsed goals.
+  - FAIL CLOSED on unparseable TEST-GOALS.md. Previously returned 0 with
+    advisory message "(no parseable goals — passing)".
+
 Usage:
   verify-runtime-map-coverage.py --phase-dir <path>
   verify-runtime-map-coverage.py --phase-dir <path> --severity warn
 
 Exit codes:
   0 — all UI goals covered (or severity=warn)
-  1 — gap found (severity=block)
+  1 — gap found (severity=block) OR TEST-GOALS unparseable (was 0 — fixed)
   2 — config error (RUNTIME-MAP or TEST-GOALS missing)
 """
 from __future__ import annotations
@@ -29,6 +39,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
 
+# Markdown goal header: `## Goal G-12: title (P3.D-46)`
+GOAL_HEADER_RE = re.compile(r"^##\s+Goal\s+(G-[A-Z0-9-]+)\s*:?\s*(.*)$", re.IGNORECASE)
+# Field line: `**Surface:** ui`
+FIELD_LINE_RE = re.compile(r"^\*\*([A-Za-z][A-Za-z _-]*?)\s*:\*\*\s*(.*)$")
+
 
 def load_json(path: Path) -> dict:
     if not path.is_file():
@@ -39,10 +54,11 @@ def load_json(path: Path) -> dict:
         return {}
 
 
-def parse_test_goals(path: Path) -> list[dict]:
-    if not path.is_file():
-        return []
-    text = path.read_text(encoding="utf-8", errors="replace")
+def _normalize_field_key(label: str) -> str:
+    return label.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _parse_yaml_blocks(text: str) -> list[dict]:
     try:
         import yaml
     except ImportError:
@@ -74,6 +90,66 @@ def parse_test_goals(path: Path) -> list[dict]:
     return out
 
 
+def _parse_markdown_goals(text: str) -> list[dict]:
+    """Parse `## Goal G-XX: title` headers + subsequent `**Field:** value` lines.
+
+    Stops a goal block at next `## ` header or `---` separator. Surface defaults
+    to 'ui' to mirror legacy behavior — explicit `**Surface:** api` etc.
+    overrides.
+    """
+    out: list[dict] = []
+    cur: dict | None = None
+
+    def _flush():
+        if cur and cur.get("id"):
+            out.append(cur.copy())
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        m_header = GOAL_HEADER_RE.match(line)
+        if m_header:
+            _flush()
+            cur = {"id": m_header.group(1).upper(), "title": m_header.group(2).strip()}
+            continue
+        if cur is None:
+            continue
+        # End-of-block separators
+        if line.startswith("## ") or line.strip() == "---":
+            _flush()
+            cur = None
+            continue
+        m_field = FIELD_LINE_RE.match(line)
+        if m_field:
+            key = _normalize_field_key(m_field.group(1))
+            val = m_field.group(2).strip()
+            # Field name aliases for downstream consumers
+            if key == "surface":
+                cur["surface"] = val.lower()
+            elif key in {"maps_to_view", "view"}:
+                cur["maps_to_view"] = val
+            else:
+                cur[key] = val
+    _flush()
+    return out
+
+
+def parse_test_goals(path: Path) -> tuple[list[dict], str]:
+    """Return (goals, format_used). format_used in {'yaml', 'markdown', 'none'}."""
+    if not path.is_file():
+        return [], "none"
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    yaml_goals = _parse_yaml_blocks(text)
+    if yaml_goals:
+        return yaml_goals, "yaml"
+
+    md_goals = _parse_markdown_goals(text)
+    if md_goals:
+        return md_goals, "markdown"
+
+    return [], "none"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--phase-dir", required=True)
@@ -92,11 +168,32 @@ def main() -> int:
         print(f"⛔ RUNTIME-MAP.json missing in {phase_dir}", file=sys.stderr)
         return 2
 
-    goals = parse_test_goals(phase_dir / "TEST-GOALS.md")
+    goals_path = phase_dir / "TEST-GOALS.md"
+    if not goals_path.is_file():
+        print(f"⛔ TEST-GOALS.md missing in {phase_dir}", file=sys.stderr)
+        return 2
+
+    goals, fmt = parse_test_goals(goals_path)
     if not goals:
-        if not args.quiet:
-            print(f"  (no parseable goals in {phase_dir}/TEST-GOALS.md — passing)")
-        return 0
+        # FAIL CLOSED (was: return 0 silently). Unparseable TEST-GOALS means
+        # we cannot enforce the invariant. Treat as a gap.
+        msg = (
+            f"⛔ TEST-GOALS.md unparseable — neither YAML frontmatter blocks nor "
+            f"`## Goal G-XX` markdown headers found in {goals_path}. Validator "
+            f"cannot enforce coverage invariant. Fix the file format then re-run."
+        )
+        if args.json:
+            print(json.dumps({
+                "phase_dir": str(phase_dir),
+                "ui_goals_total": 0,
+                "gaps": [],
+                "gate_pass": False,
+                "severity": args.severity,
+                "error": "test_goals_unparseable",
+            }, indent=2))
+        elif not args.quiet:
+            print(msg)
+        return 1 if args.severity == "block" else 0
 
     views = rmap.get("views") or {}
     sequences = rmap.get("goal_sequences") or {}
@@ -117,19 +214,32 @@ def main() -> int:
         steps = seq.get("steps") if isinstance(seq, dict) else None
         steps_count = len(steps) if isinstance(steps, list) else 0
 
-        if elements_count == 0 or steps_count == 0:
-            gaps.append({
-                "goal_id": gid,
-                "surface": surface,
-                "view": view_url,
-                "elements_count": elements_count,
-                "steps_count": steps_count,
-                "reason": "elements_empty" if elements_count == 0 else "steps_empty",
-            })
+        if steps_count == 0:
+            # Missing goal_sequences entirely — covers the Phase 3.2 case where
+            # 40/67 goals had no sequence recorded but matrix said READY.
+            reason = "no_sequence_in_runtime_map"
+        elif elements_count == 0 and view_url:
+            reason = "elements_empty"
+        else:
+            continue
+
+        gaps.append({
+            "goal_id": gid,
+            "surface": surface,
+            "view": view_url,
+            "elements_count": elements_count,
+            "steps_count": steps_count,
+            "reason": reason,
+        })
+
+    ui_goals_total = sum(
+        1 for g in goals if (g.get("surface") or "ui").lower() in {"ui", "ui-mobile"}
+    )
 
     payload = {
         "phase_dir": str(phase_dir),
-        "ui_goals_total": sum(1 for g in goals if (g.get("surface") or "ui").lower() in {"ui", "ui-mobile"}),
+        "format": fmt,
+        "ui_goals_total": ui_goals_total,
         "gaps": gaps,
         "gate_pass": len(gaps) == 0,
         "severity": args.severity,
@@ -139,12 +249,18 @@ def main() -> int:
         print(json.dumps(payload, indent=2))
     elif not args.quiet:
         if not gaps:
-            print(f"✓ Runtime-map coverage OK ({payload['ui_goals_total']} UI goals, all have elements + steps)")
+            print(
+                f"✓ Runtime-map coverage OK ({ui_goals_total} UI goals via {fmt}, "
+                f"all have elements + steps)"
+            )
         else:
             tag = "⛔" if args.severity == "block" else "⚠ "
-            print(f"{tag} Runtime-map coverage: {len(gaps)} gap(s)")
+            print(f"{tag} Runtime-map coverage: {len(gaps)}/{ui_goals_total} gap(s) (format={fmt})")
             for g in gaps:
-                print(f"   {g['goal_id']} on {g['view']}: {g['reason']} (elements={g['elements_count']}, steps={g['steps_count']})")
+                print(
+                    f"   {g['goal_id']} on {g['view'] or '<no-view>'}: {g['reason']} "
+                    f"(elements={g['elements_count']}, steps={g['steps_count']})"
+                )
 
     if gaps and args.severity == "block":
         return 1

--- a/scripts/validators/verify-runtime-map-crud-depth.py
+++ b/scripts/validators/verify-runtime-map-crud-depth.py
@@ -31,10 +31,35 @@ from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # no
 
 REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
 MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+# Mutation verb vocabulary. Expanded by v2.45 fail-closed-validators PR after
+# Phase 3.2 dogfood: G-10 "Admin clicks Approve", G-11 "Admin clicks Reject",
+# G-23 "Admin resets cooling period", G-26 "Admin enables withdraw permission"
+# all bypassed the depth gate because the verbs were not listed.
+# When adding new verbs, prefer state-transition language (approve/reject/flag/
+# reset/enable) over generic CRUD (create/update/delete) — admin actions
+# rarely use plain CRUD wording.
 MUTATION_WORD_RE = re.compile(
-    r"\b(create|created|update|updated|delete|deleted|submit|submitted|"
-    r"save|saved|edit|edited|remove|removed|"
-    r"tao|cap\s*nhat|xoa|sua|luu|gui)\b",
+    r"\b("
+    # Generic CRUD
+    r"create|created|update|updated|delete|deleted|submit|submitted|"
+    r"save|saved|edit|edited|remove|removed|add|added|insert|inserted|"
+    # State-transition (admin actions, workflow gates)
+    r"approve|approved|approving|reject|rejected|rejecting|"
+    r"flag|flagged|flagging|unflag|unflagged|"
+    r"enable|enabled|enabling|disable|disabled|disabling|"
+    r"activate|activated|deactivate|deactivated|"
+    r"reset|resetting|cancel|cancelled|cancelling|"
+    r"archive|archived|restore|restored|publish|published|unpublish|"
+    r"lock|locked|unlock|unlocked|freeze|frozen|unfreeze|unfrozen|"
+    r"suspend|suspended|resume|resumed|"
+    r"verify|verified|confirm|confirmed|deny|denied|"
+    r"assign|assigned|unassign|unassigned|transfer|transferred|"
+    r"upload|uploaded|download|downloaded|"
+    # Vietnamese
+    r"tao|cap\s*nhat|xoa|sua|luu|gui|"
+    r"duyet|tu\s*choi|danh\s*dau|mo\s*khoa|khoa|"
+    r"kich\s*hoat|vo\s*hieu|huy|chuyen"
+    r")\b",
     re.IGNORECASE,
 )
 CRUD_WORD_RE = re.compile(


### PR DESCRIPTION
## Summary

PrintwayV3 Phase 3.2 dogfood found **6 distinct VGFlow defects** chaining together to produce a false-PASS at `/vg:review` and `/vg:test`, masking real production bugs (admin topup approve/flag forms crashed in browser while pipeline showed all green).

Root architectural cause: **validators were FAIL OPEN.** Format drift, regex miss, parse failure all returned PASS or WARN. AI consumers trusted the gate.

This PR converts 4 validators to fail-closed, adds 1 new content-aware validator, and removes 1 silent fallback path in `/vg:test`.

## Bug chain (Phase 3.2 evidence)

```
TEST-GOALS.md format = markdown "## Goal G-XX:"
  ↓
verify-runtime-map-coverage parses YAML only → 0 goals → return PASS thầm
  ↓
verify-runtime-map-crud-depth MUTATION_WORD_RE missing approve/reject/flag/reset
  → 0 mutation goals classified → return PASS
  ↓
verify-contract-runtime regex `^##\s+METHOD` only matches level-2 headers,
  Phase 3.2 used `### POST /...` → 0 endpoints → WARN empty_contract
  ↓
Review skill ghi 27/67 sequences but matrix=65 READY (no validator caught
  the matrix↔runtime fabrication)
  ↓
/vg:test sees READY + missing seq → silent fallback to "structural spec
  from CRUD-SURFACES.md" → list-render .spec.ts với no mutation evidence
  ↓
.spec.ts PASS (lists render fine), production Approve/Reject/Flag buttons
  crash with "Cannot read properties of undefined (reading 'name')"
```

## What changed

| Component | Before | After |
|---|---|---|
| `verify-runtime-map-coverage.py` | YAML-only parser, return 0 on parse fail | Markdown + YAML, BLOCK on unparseable |
| `verify-runtime-map-crud-depth.py` | Mutation regex: 6 generic CRUD verbs | + 30 state-transition verbs (approve/reject/flag/etc.) + Vietnamese |
| `verify-contract-runtime.py` | Regex `^##\s+METHOD`, WARN on empty | Regex `^#{2,4}\s+METHOD`, BLOCK on empty |
| **NEW** `verify-matrix-evidence-link.py` | — | Cross-checks GOAL-COVERAGE-MATRIX.md vs RUNTIME-MAP.json sequences |
| `commands/vg/review.md` | No matrix↔runtime cross-check at exit | Validator wired before run-complete |
| `commands/vg/test.md` | Silent CRUD-structural fallback default | BLOCK by default; legacy fallback gated behind `--allow-structural-fallback` flag |

## Phase 3.2 smoke results (after fix)

| Validator | Verdict | Findings |
|---|---|---|
| verify-runtime-map-coverage | BLOCK | 10 UI gaps (G-09, G-21, G-24, G-36, G-43, G-48, ...) — markdown parsed correctly |
| verify-runtime-map-crud-depth | BLOCK | 3 mutation goals lack evidence (G-08 list-only, G-21+G-49 no sequence) |
| verify-matrix-evidence-link | BLOCK | 55 mismatches: 40 matrix-status-without-runtime-sequence + 11 matrix-status-contradicts-runtime-result + 4 empty-sequence |
| verify-contract-runtime | PASS | All 52 endpoints have route registrations (legitimately passes after regex fix) |

## Architectural rule (added to changelog)

> Validators MUST fail-closed on parse error / format drift / regex miss. Returning PASS/WARN when the validator cannot enforce its invariant means the gate has been silently bypassed. The default for unparseable input is BLOCK with a hint to fix the format.

## Deferred

- **Full field-shape validator** (BE handler return shape vs FE response consumption vs API-CONTRACTS.md Response section) — separate larger feature, needs Zod/TypeScript AST parser. Tracked for follow-up PR.
- **Matrix as derived artifact** (script writes from goal_sequences, AI cannot edit) — opportunistic; current matrix-evidence-link gate already prevents fabrication.

## Test plan

- [x] R4 verify-runtime-map-coverage smoke against Phase 3.2: BLOCK with markdown format detected
- [x] R5 verify-runtime-map-crud-depth smoke: BLOCK on G-08/G-21/G-49
- [x] R1 verify-matrix-evidence-link smoke: 55 mismatches detected
- [x] R6 verify-contract-runtime smoke: PASS with 52 endpoints parsed
- [ ] Reviewer: confirm `--allow-structural-fallback` flag opt-in path still works for legacy phases (legacy behavior preserved, gated)
- [ ] Reviewer: confirm matrix-evidence-link gate doesn't block on legitimate INFRA_PENDING/UNREACHABLE/DEFERRED statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)