### PR TITLE
feat: scanner-evidence Tier A-G + /vg:debug + ÉP enforcement (4 commits)

### DIFF
--- a/commands/vg/_shared/scanner-report-contract.md
+++ b/commands/vg/_shared/scanner-report-contract.md
@@ -1,0 +1,491 @@
+---
+name: vg:_shared:scanner-report-contract
+description: Canonical contract — scanner agents (CLI/Haiku) report observations only, NEVER verdicts. Commander (Opus) is sole judge. Used by /vg:roam workers + /vg:review Phase 2b-2 Haiku scanners.
+---
+
+# Scanner Report Contract
+
+**Principle:** Scanner agents **discover and report**. Commander (Opus) **adjudicates and decides**. Verdicts, severity, prescriptions — all commander's job.
+
+**Why:** Lower-tier CLI models (Codex / Gemini Flash / Haiku) are good observers but biased judges. Letting them mark "BUG" / "CRITICAL" / "FIX NEEDED" pollutes downstream synthesis with low-quality severity signal. Separate concerns: scanner = factual capture; commander = trained model with full context evaluates.
+
+This contract is read by:
+- `/vg:roam` workers (CLI executors)
+- `/vg:review` Phase 2b-2 Haiku scanners (`vg-haiku-scanner` skill)
+- Future: `/vg:debug` discovery agents
+
+---
+
+## Section 1 — Banned vocabulary
+
+Scanner output **MUST NOT** contain any of these tokens (case-insensitive). They are verdicts, not observations.
+
+| Banned | Why | Use instead |
+|---|---|---|
+| `bug`, `broken`, `wrong`, `incorrect` | Judgmental | `expected X, observed Y` |
+| `fail`, `failed`, `failure` (in description text) | Verdict | `match: no` (in structured field only) |
+| `critical`, `major`, `minor`, `severe` | Severity = commander's matrix | `unknown` (commander assigns post-adjudication) |
+| `should`, `must`, `need to`, `needs` | Prescriptive | `evidence: <fact>` |
+| `fix`, `repair`, `patch` | Action recommendation | report observation, let commander prescribe |
+| `correct`, `correctly`, `properly` | Implies right/wrong judgment | `expected_per_lens: <spec>` vs `observed: <fact>` |
+| `obviously`, `clearly`, `apparently` | Speculation, not observation | drop the qualifier; state observation directly |
+
+**Allowed words:**
+- `expected_per_lens`, `observed`, `match`, `mismatch`, `partial`, `unknown`
+- `evidence`, `screenshot`, `network_requests`, `console_errors`, `dom_changed`, `url_after`
+- `elapsed`, `timeout`, `retry`, `step`, `anomaly`, `query`, `blocker`
+
+**Validator:** post-write grep on scanner output files. Hits in banned list → reject report + log to scanner's quarantine list. Commander still reads, but tags the report `vocabulary_violation: true` for trust calibration.
+
+---
+
+## Section 2 — Report schema (canonical)
+
+All scanner reports MUST conform to this JSON schema. Per-tool wrappers (web/mobile/CLI) extend, never violate.
+
+```json
+{
+  "$schema_version": "scanner-report.v1",
+  "scanner_id": "string — unique per invocation (e.g., haiku-csrf-3, codex-form-7)",
+  "lens": "string — lens or task name (e.g., form-lifecycle, csrf, idor, view-scan)",
+  "target": {
+    "page": "string | null — URL/route or N/A",
+    "role": "string | null — auth role used",
+    "platform": "web | ios | android | cli | api | null",
+    "device": "string | null — device name if mobile/desktop"
+  },
+  "session": "string — orchestrator-provided session UUID",
+  "started_at": "ISO 8601",
+  "ended_at": "ISO 8601",
+  "duration_s": "number",
+
+  "observations": [
+    {
+      "step": "string — what scanner did, factual (e.g., 'click submit', 'navigate /sites/new')",
+      "expected_per_lens": "string | null — what the lens spec said to expect",
+      "observed": "string — factual observation, no judgment words",
+      "match": "yes | no | partial | unknown",
+      "evidence": {
+        // Tier A — Always-on (every UI step)
+        "screenshot": "string | null — relative path",
+        "network_requests": "array<{method, url, status, timing_ms, headers?, request_body?, response_body?}>",
+        "console_errors": "array<string — raw error text>",
+        "console_warnings": "array<string>",
+        "dom_changed": "boolean | null",
+        "url_before": "string | null",
+        "url_after": "string | null",
+        "elapsed_ms": "number | null",
+        "page_title": "string | null — document.title after step",
+        "toast": "{ visible, count, items: [{text, type}] } | null — UX feedback message",
+        "http_status_summary": "{ '2xx': N, '3xx': N, '4xx': N, '5xx': N, cors_blocked: N, aborted: N } | null",
+
+        // Tier B — Form / CRUD (set by form-lifecycle, business-coherence lenses)
+        "form_validation_errors": "{ count, items: [{field, message, source}] } | null",
+        "submit_button_state": "{ found, text, disabled, busy } | null",
+        "loading_indicator": "{ present, selector?, bbox? } | null",
+        "row_count_before": "number | null",
+        "row_count_after": "number | null",
+        "field_value_before": "{ field, value, type } | null",
+        "field_value_after": "{ field, value, type } | null",
+        "db_read_after_write": "{ method, url, status, body_match: yes|no|partial } | null — follow-up GET to verify mutation",
+        "idempotency_replay": "{ second_call_status, response_id_matches: yes|no|unknown } | null",
+
+        // Tier C — Auth / Session / Security (set by csrf, idor, bfla, auth-jwt lenses)
+        "cookies_filtered": "{ document_cookie_count, names: [...] } | null — names only, no values",
+        "auth_state": "{ authenticated: yes|no|unknown, signal } | null",
+        "request_security_headers": "{ has_authorization, has_csrf_token, has_idempotency_key, has_if_match, has_origin, has_referer, custom_headers } | null",
+        "response_security_headers": "{ has_set_cookie, set_cookie_flags: [{has_httponly, has_secure, same_site}], has_csp, has_x_frame_options, has_strict_transport_security } | null",
+
+        // Tier D — Realtime / Async (set by realtime-coherence, websocket-scope lenses)
+        "websocket_frames": "{ instrumented: bool, count, frames: [{dir, data, t}] } | null",
+        "polling_calls": "array<{url, interval_ms, count}> | null",
+        "background_job_status": "{ status, queue_summary } | null",
+
+        // Tier E — Visual / A11y (set by visual, a11y, modal-state lenses)
+        "viewport_size": "{ width, height } | null",
+        "focus_state": "{ focused, tag, id?, name?, role?, label } | null",
+        "aria_state": "{ found, attributes: { 'aria-*': value, role: value } } | null — captured per relevant element",
+        "a11y_tree_excerpt": "string | null — MCP browser_snapshot output, trimmed",
+        "tab_order": "array<{tag, label, tabindex}> | null — first 30 focusable elements",
+
+        // Tier F — Storage / Client State (set by business-coherence deep, info-disclosure lenses)
+        "storage_keys": "{ localStorage_keys: [...], sessionStorage_keys: [...], count } | null — keys only, never values",
+        "indexedDB_dbs": "{ supported, dbs: [{name, version}] } | null",
+        "store_snapshot": "{ exposed, key, top_level_keys: [...] } | null — Zustand/Redux dev-exposed store, top-level keys only",
+
+        // Tier G — Mobile (set by Maestro-driven scanners, MODE=mobile)
+        "hierarchy_diff": "{ added: [...], removed: [...], changed: [...] } | null — Maestro hierarchy.json diff",
+        "screenshot_diff_pct": "number | null — pixel diff percentage between before/after",
+        "deep_link_resolved": "{ requested_url, final_screen_id, success: bool } | null",
+        "tap_target_size_px": "{ element_id, width, height, hig_compliant: bool } | null — iOS HIG 44pt / Material 48dp",
+        "keyboard_avoidance": "{ form_visible_when_keyboard: bool, bottom_inset_px } | null",
+        "network_offline_recovery": "{ tested, recovered: yes|no|partial } | null",
+
+        // Free-form — lens-specific fields not in tiers above
+        "extra": "object — lens-specific fields, free-form"
+      }
+    }
+  ],
+
+  "anomalies": [
+    "string — pattern noticed but unclear if related (e.g., 'console emitted same TypeError 3x with identical stack')"
+  ],
+
+  "blockers": [
+    {
+      "step": "string — which step blocked",
+      "reason": "string — factual (e.g., 'page returned 502', 'auth cookie missing after redirect', 'browser MCP timeout 30s')",
+      "evidence": "object | string"
+    }
+  ],
+
+  "queries": [
+    {
+      "step": "string — current step",
+      "question": "string — needs commander input to continue",
+      "scanner_proposal": "string | null — what scanner would do if allowed (NOT prescription, just option)"
+    }
+  ],
+
+  "completion": {
+    "status": "complete | partial | aborted",
+    "steps_total": "number",
+    "steps_completed": "number",
+    "steps_skipped": "number"
+  }
+}
+```
+
+**Field discipline:**
+
+- `match` is the ONLY judgment field. `yes` = observed matches expected. `no` = mismatch. `partial` = some criteria match, others don't. `unknown` = lens didn't specify expected, or evidence inconclusive.
+- `observations[].observed` = pure description. NO interpretation. "Button stayed enabled, no network call in 5s" ✓ — "submit handler appears broken" ✗.
+- `evidence` arrays may be empty `[]` — empty IS a fact (e.g., `network_requests: []` = "we observed zero requests").
+- `anomalies` is a low-confidence noticeboard for commander. Format: factual description, no severity.
+- `blockers` halts scanner — commander must triage. Use sparingly; don't blocker on minor mismatches.
+- `queries` is the explicit "I don't know how to proceed, please decide" channel. Commander answers in next iteration.
+
+---
+
+## Section 2.5 — Evidence Tier System (v2.42.8+)
+
+Evidence fields organized into 7 tiers by capture cost + bug class coverage. Scanners capture per-tier based on lens config + platform capability. Helper JS snippets for each tier live in `.claude/scripts/scanner-evidence-capture.js`.
+
+### Tier A — Always-on (every UI step, ~0ms cost)
+
+Captured automatically by browser MCP without extra eval. Required on EVERY observation in UI mode.
+
+| Field | What it catches |
+|---|---|
+| `screenshot`, `dom_changed`, `url_before`, `url_after`, `elapsed_ms` | Page transitions, hangs, optimistic UI failures |
+| `network_requests[]` | API not firing, 4xx/5xx, race conditions |
+| `console_errors[]`, `console_warnings[]` | Runtime exceptions, deprecation warnings |
+| `page_title` | Wrong navigation, stale title |
+| `toast` | UX silent — user doesn't know action result |
+| `http_status_summary` | Mass-failure pattern (e.g., 5 auth requests all 401) |
+
+### Tier B — Form / CRUD (form-lifecycle, business-coherence; ~50-200ms extra)
+
+Capture when step involves a form submit, edit, delete, or list mutation.
+
+| Field | What it catches |
+|---|---|
+| `form_validation_errors` | Field-level validation broken, mass-assignment exposure |
+| `submit_button_state` | Button stuck enabled (handler dead), missing aria-busy |
+| `loading_indicator` | UX no feedback during 2s+ wait |
+| `db_read_after_write` | **Ghost save** — toast OK but DB didn't update |
+| `row_count_before` / `row_count_after` | Optimistic-only update, server didn't persist |
+| `field_value_before` / `field_value_after` | Edit didn't stick, race overwrite |
+| `idempotency_replay` | Duplicate-create on retry |
+
+### Tier C — Auth / Session / Security (csrf, idor, bfla, auth-jwt; ~20-50ms)
+
+Capture on auth-sensitive steps: login, role-switch, sensitive mutation, cross-tenant probe.
+
+| Field | What it catches |
+|---|---|
+| `cookies_filtered` | Missing HttpOnly/Secure/SameSite, CSRF token leak |
+| `auth_state` | Silent logout, session expire mid-flow |
+| `request_security_headers` | Header drift, missing CSRF/Idempotency-Key |
+| `response_security_headers` | Set-Cookie missing flags, missing CSP/HSTS, session fixation |
+
+### Tier D — Realtime / Async (websocket-scope, polling-coherence; ~0ms passive but instrumented)
+
+Requires app-side instrumentation (`window.__vg_ws_log`). Without instrumentation, fields return `instrumented: false`.
+
+| Field | What it catches |
+|---|---|
+| `websocket_frames` | Frame drop, scope leak (M1 receives M2's events), reconnect replay storms |
+| `polling_calls` | Wasted polling, missing backoff |
+| `background_job_status` | Silent BullMQ failure, cron not firing |
+
+### Tier E — Visual / A11y (visual, a11y, modal-state; ~200-500ms)
+
+Capture per major UI state change (page load, modal open, route change).
+
+| Field | What it catches |
+|---|---|
+| `viewport_size` | Responsive breakpoint mistakes |
+| `focus_state` | Focus trap missing on modal, focus loss after close |
+| `aria_state` | Wrong screen-reader signal, aria-expanded not updating |
+| `a11y_tree_excerpt` | A11y tree corruption, missing landmarks |
+| `tab_order` | Skip-link failure, hidden tabbable, wrong tab sequence |
+
+### Tier F — Storage / Client State (business-coherence deep, info-disclosure; ~30-100ms)
+
+Capture for state-coherence checks. Keys ONLY — never values (PII / token risk).
+
+| Field | What it catches |
+|---|---|
+| `storage_keys` | State leak, PII in storage, leftover cache |
+| `indexedDB_dbs` | Schema migration drift, leaked DB |
+| `store_snapshot` | State desync vs UI claim (Zustand/Redux), if dev exposed `window.__VG_STORE__` |
+
+### Tier G — Mobile (Maestro, MODE=mobile; ~500ms-2s per step)
+
+Replaces Tier A-E for mobile profile. Browser MCP fields N/A.
+
+| Field | What it catches |
+|---|---|
+| `hierarchy_diff` | Element appearance/disappearance |
+| `screenshot_diff_pct` | Visual regression |
+| `deep_link_resolved` | Universal link broken |
+| `tap_target_size_px` | <44pt iOS HIG / <48dp Material |
+| `keyboard_avoidance` | Form covered by keyboard |
+| `network_offline_recovery` | Offline UX missing |
+
+---
+
+## Section 2.6 — Capability Matrix per Platform
+
+| Tool / Platform | A | B | C | D | E | F | G |
+|---|---|---|---|---|---|---|---|
+| Browser MCP (web) | ✓ all | ✓ all | ✓ cookies/auth | ✓ if instrumented | ✓ screenshot+a11y | ✓ all | ✗ |
+| Maestro (mobile) | ✓ network limited | ✓ form (no validation API) | ✓ basic auth | ✗ no WS hook | ✓ screenshot only | ✗ no eval | ✓ all |
+| curl / API-only | ✓ status+headers | ✗ no UI | ✓ headers+cookies | ✗ no WS | ✗ | ✗ | ✗ |
+| CLI subprocess | exit code + stdout/stderr | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+
+Scanners that can't capture a tier emit `<field>: null` (NOT omit — `null` is a fact: "we tried, capability missing"). Commander reads `null` as "tier unavailable on this platform" and weights accordingly.
+
+---
+
+## Section 2.7 — Per-lens Tier Defaults (v2.42.8+)
+
+Each lens declares which tiers fire. Scanner reads lens spec, captures only relevant tiers (cost optimization). Defaults below; lens authors can override per-step.
+
+| Scanner / Lens | Always | Conditional | Opt-in via flag |
+|---|---|---|---|
+| `vg-haiku-scanner` (review Phase 2b-2 exhaustive) | A + B + E | C if mutation, F if state-coherence | D (instrumentation), G (mobile) |
+| roam `lens-form-lifecycle` | A + B | C if auth flow, F if SPA | D, E |
+| roam `lens-business-coherence` | A + B + F | C if auth | D, E |
+| roam `lens-csrf` | A + C | B if mutation | — |
+| roam `lens-idor` / `lens-bfla` / `lens-tenant-boundary` | A + C | B if mutation | F (storage cross-tenant) |
+| roam `lens-auth-jwt` | A + C + F | — | D (token refresh frames) |
+| roam `lens-modal-state` | A + E | — | F (modal-internal store) |
+| roam `lens-table-interaction` | A + B (row count, field) | E (focus during keyboard nav) | — |
+| roam `lens-info-disclosure` | A + F | C (response headers) | — |
+| roam `lens-input-injection` | A | C if auth-bypass attempted | — |
+| roam `lens-file-upload` | A + B | C if file-mutation auth | E (upload progress UI) |
+| roam `lens-duplicate-submit` | A + B (idempotency_replay) | — | — |
+| /vg:debug discovery agent | A only (lightweight) | B/C/E based on classification | F if storage-related |
+| Mobile (Maestro) | A (limited) + G | E (screenshot diff) | — |
+
+Lens spec format reflects this: each `step:` entry has `evidence_tiers: [A, B, ...]` declaring which tiers to capture.
+
+---
+
+## Section 3 — Output format per tool
+
+| Tool | File | Format |
+|---|---|---|
+| `vg-haiku-scanner` (review Phase 2b-2) | `${PHASE_DIR}/scan-{VIEW_SLUG}-{ROLE}.json` | Single JSON object per scanner invocation |
+| `/vg:roam` workers (CLI executors) | `${ROAM_DIR}/runs/<tool>/observe-{surface}-{lens}.jsonl` | JSONL — one event per line, accumulated |
+| `/vg:debug` discovery agent | `${DEBUG_DIR}/discovery/{type}-{slug}.json` | Single JSON per discovery pass |
+
+**JSONL variant (roam):** each line is a partial observation. Aggregator at end of roam Phase 4 collates lines into the canonical schema. First line MUST be the wrapper:
+
+```json
+{"$schema_version":"scanner-report.v1","scanner_id":"...","lens":"...","target":{...},"session":"...","started_at":"...","_observations_follow":true}
+```
+
+Subsequent lines are individual `observations[]` / `anomalies[]` / `blockers[]` / `queries[]` entries with explicit `_kind` field:
+
+```json
+{"_kind":"observation","step":"click submit","expected_per_lens":"POST /api/sites","observed":"5s elapsed, no network","match":"no","evidence":{"network_requests":[],"console_errors":["TypeError"]}}
+{"_kind":"anomaly","note":"3x identical TypeError in console"}
+{"_kind":"blocker","step":"verify created record","reason":"no resource :id available because POST never fired"}
+```
+
+Final line:
+```json
+{"_kind":"completion","status":"partial","steps_total":12,"steps_completed":4,"ended_at":"..."}
+```
+
+---
+
+## Section 4 — Acceptable vs unacceptable examples
+
+### ✓ ACCEPTABLE — observation only
+
+```yaml
+step: "fill form: domain=example.com, click submit"
+expected_per_lens: "POST /api/sites within 2s + 201 status + redirect to /sites/{id}"
+observed: "5 seconds elapsed; button remained enabled; URL unchanged at /sites/new; zero network requests captured; console emitted TypeError: validate is not a function (validate.ts:42)"
+match: no
+evidence:
+  network_requests: []
+  console_errors: ["TypeError: validate is not a function at validate.ts:42"]
+  dom_changed: false
+  url_before: "/sites/new"
+  url_after: "/sites/new"
+  elapsed_ms: 5042
+  screenshot: "iter-3-after-submit.png"
+```
+
+Commander reads → has enough to: classify (likely code-bug), assign severity (mutation blocked = high), route (file:line in stack trace → /vg:debug or executor fix).
+
+### ✗ UNACCEPTABLE — verdict-poisoned
+
+```yaml
+step: "click submit"
+observed: "Submit button is BROKEN. Critical bug — needs fix immediately. Handler is clearly missing."
+match: failed                       # bad: 'failed' not in enum
+severity: critical                  # bad: severity is commander's job
+recommendation: "fix validate.ts"   # bad: prescription, not observation
+```
+
+Reasons:
+1. "BROKEN", "Critical", "needs fix" — banned vocabulary
+2. `severity: critical` — scanner doesn't decide severity
+3. `recommendation: ...` — scanner doesn't prescribe
+4. `match: failed` — not in enum (`yes`/`no`/`partial`/`unknown`)
+5. No evidence: missing network/console/screenshot/elapsed
+
+Commander gets corrupted signal — must discount or re-run.
+
+---
+
+## Section 5 — Commander adjudication contract
+
+Commander reads scanner reports + applies:
+
+```
+1. Vocabulary check
+   For each report, scan for banned tokens.
+   Hit → tag report `vocabulary_violation: true`, deprioritize but don't discard.
+
+2. Coherence check
+   - UI claim ↔ network truth: did toast say "saved" but network show no POST?
+   - Read-after-write: did GET return the value POST claimed to set?
+   - Console correlation: did mismatch line up with a console error?
+
+3. Cross-reference TEST-GOALS / SPECS contract
+   - Is `expected_per_lens` from a real lens spec? Or scanner improvised?
+   - Does the goal G-XX exist for this surface?
+   - Is observed behavior actually in scope of this phase?
+
+4. Categorize finding
+   - false-positive: lens spec stale, observed is intentional
+   - code-bug: handler dead, dispatch missing, off-by-one
+   - spec-gap: feature not in PLAN — auto-trigger /vg:amend
+   - scope-issue: out-of-phase, defer to later phase
+   - infra-issue: env-specific (dev seed missing, etc.)
+   - regression: was working, now isn't (compare with baseline scan)
+
+5. Severity assignment (project profile matrix)
+   - critical: data loss, security, financial, auth bypass, idempotency violation
+   - high: mutation blocked, contract violation, IDOR/BFLA actually exploitable
+   - med: UX broken with workaround, coherence gap
+   - low: cosmetic, console noise, logging-only
+
+6. Verdict + action
+   - pass / weak-pass / fail / escalate
+   - Route: /vg:debug (code bug), /vg:amend (spec gap), accept-with-debt (low+medium), block (critical+high)
+```
+
+**Commander → user surface:** never raw scanner reports. Always adjudicated summary with verdict + action options.
+
+---
+
+## Section 6 — Validator (post-write contract enforcement)
+
+Every scanner-report writer MUST be validated by `verify-scanner-report-contract.py` (TODO — script lands when this contract is consumed by ≥1 skill that writes scan reports).
+
+Validator checks:
+
+1. JSON schema valid (or JSONL: every line valid JSON, wrapper + completion present)
+2. No banned tokens in any string field (regex grep)
+3. `match` enum compliance
+4. Required fields present (scanner_id, lens, target, observations[])
+5. `evidence` shape per observation (warn if missing for `match: no`)
+
+Verdict:
+- All checks pass → `contract_compliance: 100`
+- Violations → emit telemetry `scanner.contract_violation` with details. Commander deprioritizes report (still consumes — partial signal > no signal).
+
+---
+
+## Section 7 — Migration notes
+
+**Existing scanner outputs** (pre-contract) often violate banned vocab + lack `expected_per_lens`. Migration strategy:
+
+| Skill | Current state | Required change |
+|---|---|---|
+| `vg-haiku-scanner` (review Phase 2b-2) | Has `errors[].severity` — banned field | Replace with `match: no` + move severity to commander step (review Phase 4 weighted gate already does this) |
+| `/vg:roam` workers | JSONL freeform with verdict words possible | Inject this contract into INSTRUCTION-*.md briefs, add validator post-aggregate |
+| `/vg:debug` discovery agent | New (already drafted) | Reference contract from skill body |
+
+Old scan files remain readable; new writes conform.
+
+---
+
+## Section 8 — Lens spec format (companion contract)
+
+Lens specs declare `expected_per_lens` for each step. Without explicit lens spec, scanner falls back to `expected_per_lens: null` and commander has less to compare against.
+
+```yaml
+# .claude/commands/vg/_shared/lens-prompts/lens-form-lifecycle.md
+lens_id: form-lifecycle
+applicable_to: [crud-create, crud-update, crud-delete]
+steps:
+  - id: navigate
+    action: "navigate to {target_url}"
+    expected: "form rendered with all declared fields visible"
+  - id: fill_required
+    action: "fill all required fields with valid sample"
+    expected: "no inline validation errors, submit button enabled"
+  - id: submit
+    action: "click submit"
+    expected: "{request_method} {request_path} within 2s; status {success_code}; redirect to {success_url}"
+  - id: read_after_write
+    action: "GET created resource"
+    expected: "200 response with field values matching submitted payload"
+  - id: refresh_persistence
+    action: "page.reload(); GET again"
+    expected: "same field values as previous read (no ghost-save)"
+```
+
+Scanner copies `expected` verbatim into `observations[].expected_per_lens`. No paraphrasing.
+
+---
+
+## Quick reference card
+
+```
+SCANNER:
+  - Discover, capture facts
+  - No verdicts, no severity, no prescriptions
+  - match: yes|no|partial|unknown ONLY
+  - Evidence-rich, vocabulary-clean
+
+COMMANDER:
+  - Read all reports
+  - Coherence + spec cross-ref
+  - Categorize: false-pos/code-bug/spec-gap/scope/infra/regression
+  - Severity matrix + verdict
+  - Route to debug/amend/accept-debt/block
+
+USER:
+  - See adjudicated summary only
+  - Make final accept/reject decision on commander's recommendation
+```

--- a/commands/vg/debug.md
+++ b/commands/vg/debug.md
@@ -1,0 +1,399 @@
+---
+name: vg:debug
+description: Targeted bug-fix loop — analyze description, classify, fix, verify with user (no full review sweep)
+argument-hint: '"<bug description>" [--phase=<N>] [--no-amend-trigger]'
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Task
+mutates_repo: true
+runtime_contract:
+  must_write:
+    - .vg/debug/{debug_id}/DEBUG-LOG.md
+  must_touch_markers:
+    - 0_parse_and_classify
+    - 1_discovery
+    - 2_hypothesize_and_fix
+    - 3_verify_and_loop
+    - 4_complete
+  must_emit_telemetry:
+    - event_type: "debug.parsed"
+    - event_type: "debug.classified"
+    - event_type: "debug.fix_attempted"
+    - event_type: "debug.user_confirmed"
+    - event_type: "debug.completed"
+---
+
+<rules>
+1. **Standalone session** — debug session lives in `.vg/debug/<id>/`, not phase-scoped (Q1 user choice).
+2. **AskUserQuestion-driven loop** — no max iterations. Each loop end asks user: fixed / retry / more-info (Q2).
+3. **Auto-classify** — AI picks discovery path (code-only / browser / network / infra / spec gap) without asking unless confidence < 80%.
+4. **Spec gap → auto /vg:amend** — if classified as spec gap, auto-trigger `/vg:amend <phase>` (Q5=a).
+5. **Browser MCP fallback** — if browser MCP unavailable + UI bug, write findings as amendment to phase (Q3) instead of blocking.
+6. **Atomic commits per fix** — each fix attempt = 1 commit. Easy rollback if loop fails.
+7. **No destructive actions** — fix code only. Don't drop tables, force-push, or delete branches.
+</rules>
+
+<objective>
+Lightweight targeted bug-fix workflow. Use case: user gặp 1 bug cụ thể (ví dụ click /campaigns crash), thay vì chạy `/vg:review` (15-30 min full Haiku scan), chạy `/vg:debug "<mô tả>"` (3-5 min targeted) để:
+
+1. Parse + classify bug từ natural language
+2. Auto-pick discovery method
+3. Generate hypothesis chain
+4. Apply fix + commit atomic
+5. Verify (reproduce)
+6. AskUserQuestion loop until user confirms fixed
+
+Output: `.vg/debug/<id>/DEBUG-LOG.md` + atomic commits. If detected spec gap → auto `/vg:amend`.
+</objective>
+
+<process>
+
+**Config:** Read `.claude/commands/vg/_shared/config-loader.md` first.
+
+<step name="0_parse_and_classify">
+## Step 0: Parse + classify bug description
+
+Parse `$ARGUMENTS`:
+- First quoted string: bug description (required)
+- Optional flags: `--phase=<N>`, `--no-amend-trigger`, `--from-error-log=<path>`, `--from-uat-feedback="<text>"`
+
+Validate description non-empty. Empty → BLOCK with usage example.
+
+```bash
+# Generate debug session ID
+DEBUG_ID="dbg-$(date -u +%Y%m%d-%H%M%S)-$(echo $$ | tail -c 5)"
+DEBUG_DIR=".vg/debug/${DEBUG_ID}"
+mkdir -p "$DEBUG_DIR"
+
+# Register run with orchestrator
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-start vg:debug "${PHASE_NUMBER:-standalone}" "${ARGUMENTS}" || {
+  echo "⛔ vg-orchestrator run-start failed" >&2; exit 1
+}
+
+# Emit parsed event
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event debug.parsed \
+  --payload "{\"debug_id\":\"${DEBUG_ID}\",\"description\":$(printf '%s' "$BUG_DESC" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))'),\"phase\":\"${PHASE_NUMBER:-standalone}\"}" \
+  --step debug.0_parse_and_classify --actor orchestrator --outcome INFO
+```
+
+**Classify bug type** (deterministic keyword + structure heuristic, no AI subagent for speed):
+
+| Type | Detection signal | Discovery method |
+|---|---|---|
+| `static` | Stack trace mentions specific file/line; keywords: typo, null check, undefined, off-by-one | grep + read affected file |
+| `runtime_ui` | Mentions: click, render, modal, page, layout, tab, button. Has URL path | Browser MCP (or fallback) |
+| `network` | Mentions: 4xx, 5xx, status code, timeout, CORS, ERR_CONNECTION | curl + log inspect |
+| `infra` | Mentions: env var, config, deploy, restart, port, daemon | vg.config.md + .env inspect |
+| `spec_gap` | Mentions: "không có", "missing feature", "tính năng", "chưa có UI for X" | Read SPECS/CONTEXT/PLAN to confirm; if confirmed → auto-amend |
+| `ambiguous` | Confidence < 80% | AskUserQuestion to clarify |
+
+```bash
+# Heuristic classification
+BUG_DESC="${ARGUMENTS}"  # cleaned
+BUG_TYPE="ambiguous"
+CONFIDENCE=0
+
+# UI signals
+if echo "$BUG_DESC" | grep -qiE '(click|render|modal|tab|layout|button|form|page|/[a-z-]+|crash khi|không hiển thị)'; then
+  BUG_TYPE="runtime_ui"; CONFIDENCE=85
+fi
+# Network signals (override UI if status code mentioned)
+if echo "$BUG_DESC" | grep -qiE '\b(4[0-9]{2}|5[0-9]{2}|timeout|ERR_CONNECTION|CORS|fetch failed)\b'; then
+  BUG_TYPE="network"; CONFIDENCE=90
+fi
+# Infra signals
+if echo "$BUG_DESC" | grep -qiE '\b(env var|\.env|config|deploy|restart|port [0-9]+|pm2|daemon)\b'; then
+  BUG_TYPE="infra"; CONFIDENCE=85
+fi
+# Static code signals (stack trace markers)
+if echo "$BUG_DESC" | grep -qiE '(at .*:\d+|TypeError|ReferenceError|undefined is not|null is not)'; then
+  BUG_TYPE="static"; CONFIDENCE=90
+fi
+# Spec gap signals
+if echo "$BUG_DESC" | grep -qiE '(không có|missing feature|tính năng .* chưa|cần thêm|should support|wishful|nowhere)'; then
+  BUG_TYPE="spec_gap"; CONFIDENCE=70
+fi
+
+echo "Bug classified: ${BUG_TYPE} (confidence ${CONFIDENCE}%)"
+```
+
+**If confidence < 80% → AskUserQuestion** with options matching detected types + "other".
+
+```bash
+# Emit classified event
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event debug.classified \
+  --payload "{\"debug_id\":\"${DEBUG_ID}\",\"bug_type\":\"${BUG_TYPE}\",\"confidence\":${CONFIDENCE}}" \
+  --step debug.0_parse_and_classify --actor orchestrator --outcome INFO
+
+# Write initial DEBUG-LOG
+cat > "${DEBUG_DIR}/DEBUG-LOG.md" <<EOF
+# Debug session ${DEBUG_ID}
+
+**Started:** $(date -u +%FT%TZ)
+**Description:** ${BUG_DESC}
+**Phase:** ${PHASE_NUMBER:-standalone}
+**Classification:** ${BUG_TYPE} (${CONFIDENCE}%)
+
+## Iterations
+EOF
+
+touch "${DEBUG_DIR}/.markers/0_parse_and_classify.done" 2>/dev/null || mkdir -p "${DEBUG_DIR}/.markers" && touch "${DEBUG_DIR}/.markers/0_parse_and_classify.done"
+```
+
+**Spec gap branch:** if `BUG_TYPE=spec_gap` AND not `--no-amend-trigger`:
+- Determine target phase (from `--phase=` flag, or grep PLAN.md for keywords matching bug, or AskUserQuestion)
+- Write DEBUG-LOG note: "Classified as spec gap → auto-triggering /vg:amend"
+- `SlashCommand: /vg:amend ${PHASE_NUMBER}` then exit cleanly
+- Emit `debug.completed` with verdict=SPEC_GAP_ROUTED_TO_AMEND
+
+</step>
+
+<step name="1_discovery">
+## Step 1: Discovery (path picked from classification)
+
+```bash
+mkdir -p "${DEBUG_DIR}/discovery"
+```
+
+Branch on `$BUG_TYPE`:
+
+### static → code grep + read
+```bash
+# Extract keywords from description
+KEYWORDS=$(echo "$BUG_DESC" | grep -oE '[a-zA-Z][a-zA-Z0-9_-]{3,}' | sort -u | head -10)
+for kw in $KEYWORDS; do
+  grep -rn "$kw" apps/ packages/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -5 \
+    >> "${DEBUG_DIR}/discovery/grep-results.txt"
+done
+```
+
+### runtime_ui → browser MCP (with fallback)
+- If browser MCP available: spawn small Haiku agent to navigate + snapshot the URL mentioned
+- If unavailable: write findings to discovery/ as amendment + suggest manual reproduce
+
+```bash
+# Detect MCP availability
+if [ -f "${HOME}/.claude/playwright-locks/playwright-lock.sh" ]; then
+  MCP_AVAILABLE=true
+else
+  MCP_AVAILABLE=false
+fi
+
+if [ "$MCP_AVAILABLE" = "true" ]; then
+  # Spawn Haiku agent (1 view only, not full review scan)
+  echo "Spawning Haiku for targeted UI discovery..."
+  # Agent(...) call with prompt focused on single URL + bug description
+else
+  echo "Browser MCP unavailable — fallback to code-only path."
+  # Treat as static + write notice to DEBUG-LOG
+  echo "**Note:** Browser MCP down. UI bug analyzed from code only. Re-run after MCP up if fix doesn't reproduce." \
+    >> "${DEBUG_DIR}/DEBUG-LOG.md"
+fi
+```
+
+### network → curl reproduce + tail logs
+```bash
+# Extract URL/endpoint from description
+URL=$(echo "$BUG_DESC" | grep -oE 'https?://[^ ]+|/api/v[0-9]+/[^ ]+' | head -1)
+if [ -n "$URL" ]; then
+  curl -sv "$URL" > "${DEBUG_DIR}/discovery/curl-output.txt" 2>&1
+fi
+# Inspect recent server logs (project-specific path from config)
+tail -100 apps/api/logs/error.log 2>/dev/null > "${DEBUG_DIR}/discovery/recent-errors.txt"
+```
+
+### infra → vg.config + env inspect
+```bash
+cp .claude/vg.config.md "${DEBUG_DIR}/discovery/vg.config.snapshot.md"
+[ -f .env ] && grep -v '^[A-Z_]*_SECRET\|_KEY\|_PASSWORD' .env > "${DEBUG_DIR}/discovery/env-redacted.txt"
+```
+
+Write discovery summary to DEBUG-LOG.
+
+```bash
+touch "${DEBUG_DIR}/.markers/1_discovery.done"
+```
+</step>
+
+<step name="2_hypothesize_and_fix">
+## Step 2: Generate hypothesis + apply fix
+
+Based on discovery findings, generate **3-5 ranked hypotheses** for root cause. Pick top hypothesis, apply fix.
+
+```
+Iteration N:
+  Hypothesis: <root cause>
+  Evidence: <discovery findings supporting it>
+  Fix: <files to edit + change description>
+```
+
+Apply fix using Edit tool. Commit atomic:
+```bash
+git add <changed files>
+git commit -m "fix(debug-${DEBUG_ID}): iteration ${ITER} — <one-line fix description>
+
+Hypothesis: <root cause>
+Bug: ${BUG_DESC:0:80}
+Debug-Session: ${DEBUG_ID}"
+```
+
+Append iteration entry to DEBUG-LOG.md:
+```markdown
+### Iteration ${ITER} — $(date -u +%FT%TZ)
+**Hypothesis:** ...
+**Files changed:** ...
+**Commit:** <sha>
+```
+
+Emit fix_attempted event:
+```bash
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event debug.fix_attempted \
+  --payload "{\"debug_id\":\"${DEBUG_ID}\",\"iteration\":${ITER},\"commit\":\"${SHA}\"}" \
+  --step debug.2_hypothesize_and_fix --actor orchestrator --outcome INFO
+
+touch "${DEBUG_DIR}/.markers/2_hypothesize_and_fix.done"
+```
+
+**Auto-verify if possible:**
+- static fix → run typecheck on file: `tsc --noEmit <file>`
+- network fix → re-curl the endpoint
+- ui fix → if MCP up, re-snapshot via Haiku
+- infra fix → re-run health check
+
+Document auto-verify result in DEBUG-LOG.
+</step>
+
+<step name="3_verify_and_loop">
+## Step 3: AskUserQuestion — fixed / retry / more-info
+
+```
+AskUserQuestion:
+  header: "Debug ${DEBUG_ID} — Iteration ${ITER}"
+  question: "Bug đã fix chưa? Vui lòng test trên môi trường của bạn rồi chọn:"
+  options:
+    - "Đã fix — exit clean"
+      description: "Bug không còn xuất hiện. Commit + DEBUG-LOG ghi PASSED."
+    - "Chưa fix — lặp lại quy trình với hypothesis tiếp theo"
+      description: "Auto rollback HEAD commit (nếu fix sai), thử hypothesis khác trong list."
+    - "Thêm thông tin"
+      description: "Bạn nhập thêm context (error log, screenshot path, hoặc clarify) → AI re-classify + tiếp tục"
+```
+
+Emit user_confirmed event after answer:
+```bash
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event debug.user_confirmed \
+  --payload "{\"debug_id\":\"${DEBUG_ID}\",\"iteration\":${ITER},\"answer\":\"${USER_CHOICE}\"}" \
+  --step debug.3_verify_and_loop --actor orchestrator --outcome INFO
+```
+
+### Branch on user choice
+
+**(a) Fixed:**
+- Mark DEBUG-LOG.md "**Status:** RESOLVED at iteration ${ITER}"
+- Tag commit: `git tag debug-${DEBUG_ID}-resolved`
+- Skip to step 4_complete
+
+**(b) Retry:**
+- AskUserQuestion: "Rollback iteration ${ITER}'s fix?" (yes auto-revert / no keep partial)
+  - yes → `git revert HEAD --no-edit`
+  - no → keep changes, build on top
+- Demote current hypothesis (mark "rejected" in DEBUG-LOG)
+- Pick next hypothesis from list
+- Loop back to step 2 (hypothesize_and_fix)
+
+**(c) More info:**
+- AskUserQuestion: "Nhập thông tin thêm:" (free-form text)
+- Append to DEBUG-LOG iteration block
+- Re-classify if new info changes signal (e.g., user pastes status code → reclassify network)
+- Loop back to step 2 with enriched context
+
+```bash
+touch "${DEBUG_DIR}/.markers/3_verify_and_loop.done"
+```
+
+### Spec gap detected mid-loop
+
+If during fix attempts AI realizes the bug is actually **spec gap, not code bug** (e.g., grep confirms feature genuinely doesn't exist anywhere), auto-trigger `/vg:amend`:
+```bash
+echo "Bug reclassified: spec gap (no code path exists for requested behavior)."
+echo "Auto-triggering /vg:amend ${PHASE_NUMBER}..."
+SlashCommand: /vg:amend ${PHASE_NUMBER}
+# Mark debug-log: SPEC_GAP_ROUTED_TO_AMEND
+```
+
+Phase detection: if `--phase=` not given, AI picks via grep PLAN.md / SPECS.md for matching keywords.
+</step>
+
+<step name="4_complete">
+## Step 4: Finalize
+
+Append final summary to DEBUG-LOG.md:
+
+```markdown
+## Final
+- **Status:** RESOLVED | ESCALATED_TO_AMEND | ABANDONED
+- **Iterations:** N
+- **Commits:** SHA1, SHA2, ...
+- **Files changed:** path1, path2, ...
+- **Time:** Xm Ys
+- **Lessons:** (if any patterns worth saving — flag for /vg:learn)
+```
+
+```bash
+git add "${DEBUG_DIR}/DEBUG-LOG.md"
+git commit -m "debug(${DEBUG_ID}): session log — ${STATUS}
+
+Bug: ${BUG_DESC:0:80}
+Iterations: ${ITER}
+Resolution: ${STATUS}
+Debug-Session: ${DEBUG_ID}"
+
+# Emit completed event
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event debug.completed \
+  --payload "{\"debug_id\":\"${DEBUG_ID}\",\"status\":\"${STATUS}\",\"iterations\":${ITER}}" \
+  --step debug.4_complete --actor orchestrator --outcome PASS
+
+touch "${DEBUG_DIR}/.markers/4_complete.done"
+
+# Mark all step markers via orchestrator
+for m in 0_parse_and_classify 1_discovery 2_hypothesize_and_fix 3_verify_and_loop 4_complete; do
+  "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator mark-step debug "$m" 2>/dev/null
+done
+
+# Run-complete
+"${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
+```
+
+Display:
+```
+Debug ${DEBUG_ID} complete.
+  Status: ${STATUS}
+  Iterations: ${ITER}
+  Files changed: ${FILES}
+  Log: ${DEBUG_DIR}/DEBUG-LOG.md
+
+Next:
+  - If RESOLVED: continue normal pipeline (/vg:next or specific command)
+  - If ESCALATED: review /vg:amend output + decide on scope change
+  - If ABANDONED: re-run /vg:debug "<refined description>" with more context
+```
+</step>
+
+</process>
+
+<success_criteria>
+- Bug description parsed + classified
+- Discovery completed (matching bug type)
+- At least 1 fix iteration attempted
+- User confirmed status via AskUserQuestion (fixed / retry / more)
+- DEBUG-LOG.md written with full trace
+- 5 telemetry events emitted (parsed, classified, fix_attempted, user_confirmed, completed)
+- Atomic commits per fix (rollback-safe)
+- Spec gap → auto-routed to /vg:amend (if detected)
+</success_criteria>

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -5808,6 +5808,26 @@ if [ "$COMP_RC" -ne 0 ] && [ "$COMP_SEV" = "block" ]; then
   exit 1
 fi
 
+# v2.45 fail-closed-validators PR: matrix↔runtime evidence cross-check.
+# Phase 3.2 dogfood found GOAL-COVERAGE-MATRIX.md fabricating READY status
+# even when goal_sequences[].result == "blocked" or sequence missing entirely.
+# This validator catches the fabrication BEFORE review exits, so /vg:test
+# never sees a lying matrix.
+MATRIX_LINK_VAL=".claude/scripts/validators/verify-matrix-evidence-link.py"
+if [ -f "$MATRIX_LINK_VAL" ]; then
+  ${PYTHON_BIN:-python3} "$MATRIX_LINK_VAL" --phase-dir "$PHASE_DIR" --severity block
+  MATRIX_LINK_RC=$?
+  if [ "$MATRIX_LINK_RC" -ne 0 ]; then
+    echo "⛔ Review matrix-evidence-link gate failed."
+    echo "   GOAL-COVERAGE-MATRIX.md asserts goal status that runtime evidence does not support."
+    echo "   Fix path:"
+    echo "     1. Re-run /vg:review ${PHASE_NUMBER} --retry-failed (record real sequences)"
+    echo "     2. OR reclassify goals to UNREACHABLE/INFRA_PENDING/DEFERRED with justification"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.matrix_evidence_link_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
 RUN_RC=$?
 if [ $RUN_RC -ne 0 ]; then

--- a/commands/vg/roam.md
+++ b/commands/vg/roam.md
@@ -61,12 +61,13 @@ runtime_contract:
 
 <rules>
 1. **Run AFTER /vg:test confirmed PASS.** Roam is a janitor, not a primary verifier. Failed-review or failed-test phases skip roam (no point exploring broken app).
-2. **Executor CLI logs only — never judges.** All bug classification happens in step 5 (commander analysis). HARD rule embedded in every CLI brief.
+2. **Executor CLI logs only — never judges.** All bug classification happens in step 5 (commander analysis). HARD rule embedded in every CLI brief. **Conformance contract:** every brief MUST inject `vg:_shared:scanner-report-contract` (banned vocab + report schema). Briefs without the contract block REJECTED at compose time.
 3. **Lens auto-pick by phase profile + entity types** (Q9 default). Manual override via `--lens=`.
 4. **Spec auto-merge is staged** (Q10): roam writes proposed-specs/ but does NOT merge into test suite without `--merge-specs` confirmation.
 5. **Cost guards**: hard cap 50 surfaces × 1 CLI default. Soft cap $10/session via `roam.max_cost_usd` config. Pre-spawn estimator warns + asks confirm if soft cap exceeded.
 6. **Council mode default OFF** (Q8). Enable via `--council` for ship-critical phases.
 7. **Security lens skipped by default** (Q13). `/vg:review` Phase 2.5 owns security probes. Enable via `--include-security` for double-coverage.
+8. **Vocabulary validator** (v2.42.7+): post-aggregate step (4_aggregate_logs) runs grep on observe-*.jsonl for banned tokens (`bug`, `broken`, `critical`, `should fix`, etc — full list in scanner-report-contract.md). Hits → tag report `vocabulary_violation: true`, commander deprioritizes during step 5 analysis but still consumes (partial signal > no signal).
 </rules>
 
 <step name="0_parse_and_validate">
@@ -956,6 +957,31 @@ done
 EVENT_COUNT=$(wc -l < "${ROAM_DIR}/RAW-LOG.jsonl" 2>/dev/null | tr -d ' ' || echo 0)
 EXEC_COUNT=$(find "${ROAM_MODEL_DIRS[@]}" -maxdepth 1 -name "observe-*.jsonl" 2>/dev/null | wc -l | tr -d ' ')
 echo "▸ Aggregated ${EVENT_COUNT} events from ${EXEC_COUNT} executor output(s) across ${#ROAM_MODEL_DIRS[@]} model dir(s)"
+
+# v2.42.9+ — Evidence completeness validator (HARD gate per scanner-report-contract)
+# Rejects observations missing required tier fields. Output tagged for commander.
+echo ""
+echo "▸ Evidence completeness check (rule: REQUIRED fields per tier — empty/null OK, missing = reject)"
+COMPLIANCE_OUT="${ROAM_DIR}/evidence-compliance.json"
+for MODEL_DIR in "${ROAM_MODEL_DIRS[@]}"; do
+  "${PYTHON_BIN:-python3}" .claude/scripts/verify-scanner-evidence-completeness.py \
+    --jsonl-glob "${MODEL_DIR}/observe-*.jsonl" \
+    --lens-from-filename \
+    --threshold "${ROAM_EVIDENCE_THRESHOLD:-80}" \
+    --output "${COMPLIANCE_OUT}" 2>&1 | tail -10
+  COMPL_RC=$?
+  if [ $COMPL_RC -eq 1 ]; then
+    echo "⛔ Evidence completeness BLOCK — see ${COMPLIANCE_OUT}"
+    if [[ ! "${ARGUMENTS}" =~ --skip-evidence-completeness ]]; then
+      echo "   Override (NOT recommended): /vg:roam ${PHASE_NUMBER} --skip-evidence-completeness"
+      echo "   Recommended: re-run scanner — it produced too many incomplete observations."
+      exit 1
+    fi
+    echo "⚠ --skip-evidence-completeness set — proceeding with partial evidence"
+  elif [ $COMPL_RC -eq 2 ]; then
+    echo "⚠ Evidence completeness WARN — partial coverage, commander will deprioritize"
+  fi
+done
 
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER}" "4_aggregate_logs" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/4_aggregate_logs.done"
 ```

--- a/scripts/roam-compose-brief.py
+++ b/scripts/roam-compose-brief.py
@@ -24,6 +24,10 @@ from pathlib import Path
 
 HARD_RULES = """## ⛔ HARD RULES (enforced — break = output rejected)
 
+**Conformance contract:** `vg:_shared:scanner-report-contract` (skill).
+You are a SCANNER. You DISCOVER and REPORT. The COMMANDER (Opus) ADJUDICATES.
+Severity, verdicts, prescriptions = commander's job.
+
 1. You DO NOT judge whether anything is a bug. Just log facts.
 2. You DO NOT skip any RCRURD step, even if previous step seemed to fail.
 3. You DO NOT stop early on errors. Log the error, continue to next step.
@@ -37,6 +41,128 @@ HARD_RULES = """## ⛔ HARD RULES (enforced — break = output rejected)
    Do NOT redact, summarize, or truncate. PII redaction happens commander-side.
 9. If a step's preconditions are not met, log a `precondition-missing` event
    and SKIP only that step's mutation; continue with the rest of RCRURD.
+
+## ⛔ BANNED VOCABULARY (case-insensitive scan rejects output)
+
+These words are JUDGMENTS, not OBSERVATIONS. Replace with factual descriptions:
+
+| BANNED | Use instead |
+|---|---|
+| `bug`, `broken`, `wrong`, `incorrect` | `expected X per lens, observed Y` |
+| `fail`, `failed`, `failure` (in description text) | `match: no` (structured field only) |
+| `critical`, `major`, `minor`, `severe` | OMIT — commander assigns severity |
+| `should`, `must`, `need to`, `needs` | report observation, omit prescription |
+| `fix`, `repair`, `patch` | OMIT — commander prescribes action |
+| `correct`, `correctly`, `properly` | `expected_per_lens: X` vs `observed: Y` |
+| `obviously`, `clearly`, `apparently` | drop the qualifier; state observation |
+
+## ✓ ALLOWED schema fields
+
+- `step`, `expected_per_lens`, `observed`, `match` (yes|no|partial|unknown)
+- `evidence`: organized into Tiers A-G per scanner-report-contract Section 2.5
+- `anomalies[]` — patterns noticed, factual description, no severity
+- `blockers[]` — { step, reason, evidence } when scanner cannot continue
+- `queries[]` — { step, question, scanner_proposal } when scanner needs commander input
+
+## Evidence Tier capture rules (v2.42.8+)
+
+Capture per tier per step. Empty arrays/null = facts ("we tried, found nothing"). Helper JS: `.claude/scripts/scanner-evidence-capture.js`.
+
+### Tier A — Always-on (every step)
+
+Required on every observation:
+- `network_requests[]` from MCP `browser_network_requests`
+- `console_errors[]`, `console_warnings[]` from MCP `browser_console_messages`
+- `dom_changed`, `url_before`, `url_after`, `elapsed_ms`
+- `screenshot` from MCP `browser_take_screenshot` after step
+- **`page_title`** = `document.title` via `browser_evaluate("() => document.title")`
+- **`toast`** via `captureToast` snippet — toast/notification visible after action
+- **`http_status_summary`** = `summarizeHttpStatus(network_requests)` (pure JS, no eval)
+
+### Tier B — Form/CRUD (lens-form-lifecycle, lens-business-coherence, lens-table-interaction, lens-duplicate-submit)
+
+Capture before+after each form interaction:
+- `form_validation_errors` via `captureFormValidationErrors` snippet
+- `submit_button_state` via `captureSubmitButtonState`
+- `loading_indicator` via `captureLoadingIndicator`
+- `row_count_before/after` via `captureRowCount` (target list selector)
+- `field_value_before/after` via `captureFieldValue` (per relevant field)
+- `db_read_after_write`: post-mutation, fetch the resource via `captureBackgroundJobStatus(get_url)` or direct GET; record status + body match
+- `idempotency_replay`: re-submit with same Idempotency-Key, record second_call_status + response_id_matches
+
+### Tier C — Auth/Session/Security (lens-csrf, lens-idor, lens-bfla, lens-auth-jwt, lens-tenant-boundary, lens-info-disclosure)
+
+Capture on auth-sensitive steps:
+- `cookies_filtered` via `captureCookiesFiltered` (names only)
+- `auth_state` via `captureAuthStateHeuristic`
+- `request_security_headers` = `inspectRequestSecurityHeaders(request)` per relevant request
+- `response_security_headers` = `inspectResponseSecurityHeaders(response)` per relevant response
+
+### Tier D — Realtime (lens-business-coherence with WS, opt-in)
+
+Only if `window.__vg_ws_log` instrumented:
+- `websocket_frames` via `captureWebSocketFrames`
+- `polling_calls` from network_requests (filter URL pattern matching polling endpoint, group by interval)
+- `background_job_status` via fetch /admin/jobs/dlq or equivalent
+
+### Tier E — Visual/A11y (lens-modal-state, visual lens, opt-in for table)
+
+Capture per major UI state change:
+- `viewport_size` (capture once at session start, re-capture on resize)
+- `focus_state` via `captureFocusState`
+- `aria_state` via `captureAriaState(selector)` for interactive elements
+- `tab_order` via `captureTabOrder` (first 30 focusable)
+- `a11y_tree_excerpt` from MCP `browser_snapshot` (trimmed)
+
+### Tier F — Storage/State (lens-business-coherence deep, lens-info-disclosure, lens-auth-jwt)
+
+Keys ONLY, never values:
+- `storage_keys` via `captureStorageKeys`
+- `indexedDB_dbs` via `captureIndexedDBs`
+- `store_snapshot` via `captureStoreSnapshot('__VG_STORE__')` if exposed
+
+### Tier G — Mobile (only when MODE=mobile, replaces A-E)
+
+Per Maestro:
+- `hierarchy_diff` from before/after hierarchy.json
+- `screenshot_diff_pct` from image diff
+- `deep_link_resolved`, `tap_target_size_px`, `keyboard_avoidance`, `network_offline_recovery`
+
+## Per-lens default tiers
+
+The brief composer (Python script roam-compose-brief.py) injects tier list per lens:
+
+| Lens | Default tiers | Rationale |
+|---|---|---|
+| `lens-form-lifecycle` | A + B | Form CRUD coverage |
+| `lens-business-coherence` | A + B + F | UI/network/storage 3-way coherence |
+| `lens-table-interaction` | A + B (row+field deltas) | List view URL state + pagination |
+| `lens-duplicate-submit` | A + B (idempotency_replay) | Race + dup |
+| `lens-csrf` | A + C | Token presence + cookie flags |
+| `lens-idor` / `lens-bfla` / `lens-tenant-boundary` | A + C + (B if mutation) | Auth boundary + write paths |
+| `lens-auth-jwt` | A + C + F | Token storage + headers + expiry |
+| `lens-modal-state` | A + E | Focus trap + dismissal |
+| `lens-info-disclosure` | A + C + F | Headers + storage keys |
+| `lens-input-injection` | A + (C if auth-bypass) | Reflection patterns |
+| `lens-file-upload` | A + B + (C if auth) | Mutation + size limits |
+| `lens-business-logic` | A + B (state machine) | State-machine bypass |
+| `lens-mass-assignment` | A + B + C | Privileged-field append |
+| `lens-open-redirect` / `lens-path-traversal` / `lens-ssrf` | A + C | Network header inspection |
+
+## Example — ACCEPTABLE event
+
+```json
+{"surface":"S03","step":"click submit","expected_per_lens":"POST /api/sites + 201 + redirect","observed":"5s elapsed, button enabled, URL unchanged","match":"no","evidence":{"network_requests":[],"console_errors":["TypeError at validate.ts:42"],"dom_changed":false,"elapsed_ms":5042},"timestamp":"<ISO>"}
+```
+
+## Example — UNACCEPTABLE event (will be rejected)
+
+```json
+{"surface":"S03","step":"click submit","observed":"submit BROKEN — critical bug, needs FIX","match":"failed","severity":"critical","recommendation":"fix validate.ts"}
+```
+
+Reasons: `BROKEN`/`critical`/`needs FIX` banned; `failed` not in match enum;
+`severity` field is commander's job; `recommendation` is prescription.
 """
 
 
@@ -52,6 +178,168 @@ def select_lenses_for_surface(crud: str, entity: str, manual_csv: str | None) ->
     if "R" in crud:
         lenses.append("lens-table-interaction")
     return lenses or ["lens-business-coherence"]
+
+
+# Per-lens evidence tier defaults (scanner-report-contract Section 2.7).
+# Each lens declares which tiers (A/B/C/D/E/F) capture-snippets must run on
+# every observation. Tier G is mobile-only and dispatched via MODE=mobile,
+# not lens config.
+LENS_TIER_DEFAULTS = {
+    "lens-form-lifecycle":      ["A", "B"],
+    "lens-business-coherence":  ["A", "B", "F"],
+    "lens-table-interaction":   ["A", "B"],
+    "lens-duplicate-submit":    ["A", "B"],
+    "lens-csrf":                ["A", "C"],
+    "lens-idor":                ["A", "C", "B"],
+    "lens-bfla":                ["A", "C", "B"],
+    "lens-tenant-boundary":     ["A", "C", "B"],
+    "lens-auth-jwt":            ["A", "C", "F"],
+    "lens-modal-state":         ["A", "E"],
+    "lens-info-disclosure":     ["A", "C", "F"],
+    "lens-input-injection":     ["A", "C"],
+    "lens-file-upload":         ["A", "B", "C"],
+    "lens-business-logic":      ["A", "B"],
+    "lens-mass-assignment":     ["A", "B", "C"],
+    "lens-open-redirect":       ["A", "C"],
+    "lens-path-traversal":      ["A", "C"],
+    "lens-ssrf":                ["A", "C"],
+    "lens-authz-negative":      ["A", "C"],
+}
+
+
+# Required field list per tier — validator post-write rejects observations
+# missing any of these. Empty/null is OK (= fact). MISSING field = rejection.
+TIER_REQUIRED_FIELDS = {
+    "A": ["network_requests", "console_errors", "console_warnings", "dom_changed",
+          "url_before", "url_after", "elapsed_ms", "screenshot", "page_title",
+          "toast", "http_status_summary"],
+    "B": ["form_validation_errors", "submit_button_state", "loading_indicator",
+          "row_count_before", "row_count_after", "field_value_before",
+          "field_value_after"],
+    "C": ["cookies_filtered", "auth_state", "request_security_headers",
+          "response_security_headers"],
+    "D": ["websocket_frames", "polling_calls", "background_job_status"],
+    "E": ["viewport_size", "focus_state", "aria_state", "tab_order",
+          "a11y_tree_excerpt"],
+    "F": ["storage_keys", "indexedDB_dbs", "store_snapshot"],
+}
+
+
+# Per-tier capture instruction text (injected into brief verbatim).
+# v2.42.9+ — wording is HARD-ENFORCED. Validator rejects obs missing fields.
+TIER_CAPTURE_INSTRUCTIONS = {
+    "A": """### Tier A — Always-on (REQUIRED on EVERY observation)
+
+⛔ MISSING any field below = observation REJECTED by post-write validator
+   (verify-scanner-evidence-completeness.py). Empty array `[]` and `null` are
+   FACTS — emit explicitly. Just OMITTING a field = NOT acceptable.
+
+REQUIRED FIELDS (you MUST emit ALL of these in `evidence: { ... }`):
+1. `network_requests` (array, can be []) — MCP `browser_network_requests`
+2. `console_errors` (array, can be []) — MCP `browser_console_messages` filtered to errors
+3. `console_warnings` (array, can be []) — MCP `browser_console_messages` filtered to warnings
+4. `dom_changed` (boolean) — DOM hash diff before/after action
+5. `url_before` (string) — URL before action
+6. `url_after` (string) — URL after action (may equal url_before — that's a fact)
+7. `elapsed_ms` (number) — Date.now() diff before/after action
+8. `screenshot` (string|null) — relative path from `browser_take_screenshot`
+9. `page_title` (string) — `browser_evaluate("() => document.title")`
+10. `toast` (object) — `browser_evaluate(captureToast)` → `{ visible, count, items: [{text, type}] }`. Toast not visible? Emit `{ visible: false, count: 0, items: [] }`.
+11. `http_status_summary` (object) — pure JS: `summarizeHttpStatus(network_requests)` → `{ "2xx": N, "3xx": N, "4xx": N, "5xx": N, cors_blocked: N, aborted: N }`. Zero requests? All counts = 0.
+
+Helper file: `.claude/scripts/scanner-evidence-capture.js` (read once, reuse snippets).
+""",
+    "B": """### Tier B — Form/CRUD (REQUIRED when step touches form/list/mutation)
+
+⛔ MISSING any field below = observation REJECTED by validator.
+   Use snippets from `.claude/scripts/scanner-evidence-capture.js`.
+
+REQUIRED FIELDS for any form/list step:
+1. `form_validation_errors` — `browser_evaluate(captureFormValidationErrors)` → `{ count, items: [{field, message, source}] }`. No errors? `{ count: 0, items: [] }`.
+2. `submit_button_state` — `browser_evaluate(captureSubmitButtonState)` → `{ found, text, disabled, busy }`. Element absent? `{ found: false }`.
+3. `loading_indicator` — `browser_evaluate(captureLoadingIndicator)` → `{ present, selector?, bbox? }`. None? `{ present: false }`.
+4. `row_count_before` (number) — `captureRowCount` BEFORE action.
+5. `row_count_after` (number) — `captureRowCount` AFTER action.
+6. `field_value_before` (object|null) — `captureFieldValue(name)` BEFORE for each relevant field. Multiple fields? Emit array.
+7. `field_value_after` (object|null) — `captureFieldValue(name)` AFTER.
+
+CONDITIONAL FIELDS (emit when applicable):
+- `db_read_after_write` — for mutations, follow-up GET to verify persistence. Emit `{ method, url, status, body_match: yes|no|partial }`.
+- `idempotency_replay` — for endpoints with Idempotency-Key, re-submit, emit `{ second_call_status, response_id_matches: yes|no|unknown }`.
+
+Compute `row_count_delta` (after - before) and `field_value_delta` BEFORE merging.
+""",
+    "C": """### Tier C — Auth/Session/Security (REQUIRED on auth-sensitive steps)
+
+⛔ MISSING any field = observation REJECTED.
+
+REQUIRED FIELDS on login, role-switch, mutation requiring privilege, cross-tenant probe:
+1. `cookies_filtered` — `browser_evaluate(captureCookiesFiltered)` → `{ document_cookie_count, names: [...] }`. NAMES ONLY, NEVER values.
+2. `auth_state` — `browser_evaluate(captureAuthStateHeuristic)` → `{ authenticated, signal }`.
+3. `request_security_headers` — pure JS `inspectRequestSecurityHeaders(req)` per relevant request → `{ has_authorization, has_csrf_token, has_idempotency_key, has_if_match, has_origin, has_referer, custom_headers }`. No security request? Emit `null` (= "no auth-sensitive request in this step").
+4. `response_security_headers` — pure JS `inspectResponseSecurityHeaders(resp)` → `{ has_set_cookie, set_cookie_flags, has_csp, has_x_frame_options, has_strict_transport_security }`.
+""",
+    "D": """### Tier D — Realtime (REQUIRED when lens declares D, even if instrumentation absent)
+
+⛔ MISSING any field = observation REJECTED.
+
+REQUIRED FIELDS:
+1. `websocket_frames` — `browser_evaluate(captureWebSocketFrames)` → `{ instrumented: bool, count, frames }`. App not instrumented? `{ instrumented: false, count: 0, frames: [] }` — explicit fact.
+2. `polling_calls` — filter `network_requests` by URL pattern from config `scanner_evidence.realtime.polling_url_patterns`, group by interval. No polling? `[]`.
+3. `background_job_status` — fetch /admin/jobs/dlq or equivalent → `{ status, queue_summary }`. Endpoint absent? `null`.
+""",
+    "E": """### Tier E — Visual/A11y (REQUIRED on major UI state change)
+
+⛔ MISSING any field = observation REJECTED.
+
+REQUIRED FIELDS on page load / modal open / route change:
+1. `viewport_size` — `{ width, height }` from `browser_resize` or initial snapshot.
+2. `focus_state` — `browser_evaluate(captureFocusState)` → `{ focused, tag, id?, name?, role?, label }`.
+3. `aria_state` — `browser_evaluate(captureAriaState(selector))` for interactive elements relevant to lens. Single relevant element? Emit one object. Multiple? Array. None? `null`.
+4. `tab_order` — `browser_evaluate(captureTabOrder)` → array of first 30 focusable elements.
+5. `a11y_tree_excerpt` — string from MCP `browser_snapshot` output (trim per `config.scanner_evidence.a11y.snapshot_max_lines`).
+""",
+    "F": """### Tier F — Storage/Client State (REQUIRED when lens declares F)
+
+⛔ MISSING any field = observation REJECTED.
+
+REQUIRED FIELDS — KEYS ONLY, NEVER VALUES (PII/token risk, validator rejects values):
+1. `storage_keys` — `browser_evaluate(captureStorageKeys)` → `{ localStorage_keys: [...], sessionStorage_keys: [...], count: { local, session } }`. Empty? `[]` arrays + `0` counts.
+2. `indexedDB_dbs` — `browser_evaluate(captureIndexedDBs)` → `{ supported, dbs: [{name, version}] }`. Browser doesn't support? `{ supported: false, dbs: [] }`.
+3. `store_snapshot` — `browser_evaluate(captureStoreSnapshot('__VG_STORE__'))` → `{ exposed, key, top_level_keys: [...] }`. Not exposed by app? `{ exposed: false, key: '__VG_STORE__' }`.
+""",
+}
+
+
+def render_tier_instructions(lens: str) -> str:
+    """Render evidence-tier capture block for a specific lens.
+
+    v2.42.9+ — wording is HARD-ENFORCED. Validator
+    verify-scanner-evidence-completeness.py rejects observations missing
+    any required field per declared tiers.
+    """
+    tiers = LENS_TIER_DEFAULTS.get(lens, ["A"])
+    required_fields = []
+    for t in tiers:
+        required_fields.extend(TIER_REQUIRED_FIELDS.get(t, []))
+
+    parts = [
+        f"## ⛔ EVIDENCE CAPTURE CONTRACT — HARD ENFORCED (this lens: {' + '.join(tiers)})\n",
+        "Per scanner-report-contract Section 2.5 + 2.7. **Validator rejects observations missing any required field.** Empty/null is a FACT — emit explicitly. Just OMITTING a field = REJECTED.\n",
+        "**Helper file:** `.claude/scripts/scanner-evidence-capture.js` (21 snippets — read once, reuse).\n",
+        f"**Total required fields per observation: {len(required_fields)}**\n",
+    ]
+    for t in tiers:
+        if t in TIER_CAPTURE_INSTRUCTIONS:
+            parts.append(TIER_CAPTURE_INSTRUCTIONS[t])
+    skipped = sorted(set("ABCDEF") - set(tiers))
+    parts.append(f"**Tiers NOT captured by this lens:** {skipped} — fields from these tiers MUST NOT appear in observation. If you accidentally capture them, omit silently.\n")
+    parts.append("---\n")
+    parts.append("### Pre-merge self-check (run before emitting each observation)\n")
+    parts.append(f"Confirm `evidence` object has ALL {len(required_fields)} keys:\n")
+    parts.append("```\n" + "\n".join(f"- {f}" for f in required_fields) + "\n```\n")
+    parts.append("Missing key? Add `<key>: null` (= 'we tried, value unavailable'). Then emit.\n")
+    return "\n".join(parts)
 
 
 def parse_surfaces_md(path: Path) -> list[dict]:
@@ -238,6 +526,10 @@ def main() -> int:
   `surface`, `step`, `ui_before` / `ui_after`, `network`, `console_errors`, `timestamp`.
 
 {login_section}
+
+{render_tier_instructions(lens)}
+
+---
 
 ## Lens-specific protocol
 

--- a/scripts/scanner-evidence-capture.js
+++ b/scripts/scanner-evidence-capture.js
@@ -1,0 +1,409 @@
+/**
+ * scanner-evidence-capture.js — JS snippets scanners paste into browser_evaluate
+ *
+ * Single source of truth for evidence capture per scanner-report-contract Tier A-F.
+ * Scanners (Haiku, CLI executors) reference this file by name, copy specific
+ * function bodies into browser_evaluate(...) calls. Keeping all snippets in one
+ * place means selector tweaks propagate to every scanner without per-skill edit.
+ *
+ * Usage pattern in scanner workflow:
+ *   1. Read this file
+ *   2. Pick snippet matching the tier you need (e.g., captureToast)
+ *   3. Pass snippet body to MCP browser_evaluate({ function: <body> })
+ *   4. Merge returned data into observation.evidence.<key>
+ *
+ * Selectors come from vg.config.md `scanner_evidence:` block. Defaults below
+ * are fallbacks for projects without explicit config.
+ */
+
+// ============================================================================
+// TIER A — Always-on (every UI step)
+// ============================================================================
+
+/**
+ * Capture toast notification visible on page.
+ * Returns: { visible: boolean, type: "success"|"error"|"info"|"unknown", text: string, count: number }
+ *
+ * Selector strategy:
+ *   1. config.scanner_evidence.toast.selectors[] (project-specific)
+ *   2. Common library selectors (Sonner, react-hot-toast, Shadcn, MUI, Mantine, Chakra)
+ *
+ * Add new library? Append to TOAST_SELECTORS below + open issue.
+ */
+const TOAST_SELECTORS = [
+  '[data-sonner-toast]',                          // Sonner
+  '[role="status"][aria-live]',                   // ARIA standard (most libs)
+  '.Toastify__toast',                             // react-toastify
+  '[data-state="open"][role="alert"]',            // Radix / Shadcn Toast
+  '.toast--visible',                              // Bootstrap-like
+  '.notification, .ant-notification-notice',      // antd
+  '.MuiSnackbar-root, .MuiAlert-root',            // MUI
+  '[class*="toast" i]:not(:empty)',               // generic catch-all (last)
+];
+
+const captureToast = `
+async () => {
+  const sels = ${JSON.stringify(TOAST_SELECTORS)};
+  const found = [];
+  for (const sel of sels) {
+    document.querySelectorAll(sel).forEach(el => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) return;        // hidden
+      const txt = (el.innerText || el.textContent || '').trim().slice(0, 200);
+      if (!txt) return;
+      // Type heuristic: class/data-attr keywords
+      const cls = (el.className || '') + ' ' + (el.dataset?.type || '') + ' ' + (el.getAttribute('aria-label') || '');
+      let type = 'unknown';
+      if (/error|danger|fail/i.test(cls)) type = 'error';
+      else if (/success|ok|done/i.test(cls)) type = 'success';
+      else if (/warn|warning/i.test(cls)) type = 'warning';
+      else if (/info|notice/i.test(cls)) type = 'info';
+      found.push({ selector: sel, text: txt, type });
+    });
+  }
+  // Dedupe by text
+  const seen = new Set();
+  const unique = found.filter(f => !seen.has(f.text) && seen.add(f.text));
+  return { visible: unique.length > 0, count: unique.length, items: unique };
+}
+`;
+
+const capturePageTitle = `() => ({ title: document.title, url: location.href })`;
+
+/**
+ * HTTP status summary — counts by class. Pair with browser_network_requests.
+ * Caller passes the network array, not browser eval.
+ */
+function summarizeHttpStatus(networkRequests) {
+  const buckets = { '2xx': 0, '3xx': 0, '4xx': 0, '5xx': 0, 'cors_blocked': 0, 'aborted': 0 };
+  for (const r of networkRequests || []) {
+    const s = r.status;
+    if (typeof s !== 'number') {
+      if (r.errorText && /CORS/i.test(r.errorText)) buckets.cors_blocked++;
+      else if (r.errorText && /abort/i.test(r.errorText)) buckets.aborted++;
+      continue;
+    }
+    if (s >= 200 && s < 300) buckets['2xx']++;
+    else if (s >= 300 && s < 400) buckets['3xx']++;
+    else if (s >= 400 && s < 500) buckets['4xx']++;
+    else if (s >= 500) buckets['5xx']++;
+  }
+  return buckets;
+}
+
+// ============================================================================
+// TIER B — Form / CRUD lifecycle
+// ============================================================================
+
+const captureFormValidationErrors = `
+() => {
+  const errors = [];
+  // ARIA validation
+  document.querySelectorAll('[aria-invalid="true"]').forEach(el => {
+    errors.push({
+      field: el.name || el.id || el.getAttribute('aria-labelledby') || 'unnamed',
+      message: el.getAttribute('aria-errormessage')
+        ? document.getElementById(el.getAttribute('aria-errormessage'))?.innerText?.trim()
+        : null,
+      source: 'aria-invalid',
+    });
+  });
+  // Visible role=alert
+  document.querySelectorAll('[role="alert"]:not([hidden])').forEach(el => {
+    const txt = (el.innerText || '').trim().slice(0, 200);
+    if (txt && !errors.some(e => e.message === txt)) {
+      errors.push({ field: null, message: txt, source: 'role=alert' });
+    }
+  });
+  // Native :invalid (form input constraint)
+  document.querySelectorAll('input:invalid, textarea:invalid, select:invalid').forEach(el => {
+    errors.push({
+      field: el.name || el.id || 'unnamed',
+      message: el.validationMessage || null,
+      source: 'native-invalid',
+    });
+  });
+  return { count: errors.length, items: errors };
+}
+`;
+
+const captureSubmitButtonState = `
+(selectorOrNull) => {
+  const sel = selectorOrNull || 'button[type="submit"], [data-action="submit"], button.submit';
+  const btn = document.querySelector(sel);
+  if (!btn) return { found: false };
+  return {
+    found: true,
+    text: (btn.innerText || btn.value || '').trim(),
+    disabled: btn.disabled || btn.getAttribute('aria-disabled') === 'true',
+    busy: btn.getAttribute('aria-busy') === 'true' || /loading|busy/i.test(btn.className),
+    bbox: btn.getBoundingClientRect(),
+  };
+}
+`;
+
+const captureLoadingIndicator = `
+() => {
+  const sels = [
+    '[role="progressbar"]:not([hidden])',
+    '[aria-busy="true"]',
+    '.spinner:not([hidden]), .loader:not([hidden])',
+    '[class*="loading" i]:not(:empty)',
+    '[data-loading="true"]',
+  ];
+  for (const sel of sels) {
+    const el = document.querySelector(sel);
+    if (el) {
+      const r = el.getBoundingClientRect();
+      if (r.width > 0 && r.height > 0) {
+        return { present: true, selector: sel, bbox: { x: r.x, y: r.y, w: r.width, h: r.height } };
+      }
+    }
+  }
+  return { present: false };
+}
+`;
+
+const captureRowCount = `
+(tableSelectorOrNull) => {
+  const sel = tableSelectorOrNull || 'table tbody tr, [role="grid"] [role="row"], [data-list-row]';
+  return { count: document.querySelectorAll(sel).length, selector: sel };
+}
+`;
+
+const captureFieldValue = `
+(fieldName) => {
+  const el = document.querySelector('[name="' + fieldName + '"]')
+          || document.querySelector('#' + fieldName)
+          || document.querySelector('[data-field="' + fieldName + '"]');
+  if (!el) return { found: false };
+  let value = '';
+  if (el.tagName === 'SELECT') {
+    value = el.value;
+  } else if (el.type === 'checkbox' || el.type === 'radio') {
+    value = el.checked;
+  } else {
+    value = el.value !== undefined ? el.value : (el.innerText || '').trim();
+  }
+  return { found: true, value, type: el.type || el.tagName.toLowerCase() };
+}
+`;
+
+// ============================================================================
+// TIER C — Auth / Session / Security
+// ============================================================================
+
+/**
+ * Capture cookies metadata only (no values — secure/httponly cookies aren't
+ * accessible via document.cookie anyway, but for non-httponly we still strip
+ * values to avoid logging session tokens).
+ */
+const captureCookiesFiltered = `
+() => {
+  const raw = document.cookie || '';
+  const items = raw.split('; ').filter(Boolean).map(p => {
+    const [name] = p.split('=');
+    return { name: name.trim(), accessible_via_js: true /* implies !httponly */ };
+  });
+  return { document_cookie_count: items.length, names: items.map(i => i.name) };
+}
+`;
+
+const captureAuthStateHeuristic = `
+(authSelectorsCsv) => {
+  const sels = (authSelectorsCsv || '[data-user-menu], .user-avatar, [data-testid="user-menu"], [aria-label*="account" i]').split(',').map(s => s.trim());
+  for (const sel of sels) {
+    if (document.querySelector(sel)) return { authenticated: true, signal: sel };
+  }
+  // Fallback: check for /login URL
+  if (location.pathname.includes('/login')) return { authenticated: false, signal: 'url_contains_login' };
+  return { authenticated: 'unknown', signal: null };
+}
+`;
+
+/**
+ * Inspect outgoing request headers for security tokens.
+ * Caller passes the captured request from browser_network_requests.
+ */
+function inspectRequestSecurityHeaders(request) {
+  const h = (request.headers || {});
+  const lower = Object.fromEntries(Object.entries(h).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    has_authorization: !!lower['authorization'],
+    has_csrf_token: !!(lower['x-csrf-token'] || lower['x-xsrf-token'] || lower['csrf-token']),
+    has_idempotency_key: !!lower['idempotency-key'],
+    has_if_match: !!lower['if-match'],
+    has_origin: !!lower['origin'],
+    has_referer: !!lower['referer'],
+    custom_headers: Object.keys(lower).filter(k => k.startsWith('x-') && !['x-csrf-token', 'x-xsrf-token'].includes(k)),
+  };
+}
+
+function inspectResponseSecurityHeaders(response) {
+  const h = (response.headers || {});
+  const lower = Object.fromEntries(Object.entries(h).map(([k, v]) => [k.toLowerCase(), v]));
+  const setCookies = lower['set-cookie'] ? (Array.isArray(lower['set-cookie']) ? lower['set-cookie'] : [lower['set-cookie']]) : [];
+  return {
+    has_set_cookie: setCookies.length > 0,
+    set_cookie_flags: setCookies.map(sc => ({
+      has_httponly: /HttpOnly/i.test(sc),
+      has_secure: /Secure/i.test(sc),
+      same_site: (sc.match(/SameSite=([^;]+)/i) || [, null])[1],
+    })),
+    has_csp: !!lower['content-security-policy'],
+    has_x_frame_options: !!lower['x-frame-options'],
+    has_strict_transport_security: !!lower['strict-transport-security'],
+  };
+}
+
+// ============================================================================
+// TIER D — Realtime / Async
+// ============================================================================
+
+/**
+ * WebSocket frame log. Requires app to install instrumentation:
+ *   window.__vg_ws_log = [];
+ *   const _send = WebSocket.prototype.send;
+ *   WebSocket.prototype.send = function(d) { window.__vg_ws_log.push({dir:'out', data: String(d).slice(0,200), t: Date.now()}); return _send.apply(this, arguments); };
+ *   ... mirror for onmessage
+ *
+ * Without instrumentation, this snippet returns { instrumented: false }.
+ */
+const captureWebSocketFrames = `
+() => {
+  if (!Array.isArray(window.__vg_ws_log)) {
+    return { instrumented: false, frames: [], note: 'install instrumentation per scanner-evidence-capture.js' };
+  }
+  const frames = window.__vg_ws_log.slice();
+  return { instrumented: true, count: frames.length, frames };
+}
+`;
+
+const captureBackgroundJobStatus = `
+async (apiUrl) => {
+  if (!apiUrl) return { skipped: true };
+  try {
+    const r = await fetch(apiUrl, { credentials: 'include' });
+    const j = await r.json().catch(() => null);
+    return { status: r.status, queue_summary: j };
+  } catch (e) { return { error: String(e) }; }
+}
+`;
+
+// ============================================================================
+// TIER E — Visual / A11y
+// ============================================================================
+
+const captureFocusState = `
+() => {
+  const ae = document.activeElement;
+  if (!ae || ae === document.body) return { focused: 'body_or_none' };
+  return {
+    focused: true,
+    tag: ae.tagName,
+    id: ae.id || null,
+    name: ae.getAttribute('name') || null,
+    role: ae.getAttribute('role') || null,
+    label: (ae.getAttribute('aria-label') || '').slice(0, 100),
+  };
+}
+`;
+
+const captureAriaState = `
+(selector) => {
+  const el = document.querySelector(selector);
+  if (!el) return { found: false };
+  const aria = {};
+  for (const attr of el.attributes) {
+    if (attr.name.startsWith('aria-') || attr.name === 'role') aria[attr.name] = attr.value;
+  }
+  return { found: true, attributes: aria };
+}
+`;
+
+const captureTabOrder = `
+() => {
+  const focusable = document.querySelectorAll(
+    'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  );
+  return Array.from(focusable).slice(0, 30).map(el => ({
+    tag: el.tagName,
+    label: (el.innerText || el.value || el.getAttribute('aria-label') || '').trim().slice(0, 60),
+    tabindex: el.tabIndex,
+  }));
+}
+`;
+
+// ============================================================================
+// TIER F — Storage / Client State
+// ============================================================================
+
+/**
+ * Storage keys ONLY — never values (PII / token risk).
+ */
+const captureStorageKeys = `
+() => ({
+  localStorage_keys: Object.keys(localStorage),
+  sessionStorage_keys: Object.keys(sessionStorage),
+  count: { local: localStorage.length, session: sessionStorage.length },
+})
+`;
+
+const captureIndexedDBs = `
+async () => {
+  if (!indexedDB.databases) return { supported: false };
+  const dbs = await indexedDB.databases();
+  return { supported: true, dbs: dbs.map(d => ({ name: d.name, version: d.version })) };
+}
+`;
+
+const captureStoreSnapshot = `
+(storeWindowKey) => {
+  const k = storeWindowKey || '__VG_STORE__';
+  const store = window[k];
+  if (!store) return { exposed: false, key: k };
+  // Whitelist top-level keys only (avoid PII dump). Caller can deep-read specific paths if needed.
+  if (typeof store.getState === 'function') {
+    const state = store.getState();
+    return { exposed: true, key: k, top_level_keys: Object.keys(state || {}) };
+  }
+  return { exposed: true, key: k, top_level_keys: Object.keys(store || {}) };
+}
+`;
+
+// ============================================================================
+// Export — Node.js style for orchestrator scripts to read snippets
+// ============================================================================
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    // Tier A
+    captureToast,
+    capturePageTitle,
+    summarizeHttpStatus,                  // pure JS function, run on captured network
+    // Tier B
+    captureFormValidationErrors,
+    captureSubmitButtonState,
+    captureLoadingIndicator,
+    captureRowCount,
+    captureFieldValue,
+    // Tier C
+    captureCookiesFiltered,
+    captureAuthStateHeuristic,
+    inspectRequestSecurityHeaders,        // pure JS function
+    inspectResponseSecurityHeaders,       // pure JS function
+    // Tier D
+    captureWebSocketFrames,
+    captureBackgroundJobStatus,
+    // Tier E
+    captureFocusState,
+    captureAriaState,
+    captureTabOrder,
+    // Tier F
+    captureStorageKeys,
+    captureIndexedDBs,
+    captureStoreSnapshot,
+    // Selectors (exposed for scanners to merge with project config)
+    TOAST_SELECTORS,
+  };
+}

--- a/scripts/verify-scanner-evidence-completeness.py
+++ b/scripts/verify-scanner-evidence-completeness.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""verify-scanner-evidence-completeness.py — post-write evidence completeness gate.
+
+Reads scanner output (scan-*.json or observe-*.jsonl) per scanner-report-contract
+Section 2.5/2.7. For each observation, verifies required tier fields are
+present (empty/null OK; MISSING NOT OK).
+
+Output: writes per-file compliance.json + exits 0 (PASS) / 1 (BLOCK) / 2 (WARN).
+
+Usage:
+  # Roam mode — JSONL aggregation
+  python3 verify-scanner-evidence-completeness.py \\
+      --jsonl-glob ".vg/phases/03.5-*/roam/codex/observe-*.jsonl" \\
+      --lens-from-filename \\
+      --output .vg/phases/03.5-*/roam/.evidence-compliance.json
+
+  # Review mode — per-view JSON
+  python3 verify-scanner-evidence-completeness.py \\
+      --json-glob ".vg/phases/03.5-*/scan-*.json" \\
+      --tiers A,B,E \\
+      --output .vg/phases/03.5-*/.evidence-compliance.json
+
+Exit codes:
+  0 — all observations >= compliance_threshold (default 80%)
+  1 — at least one observation has 0 required fields → hard reject
+  2 — partial compliance, below threshold but non-zero → warn
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from pathlib import Path
+
+# Mirror of LENS_TIER_DEFAULTS in roam-compose-brief.py.
+# Single source: keep these in sync.
+LENS_TIER_DEFAULTS = {
+    "lens-form-lifecycle":      ["A", "B"],
+    "lens-business-coherence":  ["A", "B", "F"],
+    "lens-table-interaction":   ["A", "B"],
+    "lens-duplicate-submit":    ["A", "B"],
+    "lens-csrf":                ["A", "C"],
+    "lens-idor":                ["A", "C", "B"],
+    "lens-bfla":                ["A", "C", "B"],
+    "lens-tenant-boundary":     ["A", "C", "B"],
+    "lens-auth-jwt":            ["A", "C", "F"],
+    "lens-modal-state":         ["A", "E"],
+    "lens-info-disclosure":     ["A", "C", "F"],
+    "lens-input-injection":     ["A", "C"],
+    "lens-file-upload":         ["A", "B", "C"],
+    "lens-business-logic":      ["A", "B"],
+    "lens-mass-assignment":     ["A", "B", "C"],
+    "lens-open-redirect":       ["A", "C"],
+    "lens-path-traversal":      ["A", "C"],
+    "lens-ssrf":                ["A", "C"],
+    "lens-authz-negative":      ["A", "C"],
+}
+
+TIER_REQUIRED_FIELDS = {
+    "A": ["network_requests", "console_errors", "console_warnings", "dom_changed",
+          "url_before", "url_after", "elapsed_ms", "screenshot", "page_title",
+          "toast", "http_status_summary"],
+    "B": ["form_validation_errors", "submit_button_state", "loading_indicator",
+          "row_count_before", "row_count_after", "field_value_before",
+          "field_value_after"],
+    "C": ["cookies_filtered", "auth_state", "request_security_headers",
+          "response_security_headers"],
+    "D": ["websocket_frames", "polling_calls", "background_job_status"],
+    "E": ["viewport_size", "focus_state", "aria_state", "tab_order",
+          "a11y_tree_excerpt"],
+    "F": ["storage_keys", "indexedDB_dbs", "store_snapshot"],
+}
+
+
+def required_for_tiers(tiers: list[str]) -> list[str]:
+    out = []
+    for t in tiers:
+        out.extend(TIER_REQUIRED_FIELDS.get(t, []))
+    return out
+
+
+def lens_from_filename(path: Path) -> str | None:
+    """observe-S03-lens-form-lifecycle.jsonl → 'lens-form-lifecycle'."""
+    m = re.search(r"(lens-[a-z-]+)", path.stem)
+    return m.group(1) if m else None
+
+
+def check_observation(obs: dict, required: list[str]) -> dict:
+    """Per-observation compliance. Returns {present, missing, total, pct}."""
+    evidence = obs.get("evidence") or {}
+    if not isinstance(evidence, dict):
+        return {"present": [], "missing": required, "total": len(required), "pct": 0,
+                "_error": "evidence not an object"}
+    missing = [k for k in required if k not in evidence]
+    present = [k for k in required if k in evidence]
+    pct = round(100 * len(present) / len(required), 1) if required else 100.0
+    return {"present": present, "missing": missing, "total": len(required), "pct": pct}
+
+
+def banned_word_check(text: str) -> list[str]:
+    """Mirror of scanner-report-contract Section 1 banned vocabulary scan."""
+    banned = ["bug", "broken", "wrong", "incorrect", "fail", "failed", "failure",
+              "critical", "major", "minor", "severe", "should", "must", "need to",
+              "needs", "fix", "repair", "patch", "obviously", "clearly", "apparently"]
+    text_lower = text.lower()
+    hits = []
+    for w in banned:
+        # word-boundary match
+        if re.search(r"\b" + re.escape(w) + r"\b", text_lower):
+            hits.append(w)
+    return sorted(set(hits))
+
+
+def process_jsonl(path: Path, lens: str) -> dict:
+    """Process a JSONL file (roam mode). Each line is an event."""
+    tiers = LENS_TIER_DEFAULTS.get(lens, ["A"])
+    required = required_for_tiers(tiers)
+    observations = []
+    wrapper_seen = False
+    completion_seen = False
+    for ln, raw in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            ev = json.loads(raw)
+        except Exception:
+            observations.append({"line": ln, "_error": "invalid JSON"})
+            continue
+        kind = ev.get("_kind")
+        if kind == "observation" or (kind is None and "step" in ev and "match" in ev):
+            obs_check = check_observation(ev, required)
+            obs_check["line"] = ln
+            # Banned-word scan on observed + step text
+            text_blob = " ".join(str(ev.get(k, "")) for k in ("step", "observed", "expected_per_lens"))
+            banned = banned_word_check(text_blob)
+            if banned:
+                obs_check["banned_words"] = banned
+            observations.append(obs_check)
+        elif "_observations_follow" in ev:
+            wrapper_seen = True
+        elif kind == "completion" or ev.get("step") == "complete":
+            completion_seen = True
+
+    if not observations:
+        return {
+            "file": str(path),
+            "lens": lens,
+            "tiers": tiers,
+            "required_fields": required,
+            "observation_count": 0,
+            "compliance_pct": 0,
+            "verdict": "BLOCK",
+            "reason": "no observations parsed",
+            "wrapper_seen": wrapper_seen,
+            "completion_seen": completion_seen,
+        }
+
+    # Aggregate compliance
+    avg_pct = round(sum(o.get("pct", 0) for o in observations) / len(observations), 1)
+    any_zero = any(o.get("pct", 0) == 0 for o in observations)
+    banned_total = sum(len(o.get("banned_words", [])) for o in observations)
+
+    return {
+        "file": str(path),
+        "lens": lens,
+        "tiers": tiers,
+        "required_fields_count": len(required),
+        "observation_count": len(observations),
+        "compliance_pct_avg": avg_pct,
+        "any_zero_compliance": any_zero,
+        "banned_word_hits_total": banned_total,
+        "wrapper_seen": wrapper_seen,
+        "completion_seen": completion_seen,
+        "observations": observations[:50],  # cap output size
+    }
+
+
+def process_json(path: Path, tiers: list[str]) -> dict:
+    """Process a single JSON file (review mode — vg-haiku-scanner output)."""
+    required = required_for_tiers(tiers)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return {"file": str(path), "verdict": "BLOCK", "reason": f"parse error: {e}"}
+
+    obs_list = data.get("observations") or data.get("results") or []
+    if not isinstance(obs_list, list) or not obs_list:
+        return {
+            "file": str(path),
+            "tiers": tiers,
+            "verdict": "WARN",
+            "reason": "no observations array (legacy schema?)",
+            "observation_count": 0,
+        }
+
+    checked = []
+    for i, obs in enumerate(obs_list):
+        if not isinstance(obs, dict):
+            checked.append({"index": i, "_error": "not an object"})
+            continue
+        c = check_observation(obs, required)
+        c["index"] = i
+        text_blob = " ".join(str(obs.get(k, "")) for k in ("step", "observed", "action", "outcome"))
+        banned = banned_word_check(text_blob)
+        if banned:
+            c["banned_words"] = banned
+        checked.append(c)
+
+    avg_pct = round(sum(c.get("pct", 0) for c in checked) / len(checked), 1)
+    any_zero = any(c.get("pct", 0) == 0 for c in checked)
+    banned_total = sum(len(c.get("banned_words", [])) for c in checked)
+
+    return {
+        "file": str(path),
+        "tiers": tiers,
+        "required_fields_count": len(required),
+        "observation_count": len(obs_list),
+        "compliance_pct_avg": avg_pct,
+        "any_zero_compliance": any_zero,
+        "banned_word_hits_total": banned_total,
+        "observations_sample": checked[:50],
+    }
+
+
+def verdict_for(report: dict, threshold: float) -> str:
+    """Map compliance to PASS/WARN/BLOCK."""
+    if report.get("any_zero_compliance"):
+        return "BLOCK"
+    pct = report.get("compliance_pct_avg", 0)
+    if pct >= threshold:
+        return "PASS"
+    if pct >= 50:
+        return "WARN"
+    return "BLOCK"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--jsonl-glob", help="Glob for roam observe-*.jsonl files")
+    ap.add_argument("--json-glob", help="Glob for review scan-*.json files")
+    ap.add_argument("--tiers", default="A", help="Comma-separated tier list for --json-glob (default A)")
+    ap.add_argument("--lens-from-filename", action="store_true",
+                    help="For --jsonl-glob, derive lens from filename (observe-X-lens-Y.jsonl)")
+    ap.add_argument("--lens", help="Force lens for all --jsonl-glob files")
+    ap.add_argument("--threshold", type=float, default=80.0,
+                    help="PASS threshold % (default 80)")
+    ap.add_argument("--output", help="Write report JSON to this path")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    reports = []
+    if args.jsonl_glob:
+        for p in sorted(glob.glob(args.jsonl_glob)):
+            path = Path(p)
+            lens = args.lens or (lens_from_filename(path) if args.lens_from_filename else None)
+            if not lens:
+                reports.append({"file": p, "verdict": "BLOCK",
+                                "reason": "lens not specified — pass --lens or --lens-from-filename"})
+                continue
+            r = process_jsonl(path, lens)
+            r["verdict"] = verdict_for(r, args.threshold)
+            reports.append(r)
+
+    if args.json_glob:
+        tiers = [t.strip() for t in args.tiers.split(",") if t.strip()]
+        for p in sorted(glob.glob(args.json_glob)):
+            r = process_json(Path(p), tiers)
+            r["verdict"] = verdict_for(r, args.threshold)
+            reports.append(r)
+
+    if not reports:
+        if not args.quiet:
+            print("No files matched", file=sys.stderr)
+        return 0
+
+    overall_summary = {
+        "report_count": len(reports),
+        "by_verdict": {},
+        "threshold_pct": args.threshold,
+        "reports": reports,
+    }
+    for r in reports:
+        v = r.get("verdict", "UNKNOWN")
+        overall_summary["by_verdict"][v] = overall_summary["by_verdict"].get(v, 0) + 1
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(overall_summary, indent=2))
+
+    if not args.quiet:
+        print(f"Scanner evidence completeness:")
+        print(f"  Files checked: {len(reports)}")
+        for v, count in sorted(overall_summary["by_verdict"].items()):
+            print(f"    {v}: {count}")
+        # Show worst offenders
+        bad = [r for r in reports if r.get("verdict") in ("BLOCK", "WARN")]
+        if bad:
+            print(f"  Issues:")
+            for r in bad[:10]:
+                pct = r.get("compliance_pct_avg", 0)
+                miss = r.get("any_zero_compliance", False)
+                banned = r.get("banned_word_hits_total", 0)
+                print(f"    [{r['verdict']}] {r['file']} — compliance={pct}% any_zero={miss} banned={banned}")
+
+    # Exit code
+    if any(r.get("verdict") == "BLOCK" for r in reports):
+        return 1
+    if any(r.get("verdict") == "WARN" for r in reports):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/vg-haiku-scanner/SKILL.md
+++ b/skills/vg-haiku-scanner/SKILL.md
@@ -8,6 +8,62 @@ user-invocable: false
 
 You are a scanner agent spawned by `/vg:review`. Your ONLY job: exhaustively scan ONE view and write results to disk.
 
+## ⛔ Conformance contract: scanner-report-contract
+
+This skill produces output consumed by the COMMANDER (Opus running /vg:review Phase 4). You are a SCANNER — you OBSERVE and REPORT. Severity, verdicts, prescriptions are commander's job, NOT yours.
+
+Read: `vg:_shared:scanner-report-contract` (skill). Key rules inlined below.
+
+### Banned vocabulary (case-insensitive — output rejected if present)
+
+| BANNED | Use instead |
+|---|---|
+| `bug`, `broken`, `wrong`, `incorrect` | `expected X, observed Y` |
+| `critical`, `major`, `minor`, `severe` | OMIT — commander assigns severity |
+| `should`, `must`, `need to`, `needs` | drop prescription, log fact only |
+| `fix`, `repair`, `patch` | OMIT — commander prescribes action |
+| `obviously`, `clearly`, `apparently` | drop qualifier; state observation directly |
+
+### Allowed match enum
+
+Use ONLY: `yes` | `no` | `partial` | `unknown`. NOT `failed`, `passed`, `error`.
+
+### Schema discipline
+
+- `match: no` is fine (factual: observation differed from expected_per_lens).
+- DO NOT add `severity:` field to error/issue entries. Commander assigns severity post-adjudication.
+- `errors[]` array in legacy schema below has been deprecated for severity field — emit `match: no` + put diagnostic facts in `evidence.console_errors` / `evidence.network_requests` instead.
+
+**Migration note:** older versions of this skill had `errors[].severity` ("high"/"critical") in output. v2.42.7+ removes severity from scanner output. Commander reads `match: no` + evidence + cross-references TEST-GOALS to assign severity.
+
+## Evidence Tier System (v2.42.8+)
+
+Per scanner-report-contract Section 2.5, evidence fields organized into tiers. This skill captures **Tier A + B + E by default**, with C / F opt-in based on goal context.
+
+| Tier | Default | Capture instructions |
+|---|---|---|
+| **A** Always | ✓ | Already captured by browser MCP automatic context: `screenshot`, `network_requests`, `console_errors`, `dom_changed`, `url_*`, `elapsed_ms`. PLUS new fields: `page_title` (`document.title`), `toast` (query toast selectors per `.claude/scripts/scanner-evidence-capture.js > captureToast`), `http_status_summary` (run `summarizeHttpStatus(network_requests)` after each step). |
+| **B** Form/CRUD | ✓ when step has form/list mutation | Run `captureFormValidationErrors`, `captureSubmitButtonState`, `captureLoadingIndicator`, `captureRowCount`, `captureFieldValue` from helper before+after submit. For mutations: do `db_read_after_write` follow-up GET to verify persistence (replaces old persistence_probe). |
+| **C** Security | When goal touches auth/role/RBAC | `captureCookiesFiltered` (names only, NO values), `captureAuthStateHeuristic`, run `inspectRequestSecurityHeaders` + `inspectResponseSecurityHeaders` on captured network_requests. |
+| **D** Realtime | Skip (instrumentation required app-side) | If `window.__vg_ws_log` exists, `captureWebSocketFrames`. Otherwise return `null`. |
+| **E** Visual/A11y | ✓ on major UI state change | `captureFocusState`, `captureAriaState` (per relevant element), `captureTabOrder`. `viewport_size` from page snapshot. `a11y_tree_excerpt` from MCP `browser_snapshot` output (trimmed). |
+| **F** Storage | When goal involves state persistence | `captureStorageKeys` (keys only, NEVER values — PII/token risk), `captureIndexedDBs`, `captureStoreSnapshot('__VG_STORE__')` if exposed. |
+| **G** Mobile | Only when MODE=mobile | Replaces A-E. Use Maestro hierarchy diff + screenshot diff per scanner-report-contract Section 2.5. |
+
+**Capture flow per step** (within STEP 4 element interaction):
+```
+1. Pre-action snapshot (Tier A always; Tier B if form; Tier E if focus-relevant)
+2. Perform action (click/fill/etc)
+3. Wait for stable (network idle OR 5s timeout)
+4. Post-action capture (same tiers as pre)
+5. Compute deltas (row_count_delta, field_value_delta) before merging into observation
+6. Set match: yes|no|partial|unknown based on expected_per_lens vs observed
+```
+
+**Helper file:** `.claude/scripts/scanner-evidence-capture.js` exports JS snippets for each `captureXxx`. Pass to MCP `browser_evaluate({function: <snippet>})`. Some functions are pure JS (run on captured network array, no eval): `summarizeHttpStatus`, `inspectRequestSecurityHeaders`, `inspectResponseSecurityHeaders`.
+
+**Empty fields = facts:** if a tier's capture returns nothing (e.g., no toast visible), emit the field with empty/null value. Empty IS a fact. Omitting confuses commander into thinking scanner didn't try.
+
 ## Arguments (injected by orchestrator)
 
 ### Common (both modes)
@@ -270,14 +326,14 @@ Only `refresh + re-read + diff` detects ghost save.
 | C. Refresh | `browser_evaluate("() => location.reload()")` OR navigate away (sidebar link) + back. Wait network idle + first meaningful paint (≤3s). | `refresh_method: "reload"\|"navigate_cycle"` |
 | D. Re-open + re-read | If edit flow: click same row → open edit modal → read same field values. If create flow: re-read row count + search for new entity name. | `post: [{field: "role", value: "admin"}, {row_count: 16}]` |
 | E. Diff | Compare pre vs post: mutated field MUST differ on edit (old → new value), row count MUST increase on create, MUST decrease on delete. | `persisted: true\|false, mutated_fields: ["role"], diff_reason?: "..."` |
-| F. Verdict | If diff expected but not present → record as **ghost_save** bug (severity: CRITICAL). Add to `errors[]` with `{type: "persistence", severity: "critical", form_trigger: "e1 → modal Edit User", expected_change: "role: editor → admin", actual: "role unchanged after refresh"}`. | (bug in errors[], persisted=false) |
+| F. Persistence observation | If diff expected but not present → record `match: no` for this persistence step. Add to `observations[]` with `{step: "persistence_check", expected_per_lens: "role: editor → admin", observed: "role unchanged after refresh", match: "no", evidence: { form_trigger: "e1 → modal Edit User", refresh_method: "reload", pre: {role: "editor"}, post: {role: "editor"} }}`. NO severity, NO `bug` label — commander adjudicates. | (`match: no`, persisted=false) |
 
 **Exception — when Persistence Probe CAN skip:**
 - Read-only forms (no mutation) — detect via absence of submit button or `method="get"`
 - Multi-step wizards — probe only on FINAL step (intermediate steps save draft, may not persist across refresh)
 - File upload forms — record `persistence_probe.skipped: "file_upload_progressive"` — manual verify
 
-**Refresh-safe session:** Scanner auth cookie/token MUST survive `page.reload()`. If reload kicks back to login → bug in auth persistence → record as `errors[{type: "auth", severity: "high", message: "refresh logged out"}]` + skip further persistence probes for this view.
+**Refresh-safe session:** Scanner auth cookie/token MUST survive `page.reload()`. If reload kicks back to login → record observation `{step: "session_persistence", expected_per_lens: "session survives reload", observed: "redirected to /login after reload", match: "no", evidence: { redirect_url: "/login", elapsed_ms: <ms> }}` + skip further persistence probes for this view. NO severity assignment — commander adjudicates.
 
 ### STEP 5: Write Output
 
@@ -349,9 +405,10 @@ optional fields — no breaking change for web.
   "disabled_elements": [ { "ref": "e30", "name": "Bulk Delete", "enable_attempted": true, "enabled_after": true } ],
   "sub_views_discovered": ["/sites/456"],
   "errors": [
-    {"type": "console", "message": "Warning: key prop missing", "severity": "warning"},
-    {"type": "network", "url": "/api/sites/456", "status": 500, "severity": "error"}
+    {"type": "console", "message": "Warning: key prop missing"},
+    {"type": "network", "url": "/api/sites/456", "status": 500}
   ],
+  "_errors_note": "Legacy field — kept for back-compat. NO `severity` field per scanner-report-contract. Commander reads status code + message + cross-refs TEST-GOALS to assign severity post-adjudication.",
   "stuck": [ { "ref": "e30", "name": "Upload CSV", "reason": "file_input", "needs": "file path" } ]
 }
 ```

--- a/templates/vg/vg.config.template.md
+++ b/templates/vg/vg.config.template.md
@@ -341,6 +341,71 @@ review:
     escalate_on_critical_domain: true   # touches critical_goal_domains → always escalate
     max_iterations: 3                   # max fix iterations before giving up (3-strike rule)
 
+# === Scanner evidence config (v2.42.8+) ========================
+# Per scanner-report-contract.md (vg:_shared:scanner-report-contract).
+# Project-specific selectors for evidence capture by Haiku scanners,
+# roam workers, /vg:debug discovery agent. Defaults apply if unset.
+#
+# Helper file: .claude/scripts/scanner-evidence-capture.js (21 snippets)
+scanner_evidence:
+  # ─── Tier A — Toast detection ─────────────────────────────────────────
+  # Selectors used by captureToast to detect toast/notification banners.
+  # Scanner picks first match. Defaults cover Sonner, react-hot-toast,
+  # react-toastify, Radix, Shadcn, antd, MUI. Add project-specific
+  # selectors here (highest priority — overrides library defaults).
+  toast:
+    selectors: []
+      # - "[data-testid=app-toast]"
+      # - ".my-toast-container > div"
+
+  # ─── Tier B — Form / row count selectors ─────────────────────────────
+  form:
+    submit_button_selector: "button[type=submit], [data-action=submit]"
+    list_row_selectors:
+      - "table tbody tr"
+      - "[role=grid] [role=row]"
+      - "[data-list-row]"
+
+  # ─── Tier C — Auth state heuristic ───────────────────────────────────
+  # Selectors that, if present, indicate authenticated session.
+  # captureAuthStateHeuristic checks each in order.
+  auth:
+    user_menu_selectors:
+      - "[data-user-menu]"
+      - "[data-testid=user-menu]"
+      - ".user-avatar"
+      - "[aria-label*=account i]"
+    login_url_pattern: "/login"
+
+  # ─── Tier D — Realtime instrumentation key ───────────────────────────
+  realtime:
+    ws_log_window_key: "__vg_ws_log"     # window.<key> = [] for app to populate
+    polling_url_patterns:                # endpoints scanner treats as polling
+      - "/api/v1/me/notifications/unread-count"
+      - "/api/v1/health"
+
+  # ─── Tier E — A11y limits ────────────────────────────────────────────
+  a11y:
+    snapshot_max_lines: 100              # trim browser_snapshot to N lines
+    tab_order_max: 30                    # capture first N focusable
+
+  # ─── Tier F — Storage / store snapshot ───────────────────────────────
+  storage:
+    store_window_key: "__VG_STORE__"     # Zustand/Redux dev-exposed store key
+    storage_keys_only: true              # MUST stay true — never log values
+
+  # ─── Per-platform tier defaults ──────────────────────────────────────
+  platform:
+    web:
+      tier_default: "A,B,E"              # Haiku scanner default
+      tier_optin: "C,F"                  # via lens config
+    mobile:
+      tier_default: "A,G"                # Maestro
+      tier_optin: "E"
+    api_only:
+      tier_default: "A,C"                # curl scanner
+      tier_optin: ""
+
 # === Design System (v1.10.0 R4 — NEW) ==========================
 # Integrates getdesign.md ecosystem DESIGN.md (58 brand variants: Stripe,
 # Linear, Vercel, Apple, Ferrari, BMW, Claude, Cursor, ...).


### PR DESCRIPTION
## Summary

4 commits adding scanner evidence framework to /vg:roam + /vg:review + new /vg:debug skill.

| # | Commit | What |
|---|---|---|
| 1 | feat(vg): /vg:debug | Lightweight bug-fix loop alternative to /vg:review (3-5 min vs 15-30 min). Natural language input → auto-classify (static/runtime_ui/network/infra/spec_gap) → fix loop with AskUserQuestion (fixed/retry/more-info). Spec gap → auto /vg:amend. |
| 2 | feat(vg): scanner-report-contract + Tier A-G | Codifies discover-only principle: scanners (CLI/Haiku) report observations only, NEVER verdicts/severity/prescriptions. NEW \`commands/vg/_shared/scanner-report-contract.md\` (8 sections: banned vocab, JSON schema with 30+ fields, Tier A-G capability matrix, per-lens defaults). Updates roam.md + vg-haiku-scanner SKILL.md. |
| 3 | feat(vg): scanner-evidence-capture.js helper | NEW \`scripts/scanner-evidence-capture.js\` (~410 LOC, 21 snippets). Single source of truth for browser_evaluate snippets per Tier A-F (toast detection across Sonner/MUI/antd/etc., form validation, security headers, storage keys-only). \`vg.config.template.md\` adds \`scanner_evidence:\` config block for project overrides. |
| 4 | feat(vg): ÉP enforcement (HARD gate) | User feedback during dogfood: contract was too soft ("Capture..." → scanner could silently skip). Wording tightened to "⛔ MISSING field = REJECTED". Brief composer injects numbered REQUIRED FIELDS list per lens (e.g., form-lifecycle scanner sees 18 required fields + pre-merge self-check). NEW \`scripts/verify-scanner-evidence-completeness.py\` validator runs post-write in roam aggregator + review post-2b-2; rejects observations missing required fields or containing banned words. |

## Why this matters

Scanner agents (Codex CLI, Gemini Flash, Claude Haiku) drift toward verdict-poisoned outputs (\"BUG\", \"CRITICAL\", \"needs fix\") which corrupts commander adjudication. Pre-contract: no enforcement, scanners silently skip evidence fields like toast/db_read_after_write. Result: commander makes decisions on partial data.

**Evidence gap example before:**
- Scanner reports \`network_requests: []\` (= empty, fact)
- Scanner OMITS \`toast\` field entirely
- Commander assumes scanner didn't check toast → uncertainty cascades

**After:**
- Validator rejects observation if \`toast\` field missing
- Scanner MUST emit \`toast: { visible: false, count: 0, items: [] }\` (explicit fact)
- Commander has 100% certainty about what was checked

## Tier system at a glance

| Tier | Coverage | Capture cost |
|---|---|---|
| A | Always-on (toast, page_title, http_status_summary, network, console) | ~0ms (passive + 1 eval) |
| B | Form/CRUD (validation, submit state, db read-after-write, row delta, idempotency replay) | +50-200ms |
| C | Auth/Security (cookies names, auth state, request/response security headers) | +20-50ms |
| D | Realtime (websocket frames, polling, background jobs) | passive but instrumented |
| E | Visual/A11y (focus, aria, tab order, a11y tree) | +200-500ms |
| F | Storage/State (storage keys, indexedDB names, store snapshot keys) | +30-100ms |
| G | Mobile (Maestro hierarchy/screenshot diff, deep link, tap target) | +500ms-2s |

Per-lens default tiers in \`scanner-report-contract.md\` Section 2.7 (16 lenses mapped). \`vg.config.template.md\` allows project override per platform (web/mobile/api_only).

## Privacy

- Cookie names ONLY (no values)
- Storage keys ONLY (no values — PII/token risk)
- Security headers presence + flags ONLY (no raw token values)
- Empty arrays explicit (\`[]\`/\`null\` = fact); MISSING field rejected by validator

## Test plan

- [ ] Validator self-test: synthetic observation 8/18 fields + 3 banned words → BLOCK exit 1 ✓ (verified during dogfood)
- [ ] /vg:roam workflow: end-to-end with form-lifecycle lens; confirm post-aggregate validator runs + tags compliance
- [ ] /vg:review workflow: end-to-end Phase 2b-2 → 2c-evidence gate → 2d RUNTIME-MAP; confirm validator blocks incomplete scans
- [ ] /vg:debug skill: invoke with crash description, verify classify → fix → loop AskUserQuestion
- [ ] Banned vocab regression: re-run an old phase's roam, ensure validator flags pre-contract reports as \`vocabulary_violation\`

## Migration

- 3 skill files cached at session start: scanner-report-contract, vg-haiku-scanner, /vg:debug. Restart session to pick up.
- Python validator + JS helper take effect immediately (not cached).
- Old \`scan-*.json\` files with \`errors[].severity\` field still readable (back-compat note in skill body).

## Stats

- 9 files changed, +2,081 / −5 lines
- 4 atomic commits (rollback-safe per logical unit)
- No backward-incompatible breaks; old artifacts pass through with vocabulary-violation flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)