### PR TITLE
feat(blueprint): AI semantic UI scope detection (replaces grep heuristic)

### DIFF
--- a/commands/vg/blueprint.md
+++ b/commands/vg/blueprint.md
@@ -121,12 +121,23 @@ Sub-steps:
 **Config:** Read .claude/commands/vg/_shared/config-loader.md first.
 
 <step name="0_design_discovery">
-## Step 0 (Phase 20 D-12): Design discovery pre-flight
+## Step 0 (Phase 20 D-12 + v2.43.6 AI semantic detection): Design discovery pre-flight
 
 Before any planning work, verify FE phases have mockup ground truth.
 Without mockups, the entire L1-L6 stack from Phase 19 SKIPs via Form B
 and the executor ships AI-imagined UI (the L-002 anti-pattern this
 whole stack was built to prevent).
+
+**v2.43.6 — UI scope detection upgraded from grep heuristic to AI semantic.**
+Retro from a real BE-only sub-phase: SPECS line 5 ("Phase này CHỈ build backend
+APIs ... UI portal Ở Phase 6/7/8") was misclassified `has_ui=true` because
+keyword grep matched "UI" inside the EXCLUSION clause. Haiku 4.5 semantic
+analysis distinguishes scope-inclusion vs scope-exclusion ("UI deferred to
+Phase X"). Result is cached at `${PHASE_DIR}/.ui-scope.json` as authoritative
+ground truth consumed by:
+  - this step's scaffold/extract gating
+  - validators/verify-ui-scope-coherence.py (cross-checks PLAN.md FE-task count)
+  - downstream UI steps 2b6_ui_spec / 2b6b / 2b6c
 
 Blueprint owns this. It must not rely on the operator remembering a
 separate `/vg:design-scaffold` command. If the phase has UI:
@@ -146,6 +157,47 @@ elif [[ "$ARGUMENTS" =~ --skip-design-discovery ]]; then
   echo "⚠ --skip-design-discovery set — Form B 'no-asset:greenfield-explicit-skip' will trigger /vg:accept critical block"
 else
   mkdir -p "${PHASE_DIR}/.tmp"
+
+  # v2.43.6 — AI semantic UI scope detection (replaces grep heuristic)
+  UI_SCOPE_JSON="${PHASE_DIR}/.ui-scope.json"
+  AI_SCOPE_DETECT_ENABLED=$(vg_config_get ui_scope.ai_detect_enabled true 2>/dev/null || echo true)
+
+  if [ "$AI_SCOPE_DETECT_ENABLED" = "true" ] && { [ ! -f "$UI_SCOPE_JSON" ] || [[ "$ARGUMENTS" =~ --redetect-ui-scope ]]; }; then
+    echo "▸ Detecting UI scope via Haiku semantic analysis..."
+    DETECT_FLAGS=()
+    [[ "$ARGUMENTS" =~ --redetect-ui-scope ]] && DETECT_FLAGS+=( --force )
+    "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/preflight/detect-ui-scope.py" \
+      --phase-dir "${PHASE_DIR}" \
+      --output ".ui-scope.json" \
+      "${DETECT_FLAGS[@]}" >/dev/null 2>&1
+    UI_SCOPE_RC=$?
+
+    case "$UI_SCOPE_RC" in
+      0) echo "✓ UI scope auto-applied (confidence ≥ 0.8). See $UI_SCOPE_JSON" ;;
+      2)
+        echo "⚠ UI scope tie-break needed (confidence 0.5-0.8). Accept low-confidence result with debt log."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "blueprint.ui_scope_tie_break" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" 2>/dev/null || true
+        ;;
+      3)
+        echo "⛔ UI scope confidence < 0.5 — operator must answer 'Phase này có UI không?'"
+        echo "   Edit ${UI_SCOPE_JSON} manually (set has_ui + confidence + method=user-confirmed) or improve SPECS clarity then re-run with --redetect-ui-scope."
+        if [[ ! "$ARGUMENTS" =~ --override-reason ]]; then
+          exit 1
+        fi
+        ;;
+      *) echo "⚠ detect-ui-scope.py exit=${UI_SCOPE_RC} — falling back to legacy grep heuristic" ;;
+    esac
+  fi
+
+  # Read authoritative UI scope decision from .ui-scope.json (AI cache)
+  HAS_UI=""
+  if [ -f "$UI_SCOPE_JSON" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$UI_SCOPE_JSON")
+    UI_SCOPE_METHOD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('method','unknown'))" "$UI_SCOPE_JSON")
+    UI_SCOPE_DEFERRED=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('deferred_to') or 'none')" "$UI_SCOPE_JSON")
+    echo "  has_ui=${HAS_UI} (method=${UI_SCOPE_METHOD}, deferred_to=${UI_SCOPE_DEFERRED})"
+  fi
+
   BLUEPRINT_DESIGN_PREFLIGHT_JSON="${PHASE_DIR}/.tmp/blueprint-design-preflight.json"
   # v2.42.3 — forward --allow-shared-mockup-reuse from blueprint args.
   # Use this when phase legitimately reuses unchanged Phase 1 slugs
@@ -153,6 +205,8 @@ else
   # per-phase mockups otherwise (closes silent-pass gap on UI phases).
   PREFLIGHT_EXTRA=()
   [[ "$ARGUMENTS" =~ --allow-shared-mockup-reuse ]] && PREFLIGHT_EXTRA+=( --allow-shared-mockup-reuse )
+  # Legacy preflight still runs to import mockups + report needs_scaffold/needs_extract.
+  # We trust HAS_UI from .ui-scope.json (AI) over its keyword-grep field of the same name.
   "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/blueprint-design-preflight.py" \
     --phase-dir "${PHASE_DIR}" \
     --repo-root "${REPO_ROOT}" \
@@ -161,7 +215,11 @@ else
     --output "${BLUEPRINT_DESIGN_PREFLIGHT_JSON}" \
     "${PREFLIGHT_EXTRA[@]}" >/dev/null
 
-  HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+  # Fallback: if .ui-scope.json missing (AI detect disabled/unavailable), use legacy grep result.
+  if [ -z "${HAS_UI}" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+    echo "ℹ HAS_UI from legacy grep heuristic (.ui-scope.json not generated): ${HAS_UI}"
+  fi
   IMPORTED_COUNT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('imported_count',0))" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_SCAFFOLD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_scaffold') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_EXTRACT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_extract') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
@@ -3163,6 +3221,33 @@ if [ -x "$TS_VAL" ]; then
       if [[ ! "$ARGUMENTS" =~ --skip-task-schema ]]; then exit 1; fi
       ;;
     *) echo "ℹ P16 task-schema: $TS_V" ;;
+  esac
+fi
+
+# Gate E (v2.43.6): ui-scope-coherence — cross-check .ui-scope.json (AI semantic
+# detection from step 0_design_discovery) against PLAN.md FE-task count.
+# BLOCK on (a) has_ui=true + 0 FE tasks (silent UI gap, L-002 class) OR
+#         (b) has_ui=false + ≥1 FE task (scope leak into BE-only phase).
+US_VAL="${REPO_ROOT}/.claude/scripts/validators/verify-ui-scope-coherence.py"
+if [ -x "$US_VAL" ]; then
+  ${PYTHON_BIN} "$US_VAL" --phase "${PHASE_NUMBER}" \
+      > "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>&1 || true
+  US_V=$(${PYTHON_BIN} -c "import json,sys; print(json.load(open(sys.argv[1])).get('verdict','SKIP'))" \
+        "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>/dev/null)
+  case "$US_V" in
+    PASS|WARN) echo "✓ ui-scope-coherence: $US_V" ;;
+    BLOCK)
+      echo "⛔ ui-scope-coherence: BLOCK — see ${VG_TMP}/ui-scope-coherence.json" >&2
+      echo "   Mismatch between .ui-scope.json (AI scope decision) and PLAN.md FE-task count." >&2
+      echo "   Either re-plan to match scope, edit SPECS to match PLAN, or override:" >&2
+      echo "     --override-reason='<issue-id>' (logs OVERRIDE-DEBT, not recommended)" >&2
+      echo "     --skip-ui-scope-coherence (downgrade gate)" >&2
+      echo "     ${PYTHON_BIN} ${US_VAL} --phase ${PHASE_NUMBER} --allow-mismatch (downgrade BLOCK→WARN)" >&2
+      if [[ ! "$ARGUMENTS" =~ --override-reason ]] && [[ ! "$ARGUMENTS" =~ --skip-ui-scope-coherence ]]; then
+        exit 1
+      fi
+      ;;
+    *) echo "ℹ ui-scope-coherence: $US_V" ;;
   esac
 fi
 

--- a/scripts/preflight/detect-ui-scope.py
+++ b/scripts/preflight/detect-ui-scope.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""AI-driven UI scope detection for blueprint preflight (replaces grep heuristic).
+
+Spawns an isolated Haiku subagent (zero parent context) to read SPECS.md +
+CONTEXT.md and decide whether the phase has UI in scope. Output is cached to
+`{phase_dir}/.ui-scope.json` and consumed as authoritative ground truth by:
+
+  - blueprint.md step 0_design_discovery (gates 2b6_ui_spec / 2b6b / 2b6c)
+  - validators/verify-ui-scope-coherence.py (cross-check vs PLAN.md FE tasks)
+
+Why AI not grep:
+  Phase 4.3 example — SPECS line 5: "Phase này CHỈ build backend APIs...
+  UI portal Ở Phase 6/7/8". Keyword grep matches "UI" in the EXCLUSION
+  clause and falsely flags has_ui=true. AI semantic reading distinguishes
+  scope-inclusion ("phase này có UI") vs scope-exclusion ("UI deferred to
+  Phase X"). Same lesson L-002 motivated Phase 19 D-04 view decomposition.
+
+Confidence routing (matches goal-classifier.sh pattern):
+  - >= 0.8: auto-apply, write cache, exit 0
+  - 0.5-0.8: emit pending JSON for caller to spawn Haiku tie-break, exit 2
+  - < 0.5: emit pending JSON for caller to AskUserQuestion, exit 3
+
+Output JSON schema (.ui-scope.json):
+  {
+    "has_ui": bool,
+    "confidence": float (0.0..1.0),
+    "evidence": str (quoted phrase from SPECS/CONTEXT),
+    "deferred_to": str|null (e.g. "Phase 6"),
+    "ui_kinds": list[str] (e.g. ["dashboard","form","modal"]),
+    "model": str ("haiku-4.5" or fallback),
+    "detected_at": str (ISO8601 UTC),
+    "method": "ai-semantic" | "user-confirmed" | "fallback-grep"
+  }
+
+Usage:
+  python3 detect-ui-scope.py --phase-dir .vg/phases/04.3-... --output .ui-scope.json
+  python3 detect-ui-scope.py --phase-dir ... --force          # bypass cache
+  python3 detect-ui-scope.py --phase-dir ... --grep-fallback  # skip AI, use legacy grep
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+CLAUDE_CLI_TIMEOUT_S = 120
+
+PROMPT_TEMPLATE = """You are a phase scope analyzer. Read the SPECS and CONTEXT below and decide
+whether THIS phase ships user-facing UI code (web pages, mobile screens, admin
+dashboards, components) — OR — is backend-only / infra / data / tooling.
+
+CRITICAL distinction: many specs mention UI as EXCLUSION ("UI portal in Phase 6/7/8"
+or "KHÔNG làm trong phase này: UI portal"). That means UI is OUT of scope here.
+Similarly "consumed by Phase X" or "Phase X owns UI" means UI is downstream.
+
+You output ONLY a single-line JSON object. No prose, no code fence, no preamble.
+
+Schema:
+{{
+  "has_ui": true|false,
+  "confidence": 0.0-1.0,
+  "evidence": "<one-sentence quote or paraphrase from SPECS/CONTEXT supporting the decision>",
+  "deferred_to": "<Phase X>" or null,
+  "ui_kinds": ["dashboard","form","modal","table","wizard","sidebar"] or []
+}}
+
+Confidence guide:
+  0.9-1.0 — explicit clause "this phase has UI" or "this phase is backend-only / no UI"
+  0.7-0.9 — strong inference from actor list (merchant clicks form) or file paths (.tsx)
+  0.5-0.7 — mixed signals or short SPECS
+  0.0-0.5 — ambiguous, not enough evidence
+
+═════════════════════════════════════════════════════════════════════════
+SPECS.md
+═════════════════════════════════════════════════════════════════════════
+{specs}
+
+═════════════════════════════════════════════════════════════════════════
+CONTEXT.md (decisions excerpt)
+═════════════════════════════════════════════════════════════════════════
+{context}
+
+═════════════════════════════════════════════════════════════════════════
+
+Output the JSON object on a single line. Nothing else.
+"""
+
+
+def trim(text: str, max_lines: int = 200) -> str:
+    """Limit prompt context to keep token cost low + Haiku focused."""
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    head = lines[: max_lines * 2 // 3]
+    tail = lines[-(max_lines // 3):]
+    return "\n".join(head + ["", f"... [{len(lines) - max_lines} lines truncated] ...", ""] + tail)
+
+
+def parse_haiku_output(raw: str) -> dict | None:
+    """Extract single JSON object from Haiku stdout. Tolerate prose preamble."""
+    raw = raw.strip()
+    # Try whole output first
+    try:
+        return json.loads(raw)
+    except Exception:
+        pass
+    # Find first `{...}` block
+    m = re.search(r"\{[^{}]*\"has_ui\"[^{}]*\}", raw, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except Exception:
+            pass
+    # Fallback: try line-by-line
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("{") and "has_ui" in line:
+            try:
+                return json.loads(line)
+            except Exception:
+                continue
+    return None
+
+
+def grep_fallback(specs: str, context: str) -> dict:
+    """Legacy heuristic — only used when AI unavailable. Conservative.
+
+    Inclusion signals: actor list + file paths + UI verbs.
+    Exclusion signals: "Phase này CHỈ build backend", "UI portal ở Phase X",
+    "no UI", "API only".
+    """
+    text = (specs + "\n" + context).lower()
+
+    # Strong exclusions first
+    exclusion_patterns = [
+        r"\bui portal\b.*\bphase\b",
+        r"\bphase này chỉ build\b.*\bbackend\b",
+        r"\bbackend[- ]only\b",
+        r"\bno ui\b",
+        r"\bapi only\b",
+        r"\bui.*ở phase \d+\b",
+        r"\bdefer.*ui.*to phase\b",
+    ]
+    for pat in exclusion_patterns:
+        if re.search(pat, text, re.IGNORECASE):
+            return {
+                "has_ui": False,
+                "confidence": 0.7,
+                "evidence": f"grep matched exclusion pattern: {pat}",
+                "deferred_to": None,
+                "ui_kinds": [],
+            }
+
+    # Inclusion signals (count weighted)
+    score = 0
+    if re.search(r"\.tsx\b|\.jsx\b|\.vue\b|\.svelte\b", text):
+        score += 3
+    if re.search(r"\bapps/(admin|merchant|vendor|web)/", text):
+        score += 3
+    if re.search(r"\b(dashboard|form|modal|wizard|sidebar|topbar)\b", text):
+        score += 2
+    if re.search(r"\bgiao diện\b|\bmàn hình\b", text):
+        score += 2
+
+    has_ui = score >= 3
+    return {
+        "has_ui": has_ui,
+        "confidence": min(0.6, score / 10),  # cap fallback confidence at 0.6
+        "evidence": f"grep heuristic score={score}",
+        "deferred_to": None,
+        "ui_kinds": [],
+    }
+
+
+def invoke_haiku(specs: str, context: str) -> tuple[dict | None, str]:
+    """Invoke Haiku via `claude --model haiku -p`. Returns (parsed_json, raw_stdout)."""
+    prompt = PROMPT_TEMPLATE.format(
+        specs=trim(specs, 250),
+        context=trim(context, 200),
+    )
+
+    cmd = [
+        "claude",
+        "--model", HAIKU_MODEL,
+        "-p",
+        prompt,
+    ]
+
+    # CRITICAL: run subprocess from /tmp so VG Stop hook doesn't fire on exit
+    # (Stop hook lives in .claude/settings.json under project root and would
+    # intercept stdout to inject orchestrator verifier output otherwise).
+    # Using --bare instead would skip auth/keychain — fails in interactive setups.
+    import tempfile
+    sandbox_cwd = tempfile.gettempdir()
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CLAUDE_CLI_TIMEOUT_S,
+            cwd=sandbox_cwd,
+        )
+    except FileNotFoundError:
+        return None, "claude CLI not found in PATH"
+    except subprocess.TimeoutExpired:
+        return None, f"claude CLI timeout after {CLAUDE_CLI_TIMEOUT_S}s"
+    except Exception as e:
+        return None, f"claude CLI error: {e}"
+
+    if proc.returncode != 0:
+        return None, f"claude exit={proc.returncode} stderr={proc.stderr[:500]}"
+
+    parsed = parse_haiku_output(proc.stdout)
+    return parsed, proc.stdout
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--phase-dir", required=True, help="phase directory (contains SPECS.md, CONTEXT.md)")
+    p.add_argument("--output", default=".ui-scope.json", help="output JSON path (relative to phase-dir)")
+    p.add_argument("--force", action="store_true", help="bypass cache, re-detect")
+    p.add_argument("--grep-fallback", action="store_true", help="skip AI, use legacy grep heuristic")
+    p.add_argument("--quiet", action="store_true", help="suppress narrative; emit only JSON to stdout")
+    args = p.parse_args()
+
+    phase_dir = Path(args.phase_dir).resolve()
+    out_path = phase_dir / args.output
+
+    if not phase_dir.is_dir():
+        print(f"⛔ phase dir not found: {phase_dir}", file=sys.stderr)
+        return 1
+
+    # Cache hit
+    if out_path.exists() and not args.force:
+        cached = json.loads(out_path.read_text(encoding="utf-8"))
+        if not args.quiet:
+            print(f"✓ cached: has_ui={cached.get('has_ui')} confidence={cached.get('confidence')} ({out_path})", file=sys.stderr)
+        print(json.dumps(cached))
+        return 0
+
+    specs_path = phase_dir / "SPECS.md"
+    context_path = phase_dir / "CONTEXT.md"
+
+    if not specs_path.exists():
+        print(f"⛔ SPECS.md not found: {specs_path}", file=sys.stderr)
+        return 1
+
+    specs = specs_path.read_text(encoding="utf-8", errors="ignore")
+    context = context_path.read_text(encoding="utf-8", errors="ignore") if context_path.exists() else ""
+
+    if args.grep_fallback:
+        result = grep_fallback(specs, context)
+        result["model"] = "fallback-grep"
+        result["method"] = "fallback-grep"
+    else:
+        if not args.quiet:
+            print(f"▸ Detecting UI scope via Haiku ({HAIKU_MODEL})...", file=sys.stderr)
+        parsed, raw = invoke_haiku(specs, context)
+        if parsed is None:
+            print(f"⚠ Haiku failed ({raw[:200]}), falling back to grep heuristic", file=sys.stderr)
+            result = grep_fallback(specs, context)
+            result["model"] = "fallback-grep"
+            result["method"] = "fallback-grep-after-ai-failure"
+            result["ai_error"] = raw[:200]
+        else:
+            result = parsed
+            result["model"] = HAIKU_MODEL
+            result["method"] = "ai-semantic"
+
+    # Required fields normalization
+    result.setdefault("has_ui", False)
+    result.setdefault("confidence", 0.0)
+    result.setdefault("evidence", "")
+    result.setdefault("deferred_to", None)
+    result.setdefault("ui_kinds", [])
+    result["detected_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+    result["phase_dir"] = str(phase_dir)
+
+    # Confidence band routing
+    confidence = float(result.get("confidence", 0.0))
+    if confidence >= 0.8:
+        result["band"] = "auto"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"✓ has_ui={result['has_ui']} confidence={confidence:.2f} (AUTO-APPLY)\n"
+                f"  evidence: {result['evidence'][:120]}\n"
+                f"  written: {out_path}",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 0
+    elif confidence >= 0.5:
+        result["band"] = "tie-break-needed"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"⚠ has_ui={result['has_ui']} confidence={confidence:.2f} (TIE-BREAK NEEDED)\n"
+                f"  caller should spawn second AI with adversarial prompt or AskUserQuestion",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 2
+    else:
+        result["band"] = "user-confirmation-needed"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"⛔ has_ui={result['has_ui']} confidence={confidence:.2f} (USER CONFIRMATION REQUIRED)\n"
+                f"  caller should AskUserQuestion: 'Phase này có UI không?'",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validators/registry.yaml
+++ b/scripts/validators/registry.yaml
@@ -777,6 +777,15 @@ validators:
     runtime_target_ms: 1500
     added_in: v2.12.0-phase-16
     description: P16 D-02 — classify PLAN tasks as xml/heading/mixed format. mode=legacy (default) PASS heading; mode=structured BLOCK heading; mode=both WARN heading. XML tasks require frontmatter `acceptance:` ≥1 entry. Migration enforcement.
+
+  - id: ui-scope-coherence
+    path: .claude/scripts/validators/verify-ui-scope-coherence.py
+    severity: block
+    phases_active: [blueprint]
+    domain: artifact
+    runtime_target_ms: 1000
+    added_in: v2.43.6
+    description: Cross-check `.ui-scope.json` (AI semantic detection from preflight/detect-ui-scope.py) vs PLAN.md FE-task count. BLOCK on mismatch — declares has_ui=true but PLAN has 0 FE tasks (silent UI gap, L-002 class) OR declares has_ui=false but PLAN has FE tasks (scope leak). Replaces grep heuristic in blueprint step 0_design_discovery.
   - id: crossai-output
     path: .claude/scripts/validators/verify-crossai-output.py
     severity: block

--- a/scripts/validators/verify-ui-scope-coherence.py
+++ b/scripts/validators/verify-ui-scope-coherence.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Validator: verify-ui-scope-coherence — UI scope vs PLAN coherence gate.
+
+Cross-checks `.ui-scope.json` (authoritative AI semantic detection from
+preflight/detect-ui-scope.py) against PLAN.md FE-task count to catch the
+class of bugs where:
+
+  A) SPECS says "phase has UI" but planner ships zero FE tasks
+     → silent UI gap, build produces backend only, UAT fails (L-002)
+
+  B) SPECS says "phase is backend-only" but planner spawns FE tasks anyway
+     → scope violation, FE leaks into wrong phase, design refs missing
+
+Mismatch → BLOCK with explicit fix hints.
+PASS = scope decision matches PLAN reality.
+
+Usage:  verify-ui-scope-coherence.py --phase 4.3
+        verify-ui-scope-coherence.py --phase 6 --strict
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, timer, emit_and_exit, find_phase_dir  # noqa: E402
+
+
+FE_PATH_RE = re.compile(
+    r"<file-path>\s*("
+    r"apps/(admin|merchant|vendor|web)/[^<\s]+|"
+    r"packages/ui/[^<\s]+|"
+    r"[^<\s]+\.(tsx|jsx|vue|svelte)"
+    r")\s*</file-path>",
+    re.IGNORECASE,
+)
+
+# Tasks that touch FE patterns even if file path uses generic naming
+FE_DESC_HINT_RE = re.compile(
+    r"\b(React component|JSX|TSX|page component|Tailwind|Shadcn|Zustand|TanStack|"
+    r"sidebar|topbar|navbar|modal|drawer|wizard|stepper|form component|UI component|"
+    r"frontend route|FE route|client-side router)\b",
+    re.IGNORECASE,
+)
+
+
+def count_fe_tasks(plan_text: str) -> tuple[int, list[str]]:
+    """Return (count, examples). Splits PLAN by `### Task N` and checks each."""
+    task_blocks = re.split(r"(?m)^### Task \d+", plan_text)
+    fe_tasks = []
+    for i, block in enumerate(task_blocks[1:], 1):
+        if FE_PATH_RE.search(block):
+            # Extract file-path for evidence
+            m = FE_PATH_RE.search(block)
+            fe_tasks.append(f"Task {i}: {m.group(1)[:80]}")
+    return len(fe_tasks), fe_tasks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--strict", action="store_true",
+                        help="treat low-confidence (<0.5) ui-scope as BLOCK")
+    parser.add_argument("--allow-mismatch", action="store_true",
+                        help="downgrade BLOCK to WARN (logs override-debt elsewhere)")
+    args = parser.parse_args()
+
+    out = Output(validator="ui-scope-coherence")
+
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(
+                type="phase_dir_not_found",
+                message=f"Phase {args.phase} directory not found",
+                fix_hint="Verify phase number; run /vg:scope <phase> first.",
+            ))
+            return emit_and_exit(out) or 1
+
+        ui_scope_path = phase_dir / ".ui-scope.json"
+        plan_path = phase_dir / "PLAN.md"
+
+        if not plan_path.exists():
+            out.warn(Evidence(
+                type="plan_not_found",
+                message=f"PLAN.md not found at {plan_path}",
+                fix_hint="Run /vg:blueprint <phase> step 2a first.",
+            ))
+            return emit_and_exit(out) or 0
+
+        if not ui_scope_path.exists():
+            out.add(Evidence(
+                type="ui_scope_missing",
+                message=f".ui-scope.json not found at {ui_scope_path}",
+                fix_hint=(
+                    "Run preflight/detect-ui-scope.py --phase-dir <phase_dir> to "
+                    "generate authoritative UI scope decision before validation."
+                ),
+            ))
+            return emit_and_exit(out) or 1
+
+        try:
+            scope = json.loads(ui_scope_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            out.add(Evidence(
+                type="ui_scope_parse_error",
+                message=f".ui-scope.json invalid JSON: {e}",
+                file=str(ui_scope_path),
+                fix_hint="Re-run preflight/detect-ui-scope.py --force to regenerate.",
+            ))
+            return emit_and_exit(out) or 1
+
+        has_ui_declared: bool = bool(scope.get("has_ui", False))
+        confidence: float = float(scope.get("confidence", 0.0))
+        evidence_quote: str = scope.get("evidence", "")[:200]
+        deferred_to: str | None = scope.get("deferred_to")
+        method: str = scope.get("method", "unknown")
+        ui_kinds: list[str] = scope.get("ui_kinds") or []
+
+        # Strict-mode confidence floor
+        if args.strict and confidence < 0.5:
+            out.add(Evidence(
+                type="low_confidence_strict",
+                message=f"ui-scope confidence={confidence:.2f} below 0.5 threshold (--strict)",
+                expected="confidence >= 0.5",
+                actual=str(confidence),
+                fix_hint=(
+                    "Re-run detect-ui-scope.py with --force, or run an "
+                    "AskUserQuestion fallback to confirm 'has_ui' manually."
+                ),
+            ))
+
+        # Count FE tasks in PLAN
+        plan_text = plan_path.read_text(encoding="utf-8")
+        fe_count, fe_examples = count_fe_tasks(plan_text)
+
+        # Decision matrix
+        if has_ui_declared and fe_count == 0:
+            # Case A: silent UI gap
+            out.add(Evidence(
+                type="ui_declared_no_fe_tasks",
+                message=(
+                    f"ui-scope declares has_ui=true (confidence={confidence:.2f}, "
+                    f"method={method}, kinds={ui_kinds}) but PLAN.md has ZERO FE "
+                    f"tasks (file paths matching apps/admin|merchant|vendor|web/, "
+                    f"packages/ui/, or .tsx/.jsx/.vue/.svelte)."
+                ),
+                file=str(plan_path),
+                expected=f"FE tasks > 0 (UI scope: {ui_kinds})",
+                actual="0 FE tasks",
+                fix_hint=(
+                    "Either (a) re-run /vg:blueprint to add FE tasks covering the "
+                    "declared UI surface; or (b) if UI is actually deferred, edit "
+                    "SPECS.md to clarify and re-run preflight/detect-ui-scope.py "
+                    "--force; or (c) run with --allow-mismatch (logs override-debt) "
+                    "if scope is intentionally split (FE in a sibling phase)."
+                ),
+            ))
+        elif not has_ui_declared and fe_count > 0:
+            # Case B: scope violation — FE leaked into BE-only phase
+            out.add(Evidence(
+                type="be_only_with_fe_leak",
+                message=(
+                    f"ui-scope declares has_ui=false (confidence={confidence:.2f}, "
+                    f"deferred_to={deferred_to or 'N/A'}) but PLAN.md has {fe_count} "
+                    f"FE task(s) — FE leaked into a backend-only phase."
+                ),
+                file=str(plan_path),
+                expected="0 FE tasks (phase is backend-only)",
+                actual=f"{fe_count} FE tasks: {fe_examples[:3]}",
+                fix_hint=(
+                    "Either (a) re-plan and remove FE tasks (move to the phase "
+                    "named in deferred_to); or (b) edit SPECS to include UI "
+                    "scope and re-run preflight/detect-ui-scope.py --force; "
+                    "or (c) --allow-mismatch (log override-debt) if FE files "
+                    "are intentional (e.g., shared component used by future phase)."
+                ),
+            ))
+        else:
+            # Coherent: both true (UI phase with FE tasks) or both false (BE phase, no FE)
+            pass
+
+        # Downgrade BLOCK → WARN under --allow-mismatch
+        if args.allow_mismatch and out.verdict == "BLOCK":
+            # Convert all evidence to WARN-level
+            out.verdict = "WARN"
+
+        # If no findings at all, emit positive evidence so the operator sees the gate ran
+        if not out.evidence:
+            out.evidence.append(Evidence(
+                type="coherent",
+                message=(
+                    f"PASS: ui-scope (has_ui={has_ui_declared}, "
+                    f"confidence={confidence:.2f}, method={method}) "
+                    f"matches PLAN ({fe_count} FE tasks). "
+                    f"Evidence: {evidence_quote}"
+                ),
+            ))
+
+    return emit_and_exit(out) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
## Problem

`/vg:blueprint` step `0_design_discovery` uses keyword grep on SPECS+CONTEXT to decide `has_ui`, which gates downstream UI steps (`2b6_ui_spec` / `2b6b_ui_map` / `2b6c_view_decomposition`). Three failure modes observed:

1. **False positive on exclusion clauses.** Real example from a BE-only sub-phase:

   > SPECS line 5: "Phase này CHỈ build backend APIs ... UI portal Ở Phase 6/7/8"

   Keyword `UI` matched inside the EXCLUSION clause → blueprint flagged `has_ui=true` → expected to ship FE → false design-asset requirements → operator fights phantom UI gates.

2. **False positive from PLAN residue.** If a previous run left FE references in `PLAN.md` (e.g. before scope was tightened), grep matched those file paths and re-flagged the phase as UI-bearing on the next run.

3. **Silent UI gap (false negative).** If SPECS describes UI in prose ("Merchant tạo đơn qua dashboard") but planner spawned 0 FE tasks, no validator caught the omission — executor shipped backend only, UAT failed (the L-002 lesson).

## Solution

AI semantic detection via Haiku 4.5 reads SPECS+CONTEXT and outputs structured JSON `{has_ui, confidence, evidence, deferred_to, ui_kinds}`. Distinguishes scope-INCLUSION from scope-EXCLUSION clauses.

Confidence routing matches the existing `goal-classifier.sh` pattern:

| Confidence | Action |
|---|---|
| ≥ 0.8 | auto-apply, write `.ui-scope.json` cache |
| 0.5–0.8 | tie-break (caller spawns adversarial AI or AskUserQuestion) |
| < 0.5 | BLOCK unless `--override-reason` |

Falls back to grep heuristic on Haiku failure (logs `ai_error`).

## Implementation

- **`scripts/preflight/detect-ui-scope.py`** (325 lines)
  Spawns `claude --model claude-haiku-4-5-20251001 -p` from `/tmp` cwd to avoid parent-session Stop-hook contamination on subprocess exit.

- **`scripts/validators/verify-ui-scope-coherence.py`** (207 lines)
  Cross-checks `.ui-scope.json` (AI scope decision) vs `PLAN.md` FE-task count (regex on `<file-path>` matching `apps/(admin|merchant|vendor|web)/`, `packages/ui/`, or `.tsx|.jsx|.vue|.svelte`). BLOCK on mismatch:
  - `has_ui=true` + 0 FE tasks → silent UI gap (L-002 class)
  - `has_ui=false` + ≥1 FE task → scope leak into BE-only phase

  Coherent → PASS with positive evidence (visible to operator).

- **`scripts/validators/registry.yaml`** — new entry `ui-scope-coherence` (severity=block, phase=blueprint, runtime_target=1000ms).

- **`commands/vg/blueprint.md`**:
  - Step `0_design_discovery` calls `detect-ui-scope.py` first; legacy `blueprint-design-preflight.py` keeps mockup-import role only. `HAS_UI` source is `.ui-scope.json` (AI), with grep fallback when AI disabled/unavailable.
  - Step `2d` adds **Gate E** `ui-scope-coherence` between existing Gate C (task-schema) and Gate D (crossai-output).

## Test results

Haiku 4.5 — all auto-apply, confidence ≥ 0.95 across 4 real phases:

| Phase | Verdict | Confidence | Notes |
|---|---|---|---|
| BE-only sub-phase (the motivating bug) | `has_ui=false` | 0.98 | `deferred_to="Phase 6,7,8"`; SPECS exclusion clause quoted as evidence |
| merchant-portal | `has_ui=true` | 0.98 | 9 `ui_kinds` |
| admin-portal | `has_ui=true` | 0.96 | 6 `ui_kinds` |
| invoice-billing | `has_ui=true` | 0.95 | 8 `ui_kinds` (mixed BE+UI phase) |

The original false positive resolved.

## Override flags

```
--redetect-ui-scope          re-run AI detection (bypass cache)
--skip-ui-scope-coherence    bypass validator BLOCK (debt-logged)
--override-reason=<id>       bypass with audit trail
```

## Cost

~\$0.005-0.01 per blueprint via Haiku 4.5. Cached at `.ui-scope.json` so re-runs are free unless `--redetect-ui-scope` or SPECS materially changes.

## Implementation gotcha (worth saving for future contributors)

`claude` subprocess inherits parent project's `.claude/settings.json` Stop hook, which fires on subprocess exit and contaminates stdout with VG orchestrator verifier output (`⛔ No active run to complete...`). Workaround: spawn from `/tmp` cwd so hook doesn't resolve. `--bare` would work too but requires `ANTHROPIC_API_KEY` (not OAuth keychain), so `/tmp` cwd is the more portable fix.

## Backward compatibility

- Existing phases without `.ui-scope.json` continue to work (legacy grep fallback).
- New `--redetect-ui-scope` is opt-in.
- Gate E only fires when `.ui-scope.json` exists; PASS-by-default if missing (graceful degradation while migrating).

## Out of scope (future work)

- Tier 2 adversarial AI for 0.5–0.8 confidence band — currently logs telemetry event and accepts low-confidence with debt; could spawn a second different-model Haiku for tie-break (mirroring `vg-design-gap-hunter`).
- Migrate `blueprint-design-preflight.py` keyword-grep `has_ui` field to call `detect-ui-scope.py` internally instead of duplicate logic.
- Apply same pattern to `/vg:scope` (could surface UI scope gap during round 2 instead of waiting for blueprint).