### PR TITLE
fix(2.46): anti-performative-review — ép scanner submit mutations + 1 validator

### DIFF
--- a/codex-skills/vg-accept/SKILL.md
+++ b/codex-skills/vg-accept/SKILL.md
@@ -2323,6 +2323,22 @@ Force-advance (NOT RECOMMENDED): /vg:next --allow-deferred
 ```
 
 ```bash
+# v2.46 Phase 6 — final traceability chain check (scanner → goal → decision → spec)
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+ATRACE_VAL=".claude/scripts/validators/verify-acceptance-traceability.py"
+if [ -f "$ATRACE_VAL" ]; then
+  ATRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-traceability-gaps ]] && ATRACE_FLAGS="$ATRACE_FLAGS --allow-traceability-gaps"
+  ${PYTHON_BIN:-python3} "$ATRACE_VAL" --phase "${PHASE_NUMBER}" $ATRACE_FLAGS
+  ATRACE_RC=$?
+  if [ "$ATRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Acceptance traceability chain broken — phase cannot ship."
+    echo "   At least one link missing: scanner → goal → decision → spec."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "accept.traceability_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2 — terminal emit + run-complete for /vg:accept
 mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "7_post_accept_actions" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/7_post_accept_actions.done"

--- a/codex-skills/vg-amend/SKILL.md
+++ b/codex-skills/vg-amend/SKILL.md
@@ -383,6 +383,41 @@ Decisions changed: ${changed_decision_ids}
 Rollback: git checkout vg-amend-${PHASE_NUMBER}-pre-${NEXT_AMENDMENT}
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# v2.46 Phase 6 — cascade cross-phase validity check
+# When this phase amends decisions, walk ALL downstream phases to mark
+# goals citing revoked D-XX as STALE so user knows what to re-review.
+CROSS_VAL=".claude/scripts/validators/verify-cross-phase-decision-validity.py"
+if [ -f "$CROSS_VAL" ] && [ -d ".vg/phases" ]; then
+  echo ""
+  echo "🔄 v2.46 amend cascade: checking dependent phases for stale D-XX references..."
+  STALE_PHASES=()
+  for phase_dir in .vg/phases/*/; do
+    other_phase_name=$(basename "$phase_dir")
+    other_phase_num=$(echo "$other_phase_name" | sed 's/^0*//' | grep -oE '^[0-9]+(\.[0-9]+)?')
+    if [ -z "$other_phase_num" ] || [ "$other_phase_num" = "$PHASE_NUMBER" ]; then
+      continue
+    fi
+    OUT=$(${PYTHON_BIN:-python3} "$CROSS_VAL" --phase "$other_phase_num" --severity warn 2>/dev/null)
+    BAD=$(echo "$OUT" | python3 -c "import json,sys
+try:
+  d = json.load(sys.stdin)
+  bad = [e for e in d.get('evidence', []) if str(e.get('type','')).startswith('cross_phase')]
+  print(len(bad))
+except Exception:
+  print(0)" 2>/dev/null || echo 0)
+    if [ "${BAD:-0}" -gt 0 ]; then
+      STALE_PHASES+=("$other_phase_num ($BAD stale)")
+    fi
+  done
+  if [ ${#STALE_PHASES[@]} -gt 0 ]; then
+    echo "  ⚠ Stale references in downstream phase(s):"
+    for p in "${STALE_PHASES[@]}"; do echo "     - $p"; done
+    echo "  Run /vg:review on each to refresh, OR /vg:amend to update goal references."
+  else
+    echo "  ✓ No downstream phases reference revoked decisions."
+  fi
+fi
 ```
 
 Display:

--- a/codex-skills/vg-blueprint/SKILL.md
+++ b/codex-skills/vg-blueprint/SKILL.md
@@ -167,12 +167,23 @@ Sub-steps:
 **Config:** Read .claude/commands/vg/_shared/config-loader.md first.
 
 <step name="0_design_discovery">
-## Step 0 (Phase 20 D-12): Design discovery pre-flight
+## Step 0 (Phase 20 D-12 + v2.43.6 AI semantic detection): Design discovery pre-flight
 
 Before any planning work, verify FE phases have mockup ground truth.
 Without mockups, the entire L1-L6 stack from Phase 19 SKIPs via Form B
 and the executor ships AI-imagined UI (the L-002 anti-pattern this
 whole stack was built to prevent).
+
+**v2.43.6 — UI scope detection upgraded from grep heuristic to AI semantic.**
+Retro from a real BE-only sub-phase: SPECS line 5 ("Phase này CHỈ build backend
+APIs ... UI portal Ở Phase 6/7/8") was misclassified `has_ui=true` because
+keyword grep matched "UI" inside the EXCLUSION clause. Haiku 4.5 semantic
+analysis distinguishes scope-inclusion vs scope-exclusion ("UI deferred to
+Phase X"). Result is cached at `${PHASE_DIR}/.ui-scope.json` as authoritative
+ground truth consumed by:
+  - this step's scaffold/extract gating
+  - validators/verify-ui-scope-coherence.py (cross-checks PLAN.md FE-task count)
+  - downstream UI steps 2b6_ui_spec / 2b6b / 2b6c
 
 Blueprint owns this. It must not rely on the operator remembering a
 separate `/vg:design-scaffold` command. If the phase has UI:
@@ -192,6 +203,47 @@ elif [[ "$ARGUMENTS" =~ --skip-design-discovery ]]; then
   echo "⚠ --skip-design-discovery set — Form B 'no-asset:greenfield-explicit-skip' will trigger /vg:accept critical block"
 else
   mkdir -p "${PHASE_DIR}/.tmp"
+
+  # v2.43.6 — AI semantic UI scope detection (replaces grep heuristic)
+  UI_SCOPE_JSON="${PHASE_DIR}/.ui-scope.json"
+  AI_SCOPE_DETECT_ENABLED=$(vg_config_get ui_scope.ai_detect_enabled true 2>/dev/null || echo true)
+
+  if [ "$AI_SCOPE_DETECT_ENABLED" = "true" ] && { [ ! -f "$UI_SCOPE_JSON" ] || [[ "$ARGUMENTS" =~ --redetect-ui-scope ]]; }; then
+    echo "▸ Detecting UI scope via Haiku semantic analysis..."
+    DETECT_FLAGS=()
+    [[ "$ARGUMENTS" =~ --redetect-ui-scope ]] && DETECT_FLAGS+=( --force )
+    "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/preflight/detect-ui-scope.py" \
+      --phase-dir "${PHASE_DIR}" \
+      --output ".ui-scope.json" \
+      "${DETECT_FLAGS[@]}" >/dev/null 2>&1
+    UI_SCOPE_RC=$?
+
+    case "$UI_SCOPE_RC" in
+      0) echo "✓ UI scope auto-applied (confidence ≥ 0.8). See $UI_SCOPE_JSON" ;;
+      2)
+        echo "⚠ UI scope tie-break needed (confidence 0.5-0.8). Accept low-confidence result with debt log."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "blueprint.ui_scope_tie_break" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" 2>/dev/null || true
+        ;;
+      3)
+        echo "⛔ UI scope confidence < 0.5 — operator must answer 'Phase này có UI không?'"
+        echo "   Edit ${UI_SCOPE_JSON} manually (set has_ui + confidence + method=user-confirmed) or improve SPECS clarity then re-run with --redetect-ui-scope."
+        if [[ ! "$ARGUMENTS" =~ --override-reason ]]; then
+          exit 1
+        fi
+        ;;
+      *) echo "⚠ detect-ui-scope.py exit=${UI_SCOPE_RC} — falling back to legacy grep heuristic" ;;
+    esac
+  fi
+
+  # Read authoritative UI scope decision from .ui-scope.json (AI cache)
+  HAS_UI=""
+  if [ -f "$UI_SCOPE_JSON" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$UI_SCOPE_JSON")
+    UI_SCOPE_METHOD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('method','unknown'))" "$UI_SCOPE_JSON")
+    UI_SCOPE_DEFERRED=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('deferred_to') or 'none')" "$UI_SCOPE_JSON")
+    echo "  has_ui=${HAS_UI} (method=${UI_SCOPE_METHOD}, deferred_to=${UI_SCOPE_DEFERRED})"
+  fi
+
   BLUEPRINT_DESIGN_PREFLIGHT_JSON="${PHASE_DIR}/.tmp/blueprint-design-preflight.json"
   # v2.42.3 — forward --allow-shared-mockup-reuse from blueprint args.
   # Use this when phase legitimately reuses unchanged Phase 1 slugs
@@ -199,6 +251,8 @@ else
   # per-phase mockups otherwise (closes silent-pass gap on UI phases).
   PREFLIGHT_EXTRA=()
   [[ "$ARGUMENTS" =~ --allow-shared-mockup-reuse ]] && PREFLIGHT_EXTRA+=( --allow-shared-mockup-reuse )
+  # Legacy preflight still runs to import mockups + report needs_scaffold/needs_extract.
+  # We trust HAS_UI from .ui-scope.json (AI) over its keyword-grep field of the same name.
   "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/blueprint-design-preflight.py" \
     --phase-dir "${PHASE_DIR}" \
     --repo-root "${REPO_ROOT}" \
@@ -207,7 +261,11 @@ else
     --output "${BLUEPRINT_DESIGN_PREFLIGHT_JSON}" \
     "${PREFLIGHT_EXTRA[@]}" >/dev/null
 
-  HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+  # Fallback: if .ui-scope.json missing (AI detect disabled/unavailable), use legacy grep result.
+  if [ -z "${HAS_UI}" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+    echo "ℹ HAS_UI from legacy grep heuristic (.ui-scope.json not generated): ${HAS_UI}"
+  fi
   IMPORTED_COUNT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('imported_count',0))" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_SCAFFOLD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_scaffold') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_EXTRACT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_extract') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
@@ -3212,6 +3270,33 @@ if [ -x "$TS_VAL" ]; then
   esac
 fi
 
+# Gate E (v2.43.6): ui-scope-coherence — cross-check .ui-scope.json (AI semantic
+# detection from step 0_design_discovery) against PLAN.md FE-task count.
+# BLOCK on (a) has_ui=true + 0 FE tasks (silent UI gap, L-002 class) OR
+#         (b) has_ui=false + ≥1 FE task (scope leak into BE-only phase).
+US_VAL="${REPO_ROOT}/.claude/scripts/validators/verify-ui-scope-coherence.py"
+if [ -x "$US_VAL" ]; then
+  ${PYTHON_BIN} "$US_VAL" --phase "${PHASE_NUMBER}" \
+      > "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>&1 || true
+  US_V=$(${PYTHON_BIN} -c "import json,sys; print(json.load(open(sys.argv[1])).get('verdict','SKIP'))" \
+        "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>/dev/null)
+  case "$US_V" in
+    PASS|WARN) echo "✓ ui-scope-coherence: $US_V" ;;
+    BLOCK)
+      echo "⛔ ui-scope-coherence: BLOCK — see ${VG_TMP}/ui-scope-coherence.json" >&2
+      echo "   Mismatch between .ui-scope.json (AI scope decision) and PLAN.md FE-task count." >&2
+      echo "   Either re-plan to match scope, edit SPECS to match PLAN, or override:" >&2
+      echo "     --override-reason='<issue-id>' (logs OVERRIDE-DEBT, not recommended)" >&2
+      echo "     --skip-ui-scope-coherence (downgrade gate)" >&2
+      echo "     ${PYTHON_BIN} ${US_VAL} --phase ${PHASE_NUMBER} --allow-mismatch (downgrade BLOCK→WARN)" >&2
+      if [[ ! "$ARGUMENTS" =~ --override-reason ]] && [[ ! "$ARGUMENTS" =~ --skip-ui-scope-coherence ]]; then
+        exit 1
+      fi
+      ;;
+    *) echo "ℹ ui-scope-coherence: $US_V" ;;
+  esac
+fi
+
 # Gate D: crossai-output (gated on --crossai flag — only audits diff if a
 # cross-AI enrichment actually ran)
 if [[ "$ARGUMENTS" =~ --crossai ]]; then
@@ -3651,6 +3736,54 @@ git commit -m "blueprint({phase}): plans + contracts + goals — CrossAI {verdic
 mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "3_complete" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/3_complete.done"
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator mark-step blueprint 3_complete 2>/dev/null || true
+
+# v2.46 Phase 6 traceability gates — closes "AI bịa goal/decision" gap.
+# Migration: VG_TRACEABILITY_MODE=warn for pre-2026-05-01 phases.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+
+# v2.46 L6a — goal frontmatter completeness (spec_ref + decisions + business_rules + expected_assertion)
+TRACE_VAL=".claude/scripts/validators/verify-goal-traceability.py"
+if [ -f "$TRACE_VAL" ]; then
+  TRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-traceability-gaps ]] && TRACE_FLAGS="$TRACE_FLAGS --allow-traceability-gaps"
+  ${PYTHON_BIN:-python3} "$TRACE_VAL" --phase "${PHASE_NUMBER}" $TRACE_FLAGS
+  TRACE_RC=$?
+  if [ "$TRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Goal traceability gate failed at blueprint."
+    echo "   Goals must cite: spec_ref, decisions, business_rules, expected_assertion, goal_class."
+    echo "   See: commands/vg/_shared/templates/TEST-GOAL-enriched-template.md (v2.46 Phase 6 enrichment)"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "blueprint.traceability_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 — D-XX → tasks coverage
+DTASK_VAL=".claude/scripts/validators/verify-decisions-to-tasks.py"
+if [ -f "$DTASK_VAL" ]; then
+  DTASK_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-uncovered-decisions ]] && DTASK_FLAGS="$DTASK_FLAGS --allow-uncovered-decisions"
+  ${PYTHON_BIN:-python3} "$DTASK_VAL" --phase "${PHASE_NUMBER}" $DTASK_FLAGS
+  DTASK_RC=$?
+  if [ "$DTASK_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions → tasks coverage gate failed at blueprint."
+    echo "   Every D-XX in CONTEXT must be referenced in ≥1 PLAN*.md task."
+    exit 1
+  fi
+fi
+
+# v2.46 — D-XX → goals coverage
+DGOAL_VAL=".claude/scripts/validators/verify-decisions-to-goals.py"
+if [ -f "$DGOAL_VAL" ]; then
+  DGOAL_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-uncovered-decisions ]] && DGOAL_FLAGS="$DGOAL_FLAGS --allow-uncovered-decisions"
+  ${PYTHON_BIN:-python3} "$DGOAL_VAL" --phase "${PHASE_NUMBER}" $DGOAL_FLAGS
+  DGOAL_RC=$?
+  if [ "$DGOAL_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions → goals coverage gate failed at blueprint."
+    echo "   Every D-XX must be cited by ≥1 goal in TEST-GOALS.md (decisions: [D-XX])."
+    exit 1
+  fi
+fi
 
 # v2.2 — terminal emit + run-complete. Validators fire here; BLOCK on violations.
 PLAN_COUNT=$(ls "${PHASE_DIR}"/PLAN*.md 2>/dev/null | wc -l | tr -d ' ')

--- a/codex-skills/vg-build/SKILL.md
+++ b/codex-skills/vg-build/SKILL.md
@@ -4000,6 +4000,23 @@ No way to skip via "promise" — events.db evidence required (OHOK-7/8).
 ## Step 12: Run-complete (validators fire, BLOCK on violations)
 
 ```bash
+# v2.46 Phase 6 — business rule constants in code
+# Closes "code drift from D-XX values" gap (e.g., D-46 says 5 but code has 3).
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+BIZRULE_VAL=".claude/scripts/validators/verify-business-rule-implemented.py"
+if [ -f "$BIZRULE_VAL" ]; then
+  BIZRULE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-rule-not-implemented ]] && BIZRULE_FLAGS="$BIZRULE_FLAGS --allow-rule-not-implemented"
+  ${PYTHON_BIN:-python3} "$BIZRULE_VAL" --phase "${PHASE_NUMBER:-${PHASE_ARG}}" $BIZRULE_FLAGS
+  BIZRULE_RC=$?
+  if [ "$BIZRULE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Business-rule-implemented gate failed: code constants drift from CONTEXT decisions."
+    echo "   Verify expected_assertion values appear as constants in apps/packages/infra source."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "build.bizrule_blocked" --payload "{\"phase\":\"${PHASE_NUMBER:-${PHASE_ARG}}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # Emit final completion telemetry only after the CrossAI loop has reached an
 # accepted terminal state. run-complete validates this event in the same call.
 SUMMARY_COUNT=$(ls "${PHASE_DIR}"/SUMMARY*.md 2>/dev/null | wc -l | tr -d " ")

--- a/codex-skills/vg-haiku-scanner/SKILL.md
+++ b/codex-skills/vg-haiku-scanner/SKILL.md
@@ -555,6 +555,12 @@ optional fields — no breaking change for web.
 - Fill and submit EVERY form you find.
 - **After EVERY form submit → run Persistence Probe (Layer 4). Record `persistence_probe: {persisted, pre, post, diff}`. No exceptions except read-only forms + final-step-of-wizard + file-upload (document skip reason).**
 - Test BOTH branches of EVERY confirm dialog (Cancel first, then OK).
+- **⛔ ANTI-CANCEL ENFORCEMENT (v2.46+ — closes Phase 3.2 dogfood meta-bug):**
+  - For ANY goal with `mutation_evidence` declared in TEST-GOALS — scanner MUST execute the OK/Submit path AT LEAST ONCE per goal. Cancelling without ever submitting = AUTOMATIC `match: no` for the goal step, NOT `match: yes`.
+  - Sandbox is a mutation environment by design (`disposable_seed_data: true` in ENV-CONTRACT). Refusing to submit because "destructive" or "modify real data" is a CONTRACT VIOLATION — sandbox seed regenerates per /vg:test run.
+  - If orchestrator (commander) prompt explicitly tells you "Cancel modals only" or "do not submit", you MUST still record `observations[].observed: "scanner_skipped_submit_per_orchestrator_directive"` with `match: unknown`. NEVER `match: yes` when submit was skipped — that fabricates passing evidence.
+  - On submit, capture FULL network chain (preflight CSRF/auth GET + mutation POST + post-mutation GET for persistence). Server errors (403 CSRF, 401 AUTH, 5xx) are FACTUAL OBSERVATIONS — record them with `match: no` + verbatim error code. NEVER classify them as "expected security check" or "as designed" (banned vocabulary per scanner-report-contract Section 1).
+  - Exception (only valid skip): goal explicitly declares `mutation_required: false` in TEST-GOALS frontmatter. Default for goals with `mutation_evidence` is `mutation_required: true`.
 - Record console errors after EVERY action.
 - Record network requests after EVERY action.
 - Re-snapshot after EVERY click and append new elements.

--- a/codex-skills/vg-review/SKILL.md
+++ b/codex-skills/vg-review/SKILL.md
@@ -5822,6 +5822,126 @@ if [ -f "$MATRIX_LINK_VAL" ]; then
   fi
 fi
 
+# v2.46 anti-performative-review: ép scanner phải submit mutation goals,
+# không được Cancel modal rồi mark passed. Phase 3.2 dogfood (2026-05-01) tìm
+# 5 false-pass goals (G-31/G-34/G-35/G-44/G-52) modal opened nhưng chưa bao giờ
+# submit. Validator này check goal_sequences.steps[] có submit click + 2xx
+# network entry trước khi cho phép run-complete.
+MUT_SUBMIT_VAL=".claude/scripts/validators/verify-mutation-actually-submitted.py"
+if [ -f "$MUT_SUBMIT_VAL" ]; then
+  MUT_FLAGS="--severity block"
+  if [[ "${ARGUMENTS}" =~ --allow-cancel-only-mutations ]]; then
+    MUT_FLAGS="--severity block --allow-cancel-only-mutations"
+  fi
+  ${PYTHON_BIN:-python3} "$MUT_SUBMIT_VAL" --phase "${PHASE_NUMBER}" $MUT_FLAGS
+  MUT_RC=$?
+  if [ "$MUT_RC" -ne 0 ]; then
+    echo "⛔ Review mutation-actually-submitted gate failed."
+    echo "   Mutation goals marked passed without actual submit click + 2xx network."
+    echo "   This is the 'performative review' meta-bug: scanner Cancel modal → never test"
+    echo "   happy path → CSRF/auth/idempotency bugs slip through to user."
+    echo "   Fix path:"
+    echo "     1. Re-run /vg:review ${PHASE_NUMBER} với scanner prompt yêu cầu SUBMIT (sandbox = disposable seed)"
+    echo "     2. OR --allow-cancel-only-mutations override (logs OVERRIDE-DEBT — legitimate"
+    echo "        only nếu phase explicitly không muốn mutate)"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.mutation_submit_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 Phase 6 enrichment: traceability + RCRURD enforcement.
+# Closes "AI bịa goal/decision/business-rule" + "scanner stops too early".
+# Migration: VG_TRACEABILITY_MODE=warn for pre-2026-05-01 phases (set in
+# vg.config.md). New phases default to block.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+
+# v2.46 L4 — RCRURD step depth (per goal_class threshold)
+RCRURD_VAL=".claude/scripts/validators/verify-rcrurd-depth.py"
+if [ -f "$RCRURD_VAL" ]; then
+  RCRURD_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-shallow-scans ]] && RCRURD_FLAGS="$RCRURD_FLAGS --allow-shallow-scans"
+  ${PYTHON_BIN:-python3} "$RCRURD_VAL" --phase "${PHASE_NUMBER}" $RCRURD_FLAGS
+  RCRURD_RC=$?
+  if [ "$RCRURD_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ RCRURD depth gate failed — scanner stopped too early on mutation goals."
+    echo "   See scanner-report-contract.md 'RCRURD Lifecycle Protocol'. Goal class drives min steps."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_depth_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — asserted_quote vs business rule similarity
+ASSERTED_VAL=".claude/scripts/validators/verify-asserted-rule-match.py"
+if [ -f "$ASSERTED_VAL" ]; then
+  ASSERTED_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-asserted-drift ]] && ASSERTED_FLAGS="$ASSERTED_FLAGS --allow-asserted-drift"
+  ${PYTHON_BIN:-python3} "$ASSERTED_VAL" --phase "${PHASE_NUMBER}" $ASSERTED_FLAGS
+  ASSERTED_RC=$?
+  if [ "$ASSERTED_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Asserted-rule-match gate failed — scanner asserted_quote drifts from BR-NN text."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.asserted_drift_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — replay-evidence (structural + optional curl replay)
+REPLAY_VAL=".claude/scripts/validators/verify-replay-evidence.py"
+if [ -f "$REPLAY_VAL" ]; then
+  REPLAY_FLAGS="--severity warn"  # default warn — auth fixture not always available
+  [[ "${ARGUMENTS}" =~ --enable-replay ]] && REPLAY_FLAGS="--severity ${TRACE_MODE} --enable-replay"
+  ${PYTHON_BIN:-python3} "$REPLAY_VAL" --phase "${PHASE_NUMBER}" $REPLAY_FLAGS
+  REPLAY_RC=$?
+  if [ "$REPLAY_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ] && [[ "${ARGUMENTS}" =~ --enable-replay ]]; then
+    echo "⛔ Replay-evidence gate failed — scanner network claims can't be verified."
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — cross-phase decision validity (D-XX from earlier phase still active)
+CROSS_VAL=".claude/scripts/validators/verify-cross-phase-decision-validity.py"
+if [ -f "$CROSS_VAL" ]; then
+  CROSS_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-stale-decisions ]] && CROSS_FLAGS="$CROSS_FLAGS --allow-stale-decisions"
+  ${PYTHON_BIN:-python3} "$CROSS_VAL" --phase "${PHASE_NUMBER}" $CROSS_FLAGS
+  CROSS_RC=$?
+  if [ "$CROSS_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Cross-phase decision validity failed — goal cites revoked/missing D-XX."
+    exit 1
+  fi
+fi
+
+# v2.46 L6 — adversarial scanner-business-alignment verifier
+# Two-phase: emit prompts → orchestrator spawns Haiku verifier per prompt →
+# re-run validator with --verifier-results to gate.
+ALIGN_VAL=".claude/scripts/validators/verify-scanner-business-alignment.py"
+if [ -f "$ALIGN_VAL" ]; then
+  PROMPTS_FILE="${PHASE_DIR}/.tmp/business-alignment-prompts.jsonl"
+  RESULTS_FILE="${PHASE_DIR}/.tmp/business-alignment-results.jsonl"
+  mkdir -p "$(dirname "$PROMPTS_FILE")" 2>/dev/null
+  ${PYTHON_BIN:-python3} "$ALIGN_VAL" --phase "${PHASE_NUMBER}" --prompts-out "$PROMPTS_FILE" 2>&1 | head -3
+  PROMPT_COUNT=$(wc -l < "$PROMPTS_FILE" 2>/dev/null | tr -d ' ' || echo 0)
+
+  if [ "$PROMPT_COUNT" -gt 0 ]; then
+    echo ""
+    echo "📋 Business alignment verifier needs ${PROMPT_COUNT} adversarial check(s)."
+    echo "   Orchestrator should spawn isolated Haiku per prompt + write JSONL results to:"
+    echo "     ${RESULTS_FILE}"
+    echo "   Then re-run review with --verifier-results=${RESULTS_FILE}"
+    echo ""
+    # If results file exists from prior orchestrator pass, gate now
+    if [ -f "$RESULTS_FILE" ]; then
+      ALIGN_FLAGS="--severity ${TRACE_MODE} --verifier-results ${RESULTS_FILE}"
+      [[ "${ARGUMENTS}" =~ --allow-business-drift ]] && ALIGN_FLAGS="$ALIGN_FLAGS --allow-business-drift"
+      ${PYTHON_BIN:-python3} "$ALIGN_VAL" --phase "${PHASE_NUMBER}" $ALIGN_FLAGS
+      ALIGN_RC=$?
+      if [ "$ALIGN_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+        echo "⛔ Business alignment gate failed — adversarial verifier flagged drift."
+        exit 1
+      fi
+    fi
+  fi
+fi
+
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
 RUN_RC=$?
 if [ $RUN_RC -ne 0 ]; then

--- a/codex-skills/vg-scope/SKILL.md
+++ b/codex-skills/vg-scope/SKILL.md
@@ -1391,6 +1391,23 @@ git add "${PHASE_DIR}/CONTEXT.md" "${PHASE_DIR}/DISCUSSION-LOG.md" \
   git add "${PHASE_DIR}/.contract-pins.json"
 git commit -m "scope(${PHASE_NUMBER}): ${DECISION_COUNT} decisions, ${ENDPOINT_COUNT} endpoints, ${TEST_SCENARIO_COUNT} test scenarios"
 
+# v2.46 Phase 6 — D-XX trace to user answer in DISCUSSION-LOG
+# Closes "AI paraphrases user answer wrongly into D-XX" gap.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+DTRACE_VAL=".claude/scripts/validators/verify-decisions-trace.py"
+if [ -f "$DTRACE_VAL" ]; then
+  DTRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-decisions-untraced ]] && DTRACE_FLAGS="$DTRACE_FLAGS --allow-decisions-untraced"
+  ${PYTHON_BIN:-python3} "$DTRACE_VAL" --phase "${PHASE_NUMBER}" $DTRACE_FLAGS
+  DTRACE_RC=$?
+  if [ "$DTRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions-trace gate failed: D-XX statements drift from DISCUSSION-LOG user answers."
+    echo "   Add 'Quote source: DISCUSSION-LOG.md#round-N' field to each D-XX in CONTEXT.md."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "scope.decisions_trace_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2: mark final step + emit completion event + invoke run-complete.
 # Orchestrator runs phase-exists + context-structure validators, emits
 # run.completed or run.blocked based on contract check. No bash catch-up

--- a/codex-skills/vg-test/SKILL.md
+++ b/codex-skills/vg-test/SKILL.md
@@ -3869,6 +3869,22 @@ esac
 ```
 
 ```bash
+# v2.46 Phase 6 — test traces to goal + business_rule
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+TTRACE_VAL=".claude/scripts/validators/verify-test-traces-to-rule.py"
+if [ -f "$TTRACE_VAL" ]; then
+  TTRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-test-untraced ]] && TTRACE_FLAGS="$TTRACE_FLAGS --allow-test-untraced"
+  ${PYTHON_BIN:-python3} "$TTRACE_VAL" --phase "${PHASE_NUMBER}" $TTRACE_FLAGS
+  TTRACE_RC=$?
+  if [ "$TTRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Test-traces-to-rule gate failed: .spec.ts files don't cite goal_id + BR-NN."
+    echo "   Header format required: '// Goal: G-XX | Rule: BR-NN | Assertion: <verbatim quote>'"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "test.trace_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2 — terminal emit + run-complete for /vg:test
 mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "complete" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/complete.done"

--- a/commands/vg/_shared/scanner-report-contract.md
+++ b/commands/vg/_shared/scanner-report-contract.md
@@ -29,6 +29,8 @@ Scanner output **MUST NOT** contain any of these tokens (case-insensitive). They
 | `fix`, `repair`, `patch` | Action recommendation | report observation, let commander prescribe |
 | `correct`, `correctly`, `properly` | Implies right/wrong judgment | `expected_per_lens: <spec>` vs `observed: <fact>` |
 | `obviously`, `clearly`, `apparently` | Speculation, not observation | drop the qualifier; state observation directly |
+| `expected security`, `as designed`, `expected behavior`, `working as intended` | Self-rationalization that hides bugs (e.g., scanner sees CSRF block on legit user flow → calls it "expected security check" → marks goal passed → real bug ships). Scanner CANNOT classify mismatch as expected — that's commander's call after cross-referencing TEST-GOALS success_criteria. | `expected_per_lens: 200 + ledger commit; observed: 403 AUTH_CSRF_MISSING; match: no` |
+| `cancel`, `cancelled`, `canceled` (when describing why mutation goal not submitted) | Performative review pattern — scanner avoids destructive action by Cancel-only path → never tests happy path → CSRF/auth/idempotency bugs slip through. Sandbox env exists FOR mutation; if disposable_seed_data declared, scanner MUST submit. | If goal has `mutation_evidence` declared: submit + capture full network chain. If commander truly wants Cancel-only path, scanner records `match: unknown, observed: scanner_skipped_submit_per_orchestrator_directive` — NEVER `match: yes`. |
 
 **Allowed words:**
 - `expected_per_lens`, `observed`, `match`, `mismatch`, `partial`, `unknown`

--- a/commands/vg/_shared/scanner-report-contract.md
+++ b/commands/vg/_shared/scanner-report-contract.md
@@ -41,6 +41,60 @@ Scanner output **MUST NOT** contain any of these tokens (case-insensitive). They
 
 ---
 
+## Section 1.5 — RCRURD Lifecycle Protocol (v2.46+)
+
+Closes "scanner stops at form-opened" gap. Every mutation goal MUST follow Read-Create-Read-Update-Read-Delete-Read pattern (or class-specific subset). Scanners that mark `result=passed` with insufficient steps fail downstream validators (`verify-rcrurd-depth.py`, `verify-mutation-actually-submitted.py`).
+
+### Step depth thresholds per goal_class
+
+| goal_class | Min steps | Pattern |
+|---|---|---|
+| `readonly` | 3 | navigate → snapshot → assert criteria |
+| `webhook` | 4 | trigger → wait → query downstream → assert |
+| `mutation` | 6 | pre-snapshot → click submit → post-wait → refresh → re-read → diff |
+| `approval` | 8 | read pending → drawer → click approve → confirm modal → submit → wait → refresh → assert status flip |
+| `wizard` | 10 | step1 fill → next → step2 fill → next → ... → submit final → re-read |
+| `crud-roundtrip` | 14 | Read empty → Create (open form, fill, submit, wait) → Read populated → Update (open edit, change, submit, wait) → Read updated → Delete (open delete, confirm, wait) → Read empty |
+
+Scanner output `goal_sequences[gid].steps[]` length below threshold = AUTOMATIC `match: no`. NEVER `match: yes` with < min_steps.
+
+### Banned scanner stopping points (in addition to Section 1 vocabulary)
+
+- "form is visible" / "modal opened" / "page loads correctly" — when this is the ONLY evidence for a mutation goal
+- "Step X not yet visible" / "form not reached" — without 3-second wait + 3 snapshot retries + DOM evaluate + console capture
+- "Cannot test [X] without [Y]" — sandbox declares `disposable_seed_data: true`; scanner MUST create Y first
+
+### Required scanner behaviors
+
+1. **Wait + retry**: when expected element absent, wait ≥3s + retry browser_snapshot ≥3 times before marking absent
+2. **Capture verbatim**: console errors + network 4xx/5xx recorded with EXACT message text, NEVER paraphrased
+3. **Try alternative paths**: if first sequence fails, try refresh + different click order + JS evaluate before giving up
+4. **Cascade documentation**: when 1 step fails, output `cascade_blocked_by: ["G-XX step Y"]` listing all downstream actions blocked. Scanner does NOT just stop — it records the blocked downstream path.
+5. **Verbatim assertion quote**: every mutation step records `asserted_quote: <verbatim text from BR-NN>` and `asserted_rule: BR-NN`. Validator (`verify-asserted-rule-match.py`) cross-checks this matches goal `expected_assertion` ≥0.5 Jaccard similarity.
+
+### "No early stop" rule
+
+If scanner believes goal cannot be tested (data unavailable, environment issue, feature missing), output `result: blocked` with EXPLICIT reason — NEVER `result: passed` based on partial observation.
+
+### Output schema additions (mutation steps)
+
+```jsonc
+{
+  "step_idx": 4,
+  "do": "click",
+  "target": "button#approve-submit",
+  "label": "Approve",
+  "asserted_rule": "BR-S-01",
+  "asserted_quote": "Approve action requires admin role + ledger commit DR merchant_wallet / CR platform_cash",
+  "observed": "POST /api/v1/admin/topup-requests/.../approve returned 200, status flip pending→approved verified via refresh",
+  "match": "yes",
+  "evidence": { ... },
+  "cascade_blocked_by": null   // populated if THIS step blocks downstream
+}
+```
+
+---
+
 ## Section 2 — Report schema (canonical)
 
 All scanner reports MUST conform to this JSON schema. Per-tool wrappers (web/mobile/CLI) extend, never violate.

--- a/commands/vg/_shared/templates/TEST-GOAL-enriched-template.md
+++ b/commands/vg/_shared/templates/TEST-GOAL-enriched-template.md
@@ -64,6 +64,63 @@ verification: automated | manual | deferred | skipped
 tests: [TS-XX, TS-YY]         # bind to test files via TS-XX markers
 
 # ─────────────────────────────────────────────────────────────────────
+# v2.46 Phase 6 enrichment — Business traceability (REQUIRED post-2026-05-01)
+# ─────────────────────────────────────────────────────────────────────
+# Closes "AI bịa goal/decision" gap surfaced in Phase 3.2 dogfood. Goals
+# missing these fields → BLOCK at /vg:blueprint via verify-goal-traceability.py.
+# Migration: pre-2026-05-01 phases run validators in WARN mode (set
+# VG_TRACEABILITY_MODE=warn). New phases default BLOCK.
+
+spec_ref: <SPECS.md#section-anchor>
+  # REQUIRED. Cite the SPECS.md section that drives this goal. Validator
+  # greps SPECS.md for the heading.
+  # e.g. "SPECS.md#suspicious-topup-detection"
+
+decisions: [P3.D-46, P3.D-15]
+  # REQUIRED if goal cites any decision. Each entry must exist in
+  # CONTEXT.md. Validator (verify-decisions-to-goals.py) cross-checks.
+  # Convention: <PHASE>.D-<NUMBER> for cross-phase, D-<NUMBER> for same-phase.
+
+business_rules: [BR-S-01, BR-S-02]
+  # REQUIRED for business-logic goals. Each entry must exist in
+  # DISCUSSION-LOG.md as "BR-NN: <rule statement>".
+  # Empty list = goal has no business-rule semantics (e.g. pure UI render goal).
+
+flow_ref: <FLOW-SPEC.md#flow-anchor>
+  # REQUIRED if surface=ui AND goal involves multi-step flow.
+  # Validator greps FLOW-SPEC.md for the anchor.
+
+api_contracts: [topup-flag-endpoint, topup-list-endpoint]
+  # REQUIRED if surface=api OR goal touches network mutations.
+  # Each entry must match an endpoint heading in API-CONTRACTS.md.
+
+expected_assertion: |
+  # REQUIRED. Verbatim quote of business rule statement that scanner/test
+  # must verify. Used by:
+  #   - verify-business-rule-implemented.py (build): grep code for
+  #     constants matching this assertion
+  #   - verify-asserted-rule-match.py (review): scanner steps[].asserted_quote
+  #     must match this text >= 80% similarity
+  #   - verify-test-traces-to-rule.py (test): .spec.ts header must cite
+  #
+  # Example:
+  #   "Topup count >= SUSPICIOUS_COUNT_THRESHOLD (5) trong 24h sliding window
+  #    → flagged_suspicious=true; AND amount sum >= AMOUNT_THRESHOLD ($100)
+  #    in same window → flagged_suspicious=true (count OR amount triggers)"
+
+goal_class: mutation | readonly | crud-roundtrip | wizard | approval | webhook
+  # REQUIRED. Drives min_steps validator threshold.
+  # readonly: ≥3 steps (navigate → snapshot → assert)
+  # mutation: ≥6 steps (pre-snapshot → submit → wait → refresh → re-read → diff)
+  # approval: ≥8 (read pending → drawer → click approve → confirm modal → submit
+  #              → wait → refresh → assert status flip)
+  # crud-roundtrip: ≥14 (Read empty → Create [4 steps] → Read populated →
+  #                      Update [4 steps] → Read updated → Delete [3 steps] →
+  #                      Read empty)
+  # wizard: ≥10 (multi-step form, capture each step transition)
+  # webhook: ≥4 (trigger event → wait → query downstream state → assert)
+
+# ─────────────────────────────────────────────────────────────────────
 # v2.5 Phase B enrichment — Security + Performance
 # ─────────────────────────────────────────────────────────────────────
 # Optional but REQUIRED for critical_goal_domains (auth/payment/billing).

--- a/commands/vg/accept.md
+++ b/commands/vg/accept.md
@@ -2248,6 +2248,22 @@ Force-advance (NOT RECOMMENDED): /vg:next --allow-deferred
 ```
 
 ```bash
+# v2.46 Phase 6 — final traceability chain check (scanner → goal → decision → spec)
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+ATRACE_VAL=".claude/scripts/validators/verify-acceptance-traceability.py"
+if [ -f "$ATRACE_VAL" ]; then
+  ATRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-traceability-gaps ]] && ATRACE_FLAGS="$ATRACE_FLAGS --allow-traceability-gaps"
+  ${PYTHON_BIN:-python3} "$ATRACE_VAL" --phase "${PHASE_NUMBER}" $ATRACE_FLAGS
+  ATRACE_RC=$?
+  if [ "$ATRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Acceptance traceability chain broken — phase cannot ship."
+    echo "   At least one link missing: scanner → goal → decision → spec."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "accept.traceability_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2 — terminal emit + run-complete for /vg:accept
 mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "7_post_accept_actions" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/7_post_accept_actions.done"

--- a/commands/vg/amend.md
+++ b/commands/vg/amend.md
@@ -263,6 +263,41 @@ Decisions changed: ${changed_decision_ids}
 Rollback: git checkout vg-amend-${PHASE_NUMBER}-pre-${NEXT_AMENDMENT}
 
 Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# v2.46 Phase 6 — cascade cross-phase validity check
+# When this phase amends decisions, walk ALL downstream phases to mark
+# goals citing revoked D-XX as STALE so user knows what to re-review.
+CROSS_VAL=".claude/scripts/validators/verify-cross-phase-decision-validity.py"
+if [ -f "$CROSS_VAL" ] && [ -d ".vg/phases" ]; then
+  echo ""
+  echo "🔄 v2.46 amend cascade: checking dependent phases for stale D-XX references..."
+  STALE_PHASES=()
+  for phase_dir in .vg/phases/*/; do
+    other_phase_name=$(basename "$phase_dir")
+    other_phase_num=$(echo "$other_phase_name" | sed 's/^0*//' | grep -oE '^[0-9]+(\.[0-9]+)?')
+    if [ -z "$other_phase_num" ] || [ "$other_phase_num" = "$PHASE_NUMBER" ]; then
+      continue
+    fi
+    OUT=$(${PYTHON_BIN:-python3} "$CROSS_VAL" --phase "$other_phase_num" --severity warn 2>/dev/null)
+    BAD=$(echo "$OUT" | python3 -c "import json,sys
+try:
+  d = json.load(sys.stdin)
+  bad = [e for e in d.get('evidence', []) if str(e.get('type','')).startswith('cross_phase')]
+  print(len(bad))
+except Exception:
+  print(0)" 2>/dev/null || echo 0)
+    if [ "${BAD:-0}" -gt 0 ]; then
+      STALE_PHASES+=("$other_phase_num ($BAD stale)")
+    fi
+  done
+  if [ ${#STALE_PHASES[@]} -gt 0 ]; then
+    echo "  ⚠ Stale references in downstream phase(s):"
+    for p in "${STALE_PHASES[@]}"; do echo "     - $p"; done
+    echo "  Run /vg:review on each to refresh, OR /vg:amend to update goal references."
+  else
+    echo "  ✓ No downstream phases reference revoked decisions."
+  fi
+fi
 ```
 
 Display:

--- a/commands/vg/blueprint.md
+++ b/commands/vg/blueprint.md
@@ -121,12 +121,23 @@ Sub-steps:
 **Config:** Read .claude/commands/vg/_shared/config-loader.md first.
 
 <step name="0_design_discovery">
-## Step 0 (Phase 20 D-12): Design discovery pre-flight
+## Step 0 (Phase 20 D-12 + v2.43.6 AI semantic detection): Design discovery pre-flight
 
 Before any planning work, verify FE phases have mockup ground truth.
 Without mockups, the entire L1-L6 stack from Phase 19 SKIPs via Form B
 and the executor ships AI-imagined UI (the L-002 anti-pattern this
 whole stack was built to prevent).
+
+**v2.43.6 — UI scope detection upgraded from grep heuristic to AI semantic.**
+Retro from a real BE-only sub-phase: SPECS line 5 ("Phase này CHỈ build backend
+APIs ... UI portal Ở Phase 6/7/8") was misclassified `has_ui=true` because
+keyword grep matched "UI" inside the EXCLUSION clause. Haiku 4.5 semantic
+analysis distinguishes scope-inclusion vs scope-exclusion ("UI deferred to
+Phase X"). Result is cached at `${PHASE_DIR}/.ui-scope.json` as authoritative
+ground truth consumed by:
+  - this step's scaffold/extract gating
+  - validators/verify-ui-scope-coherence.py (cross-checks PLAN.md FE-task count)
+  - downstream UI steps 2b6_ui_spec / 2b6b / 2b6c
 
 Blueprint owns this. It must not rely on the operator remembering a
 separate `/vg:design-scaffold` command. If the phase has UI:
@@ -146,6 +157,47 @@ elif [[ "$ARGUMENTS" =~ --skip-design-discovery ]]; then
   echo "⚠ --skip-design-discovery set — Form B 'no-asset:greenfield-explicit-skip' will trigger /vg:accept critical block"
 else
   mkdir -p "${PHASE_DIR}/.tmp"
+
+  # v2.43.6 — AI semantic UI scope detection (replaces grep heuristic)
+  UI_SCOPE_JSON="${PHASE_DIR}/.ui-scope.json"
+  AI_SCOPE_DETECT_ENABLED=$(vg_config_get ui_scope.ai_detect_enabled true 2>/dev/null || echo true)
+
+  if [ "$AI_SCOPE_DETECT_ENABLED" = "true" ] && { [ ! -f "$UI_SCOPE_JSON" ] || [[ "$ARGUMENTS" =~ --redetect-ui-scope ]]; }; then
+    echo "▸ Detecting UI scope via Haiku semantic analysis..."
+    DETECT_FLAGS=()
+    [[ "$ARGUMENTS" =~ --redetect-ui-scope ]] && DETECT_FLAGS+=( --force )
+    "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/preflight/detect-ui-scope.py" \
+      --phase-dir "${PHASE_DIR}" \
+      --output ".ui-scope.json" \
+      "${DETECT_FLAGS[@]}" >/dev/null 2>&1
+    UI_SCOPE_RC=$?
+
+    case "$UI_SCOPE_RC" in
+      0) echo "✓ UI scope auto-applied (confidence ≥ 0.8). See $UI_SCOPE_JSON" ;;
+      2)
+        echo "⚠ UI scope tie-break needed (confidence 0.5-0.8). Accept low-confidence result with debt log."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "blueprint.ui_scope_tie_break" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" 2>/dev/null || true
+        ;;
+      3)
+        echo "⛔ UI scope confidence < 0.5 — operator must answer 'Phase này có UI không?'"
+        echo "   Edit ${UI_SCOPE_JSON} manually (set has_ui + confidence + method=user-confirmed) or improve SPECS clarity then re-run with --redetect-ui-scope."
+        if [[ ! "$ARGUMENTS" =~ --override-reason ]]; then
+          exit 1
+        fi
+        ;;
+      *) echo "⚠ detect-ui-scope.py exit=${UI_SCOPE_RC} — falling back to legacy grep heuristic" ;;
+    esac
+  fi
+
+  # Read authoritative UI scope decision from .ui-scope.json (AI cache)
+  HAS_UI=""
+  if [ -f "$UI_SCOPE_JSON" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$UI_SCOPE_JSON")
+    UI_SCOPE_METHOD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('method','unknown'))" "$UI_SCOPE_JSON")
+    UI_SCOPE_DEFERRED=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('deferred_to') or 'none')" "$UI_SCOPE_JSON")
+    echo "  has_ui=${HAS_UI} (method=${UI_SCOPE_METHOD}, deferred_to=${UI_SCOPE_DEFERRED})"
+  fi
+
   BLUEPRINT_DESIGN_PREFLIGHT_JSON="${PHASE_DIR}/.tmp/blueprint-design-preflight.json"
   # v2.42.3 — forward --allow-shared-mockup-reuse from blueprint args.
   # Use this when phase legitimately reuses unchanged Phase 1 slugs
@@ -153,6 +205,8 @@ else
   # per-phase mockups otherwise (closes silent-pass gap on UI phases).
   PREFLIGHT_EXTRA=()
   [[ "$ARGUMENTS" =~ --allow-shared-mockup-reuse ]] && PREFLIGHT_EXTRA+=( --allow-shared-mockup-reuse )
+  # Legacy preflight still runs to import mockups + report needs_scaffold/needs_extract.
+  # We trust HAS_UI from .ui-scope.json (AI) over its keyword-grep field of the same name.
   "${PYTHON_BIN:-python3}" "${REPO_ROOT}/.claude/scripts/blueprint-design-preflight.py" \
     --phase-dir "${PHASE_DIR}" \
     --repo-root "${REPO_ROOT}" \
@@ -161,7 +215,11 @@ else
     --output "${BLUEPRINT_DESIGN_PREFLIGHT_JSON}" \
     "${PREFLIGHT_EXTRA[@]}" >/dev/null
 
-  HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+  # Fallback: if .ui-scope.json missing (AI detect disabled/unavailable), use legacy grep result.
+  if [ -z "${HAS_UI}" ]; then
+    HAS_UI=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('has_ui') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
+    echo "ℹ HAS_UI from legacy grep heuristic (.ui-scope.json not generated): ${HAS_UI}"
+  fi
   IMPORTED_COUNT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print(d.get('imported_count',0))" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_SCAFFOLD=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_scaffold') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
   NEEDS_EXTRACT=$("${PYTHON_BIN:-python3}" -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); print('1' if d.get('needs_extract') else '0')" "$BLUEPRINT_DESIGN_PREFLIGHT_JSON")
@@ -3163,6 +3221,33 @@ if [ -x "$TS_VAL" ]; then
       if [[ ! "$ARGUMENTS" =~ --skip-task-schema ]]; then exit 1; fi
       ;;
     *) echo "ℹ P16 task-schema: $TS_V" ;;
+  esac
+fi
+
+# Gate E (v2.43.6): ui-scope-coherence — cross-check .ui-scope.json (AI semantic
+# detection from step 0_design_discovery) against PLAN.md FE-task count.
+# BLOCK on (a) has_ui=true + 0 FE tasks (silent UI gap, L-002 class) OR
+#         (b) has_ui=false + ≥1 FE task (scope leak into BE-only phase).
+US_VAL="${REPO_ROOT}/.claude/scripts/validators/verify-ui-scope-coherence.py"
+if [ -x "$US_VAL" ]; then
+  ${PYTHON_BIN} "$US_VAL" --phase "${PHASE_NUMBER}" \
+      > "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>&1 || true
+  US_V=$(${PYTHON_BIN} -c "import json,sys; print(json.load(open(sys.argv[1])).get('verdict','SKIP'))" \
+        "${VG_TMP:-${PHASE_DIR}/.vg-tmp}/ui-scope-coherence.json" 2>/dev/null)
+  case "$US_V" in
+    PASS|WARN) echo "✓ ui-scope-coherence: $US_V" ;;
+    BLOCK)
+      echo "⛔ ui-scope-coherence: BLOCK — see ${VG_TMP}/ui-scope-coherence.json" >&2
+      echo "   Mismatch between .ui-scope.json (AI scope decision) and PLAN.md FE-task count." >&2
+      echo "   Either re-plan to match scope, edit SPECS to match PLAN, or override:" >&2
+      echo "     --override-reason='<issue-id>' (logs OVERRIDE-DEBT, not recommended)" >&2
+      echo "     --skip-ui-scope-coherence (downgrade gate)" >&2
+      echo "     ${PYTHON_BIN} ${US_VAL} --phase ${PHASE_NUMBER} --allow-mismatch (downgrade BLOCK→WARN)" >&2
+      if [[ ! "$ARGUMENTS" =~ --override-reason ]] && [[ ! "$ARGUMENTS" =~ --skip-ui-scope-coherence ]]; then
+        exit 1
+      fi
+      ;;
+    *) echo "ℹ ui-scope-coherence: $US_V" ;;
   esac
 fi
 

--- a/commands/vg/blueprint.md
+++ b/commands/vg/blueprint.md
@@ -3691,6 +3691,54 @@ mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "3_complete" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/3_complete.done"
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator mark-step blueprint 3_complete 2>/dev/null || true
 
+# v2.46 Phase 6 traceability gates — closes "AI bịa goal/decision" gap.
+# Migration: VG_TRACEABILITY_MODE=warn for pre-2026-05-01 phases.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+
+# v2.46 L6a — goal frontmatter completeness (spec_ref + decisions + business_rules + expected_assertion)
+TRACE_VAL=".claude/scripts/validators/verify-goal-traceability.py"
+if [ -f "$TRACE_VAL" ]; then
+  TRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-traceability-gaps ]] && TRACE_FLAGS="$TRACE_FLAGS --allow-traceability-gaps"
+  ${PYTHON_BIN:-python3} "$TRACE_VAL" --phase "${PHASE_NUMBER}" $TRACE_FLAGS
+  TRACE_RC=$?
+  if [ "$TRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Goal traceability gate failed at blueprint."
+    echo "   Goals must cite: spec_ref, decisions, business_rules, expected_assertion, goal_class."
+    echo "   See: commands/vg/_shared/templates/TEST-GOAL-enriched-template.md (v2.46 Phase 6 enrichment)"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "blueprint.traceability_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 — D-XX → tasks coverage
+DTASK_VAL=".claude/scripts/validators/verify-decisions-to-tasks.py"
+if [ -f "$DTASK_VAL" ]; then
+  DTASK_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-uncovered-decisions ]] && DTASK_FLAGS="$DTASK_FLAGS --allow-uncovered-decisions"
+  ${PYTHON_BIN:-python3} "$DTASK_VAL" --phase "${PHASE_NUMBER}" $DTASK_FLAGS
+  DTASK_RC=$?
+  if [ "$DTASK_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions → tasks coverage gate failed at blueprint."
+    echo "   Every D-XX in CONTEXT must be referenced in ≥1 PLAN*.md task."
+    exit 1
+  fi
+fi
+
+# v2.46 — D-XX → goals coverage
+DGOAL_VAL=".claude/scripts/validators/verify-decisions-to-goals.py"
+if [ -f "$DGOAL_VAL" ]; then
+  DGOAL_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-uncovered-decisions ]] && DGOAL_FLAGS="$DGOAL_FLAGS --allow-uncovered-decisions"
+  ${PYTHON_BIN:-python3} "$DGOAL_VAL" --phase "${PHASE_NUMBER}" $DGOAL_FLAGS
+  DGOAL_RC=$?
+  if [ "$DGOAL_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions → goals coverage gate failed at blueprint."
+    echo "   Every D-XX must be cited by ≥1 goal in TEST-GOALS.md (decisions: [D-XX])."
+    exit 1
+  fi
+fi
+
 # v2.2 — terminal emit + run-complete. Validators fire here; BLOCK on violations.
 PLAN_COUNT=$(ls "${PHASE_DIR}"/PLAN*.md 2>/dev/null | wc -l | tr -d ' ')
 ENDPOINT_COUNT=$(grep -c '^## ' "${PHASE_DIR}/API-CONTRACTS.md" 2>/dev/null || echo 0)

--- a/commands/vg/build.md
+++ b/commands/vg/build.md
@@ -3945,6 +3945,23 @@ No way to skip via "promise" — events.db evidence required (OHOK-7/8).
 ## Step 12: Run-complete (validators fire, BLOCK on violations)
 
 ```bash
+# v2.46 Phase 6 — business rule constants in code
+# Closes "code drift from D-XX values" gap (e.g., D-46 says 5 but code has 3).
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+BIZRULE_VAL=".claude/scripts/validators/verify-business-rule-implemented.py"
+if [ -f "$BIZRULE_VAL" ]; then
+  BIZRULE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-rule-not-implemented ]] && BIZRULE_FLAGS="$BIZRULE_FLAGS --allow-rule-not-implemented"
+  ${PYTHON_BIN:-python3} "$BIZRULE_VAL" --phase "${PHASE_NUMBER:-${PHASE_ARG}}" $BIZRULE_FLAGS
+  BIZRULE_RC=$?
+  if [ "$BIZRULE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Business-rule-implemented gate failed: code constants drift from CONTEXT decisions."
+    echo "   Verify expected_assertion values appear as constants in apps/packages/infra source."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "build.bizrule_blocked" --payload "{\"phase\":\"${PHASE_NUMBER:-${PHASE_ARG}}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # Emit final completion telemetry only after the CrossAI loop has reached an
 # accepted terminal state. run-complete validates this event in the same call.
 SUMMARY_COUNT=$(ls "${PHASE_DIR}"/SUMMARY*.md 2>/dev/null | wc -l | tr -d " ")

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -5828,6 +5828,33 @@ if [ -f "$MATRIX_LINK_VAL" ]; then
   fi
 fi
 
+# v2.46 anti-performative-review: ép scanner phải submit mutation goals,
+# không được Cancel modal rồi mark passed. Phase 3.2 dogfood (2026-05-01) tìm
+# 5 false-pass goals (G-31/G-34/G-35/G-44/G-52) modal opened nhưng chưa bao giờ
+# submit. Validator này check goal_sequences.steps[] có submit click + 2xx
+# network entry trước khi cho phép run-complete.
+MUT_SUBMIT_VAL=".claude/scripts/validators/verify-mutation-actually-submitted.py"
+if [ -f "$MUT_SUBMIT_VAL" ]; then
+  MUT_FLAGS="--severity block"
+  if [[ "${ARGUMENTS}" =~ --allow-cancel-only-mutations ]]; then
+    MUT_FLAGS="--severity block --allow-cancel-only-mutations"
+  fi
+  ${PYTHON_BIN:-python3} "$MUT_SUBMIT_VAL" --phase "${PHASE_NUMBER}" $MUT_FLAGS
+  MUT_RC=$?
+  if [ "$MUT_RC" -ne 0 ]; then
+    echo "⛔ Review mutation-actually-submitted gate failed."
+    echo "   Mutation goals marked passed without actual submit click + 2xx network."
+    echo "   This is the 'performative review' meta-bug: scanner Cancel modal → never test"
+    echo "   happy path → CSRF/auth/idempotency bugs slip through to user."
+    echo "   Fix path:"
+    echo "     1. Re-run /vg:review ${PHASE_NUMBER} với scanner prompt yêu cầu SUBMIT (sandbox = disposable seed)"
+    echo "     2. OR --allow-cancel-only-mutations override (logs OVERRIDE-DEBT — legitimate"
+    echo "        only nếu phase explicitly không muốn mutate)"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.mutation_submit_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
 RUN_RC=$?
 if [ $RUN_RC -ne 0 ]; then

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -5855,6 +5855,99 @@ if [ -f "$MUT_SUBMIT_VAL" ]; then
   fi
 fi
 
+# v2.46 Phase 6 enrichment: traceability + RCRURD enforcement.
+# Closes "AI bịa goal/decision/business-rule" + "scanner stops too early".
+# Migration: VG_TRACEABILITY_MODE=warn for pre-2026-05-01 phases (set in
+# vg.config.md). New phases default to block.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+
+# v2.46 L4 — RCRURD step depth (per goal_class threshold)
+RCRURD_VAL=".claude/scripts/validators/verify-rcrurd-depth.py"
+if [ -f "$RCRURD_VAL" ]; then
+  RCRURD_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-shallow-scans ]] && RCRURD_FLAGS="$RCRURD_FLAGS --allow-shallow-scans"
+  ${PYTHON_BIN:-python3} "$RCRURD_VAL" --phase "${PHASE_NUMBER}" $RCRURD_FLAGS
+  RCRURD_RC=$?
+  if [ "$RCRURD_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ RCRURD depth gate failed — scanner stopped too early on mutation goals."
+    echo "   See scanner-report-contract.md 'RCRURD Lifecycle Protocol'. Goal class drives min steps."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_depth_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — asserted_quote vs business rule similarity
+ASSERTED_VAL=".claude/scripts/validators/verify-asserted-rule-match.py"
+if [ -f "$ASSERTED_VAL" ]; then
+  ASSERTED_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-asserted-drift ]] && ASSERTED_FLAGS="$ASSERTED_FLAGS --allow-asserted-drift"
+  ${PYTHON_BIN:-python3} "$ASSERTED_VAL" --phase "${PHASE_NUMBER}" $ASSERTED_FLAGS
+  ASSERTED_RC=$?
+  if [ "$ASSERTED_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Asserted-rule-match gate failed — scanner asserted_quote drifts from BR-NN text."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.asserted_drift_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — replay-evidence (structural + optional curl replay)
+REPLAY_VAL=".claude/scripts/validators/verify-replay-evidence.py"
+if [ -f "$REPLAY_VAL" ]; then
+  REPLAY_FLAGS="--severity warn"  # default warn — auth fixture not always available
+  [[ "${ARGUMENTS}" =~ --enable-replay ]] && REPLAY_FLAGS="--severity ${TRACE_MODE} --enable-replay"
+  ${PYTHON_BIN:-python3} "$REPLAY_VAL" --phase "${PHASE_NUMBER}" $REPLAY_FLAGS
+  REPLAY_RC=$?
+  if [ "$REPLAY_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ] && [[ "${ARGUMENTS}" =~ --enable-replay ]]; then
+    echo "⛔ Replay-evidence gate failed — scanner network claims can't be verified."
+    exit 1
+  fi
+fi
+
+# v2.46 L4 — cross-phase decision validity (D-XX from earlier phase still active)
+CROSS_VAL=".claude/scripts/validators/verify-cross-phase-decision-validity.py"
+if [ -f "$CROSS_VAL" ]; then
+  CROSS_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-stale-decisions ]] && CROSS_FLAGS="$CROSS_FLAGS --allow-stale-decisions"
+  ${PYTHON_BIN:-python3} "$CROSS_VAL" --phase "${PHASE_NUMBER}" $CROSS_FLAGS
+  CROSS_RC=$?
+  if [ "$CROSS_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Cross-phase decision validity failed — goal cites revoked/missing D-XX."
+    exit 1
+  fi
+fi
+
+# v2.46 L6 — adversarial scanner-business-alignment verifier
+# Two-phase: emit prompts → orchestrator spawns Haiku verifier per prompt →
+# re-run validator with --verifier-results to gate.
+ALIGN_VAL=".claude/scripts/validators/verify-scanner-business-alignment.py"
+if [ -f "$ALIGN_VAL" ]; then
+  PROMPTS_FILE="${PHASE_DIR}/.tmp/business-alignment-prompts.jsonl"
+  RESULTS_FILE="${PHASE_DIR}/.tmp/business-alignment-results.jsonl"
+  mkdir -p "$(dirname "$PROMPTS_FILE")" 2>/dev/null
+  ${PYTHON_BIN:-python3} "$ALIGN_VAL" --phase "${PHASE_NUMBER}" --prompts-out "$PROMPTS_FILE" 2>&1 | head -3
+  PROMPT_COUNT=$(wc -l < "$PROMPTS_FILE" 2>/dev/null | tr -d ' ' || echo 0)
+
+  if [ "$PROMPT_COUNT" -gt 0 ]; then
+    echo ""
+    echo "📋 Business alignment verifier needs ${PROMPT_COUNT} adversarial check(s)."
+    echo "   Orchestrator should spawn isolated Haiku per prompt + write JSONL results to:"
+    echo "     ${RESULTS_FILE}"
+    echo "   Then re-run review with --verifier-results=${RESULTS_FILE}"
+    echo ""
+    # If results file exists from prior orchestrator pass, gate now
+    if [ -f "$RESULTS_FILE" ]; then
+      ALIGN_FLAGS="--severity ${TRACE_MODE} --verifier-results ${RESULTS_FILE}"
+      [[ "${ARGUMENTS}" =~ --allow-business-drift ]] && ALIGN_FLAGS="$ALIGN_FLAGS --allow-business-drift"
+      ${PYTHON_BIN:-python3} "$ALIGN_VAL" --phase "${PHASE_NUMBER}" $ALIGN_FLAGS
+      ALIGN_RC=$?
+      if [ "$ALIGN_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+        echo "⛔ Business alignment gate failed — adversarial verifier flagged drift."
+        exit 1
+      fi
+    fi
+  fi
+fi
+
 "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete
 RUN_RC=$?
 if [ $RUN_RC -ne 0 ]; then

--- a/commands/vg/scope.md
+++ b/commands/vg/scope.md
@@ -1290,6 +1290,23 @@ git add "${PHASE_DIR}/CONTEXT.md" "${PHASE_DIR}/DISCUSSION-LOG.md" \
   git add "${PHASE_DIR}/.contract-pins.json"
 git commit -m "scope(${PHASE_NUMBER}): ${DECISION_COUNT} decisions, ${ENDPOINT_COUNT} endpoints, ${TEST_SCENARIO_COUNT} test scenarios"
 
+# v2.46 Phase 6 — D-XX trace to user answer in DISCUSSION-LOG
+# Closes "AI paraphrases user answer wrongly into D-XX" gap.
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+DTRACE_VAL=".claude/scripts/validators/verify-decisions-trace.py"
+if [ -f "$DTRACE_VAL" ]; then
+  DTRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-decisions-untraced ]] && DTRACE_FLAGS="$DTRACE_FLAGS --allow-decisions-untraced"
+  ${PYTHON_BIN:-python3} "$DTRACE_VAL" --phase "${PHASE_NUMBER}" $DTRACE_FLAGS
+  DTRACE_RC=$?
+  if [ "$DTRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Decisions-trace gate failed: D-XX statements drift from DISCUSSION-LOG user answers."
+    echo "   Add 'Quote source: DISCUSSION-LOG.md#round-N' field to each D-XX in CONTEXT.md."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "scope.decisions_trace_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2: mark final step + emit completion event + invoke run-complete.
 # Orchestrator runs phase-exists + context-structure validators, emits
 # run.completed or run.blocked based on contract check. No bash catch-up

--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -3772,6 +3772,22 @@ esac
 ```
 
 ```bash
+# v2.46 Phase 6 — test traces to goal + business_rule
+TRACE_MODE="${VG_TRACEABILITY_MODE:-block}"
+TTRACE_VAL=".claude/scripts/validators/verify-test-traces-to-rule.py"
+if [ -f "$TTRACE_VAL" ]; then
+  TTRACE_FLAGS="--severity ${TRACE_MODE}"
+  [[ "${ARGUMENTS}" =~ --allow-test-untraced ]] && TTRACE_FLAGS="$TTRACE_FLAGS --allow-test-untraced"
+  ${PYTHON_BIN:-python3} "$TTRACE_VAL" --phase "${PHASE_NUMBER}" $TTRACE_FLAGS
+  TTRACE_RC=$?
+  if [ "$TTRACE_RC" -ne 0 ] && [ "$TRACE_MODE" = "block" ]; then
+    echo "⛔ Test-traces-to-rule gate failed: .spec.ts files don't cite goal_id + BR-NN."
+    echo "   Header format required: '// Goal: G-XX | Rule: BR-NN | Assertion: <verbatim quote>'"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "test.trace_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.2 — terminal emit + run-complete for /vg:test
 mkdir -p "${PHASE_DIR}/.step-markers" 2>/dev/null
 (type -t mark_step >/dev/null 2>&1 && mark_step "${PHASE_NUMBER:-unknown}" "complete" "${PHASE_DIR}") || touch "${PHASE_DIR}/.step-markers/complete.done"

--- a/scripts/preflight/detect-ui-scope.py
+++ b/scripts/preflight/detect-ui-scope.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""AI-driven UI scope detection for blueprint preflight (replaces grep heuristic).
+
+Spawns an isolated Haiku subagent (zero parent context) to read SPECS.md +
+CONTEXT.md and decide whether the phase has UI in scope. Output is cached to
+`{phase_dir}/.ui-scope.json` and consumed as authoritative ground truth by:
+
+  - blueprint.md step 0_design_discovery (gates 2b6_ui_spec / 2b6b / 2b6c)
+  - validators/verify-ui-scope-coherence.py (cross-check vs PLAN.md FE tasks)
+
+Why AI not grep:
+  Phase 4.3 example — SPECS line 5: "Phase này CHỈ build backend APIs...
+  UI portal Ở Phase 6/7/8". Keyword grep matches "UI" in the EXCLUSION
+  clause and falsely flags has_ui=true. AI semantic reading distinguishes
+  scope-inclusion ("phase này có UI") vs scope-exclusion ("UI deferred to
+  Phase X"). Same lesson L-002 motivated Phase 19 D-04 view decomposition.
+
+Confidence routing (matches goal-classifier.sh pattern):
+  - >= 0.8: auto-apply, write cache, exit 0
+  - 0.5-0.8: emit pending JSON for caller to spawn Haiku tie-break, exit 2
+  - < 0.5: emit pending JSON for caller to AskUserQuestion, exit 3
+
+Output JSON schema (.ui-scope.json):
+  {
+    "has_ui": bool,
+    "confidence": float (0.0..1.0),
+    "evidence": str (quoted phrase from SPECS/CONTEXT),
+    "deferred_to": str|null (e.g. "Phase 6"),
+    "ui_kinds": list[str] (e.g. ["dashboard","form","modal"]),
+    "model": str ("haiku-4.5" or fallback),
+    "detected_at": str (ISO8601 UTC),
+    "method": "ai-semantic" | "user-confirmed" | "fallback-grep"
+  }
+
+Usage:
+  python3 detect-ui-scope.py --phase-dir .vg/phases/04.3-... --output .ui-scope.json
+  python3 detect-ui-scope.py --phase-dir ... --force          # bypass cache
+  python3 detect-ui-scope.py --phase-dir ... --grep-fallback  # skip AI, use legacy grep
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+HAIKU_MODEL = "claude-haiku-4-5-20251001"
+CLAUDE_CLI_TIMEOUT_S = 120
+
+PROMPT_TEMPLATE = """You are a phase scope analyzer. Read the SPECS and CONTEXT below and decide
+whether THIS phase ships user-facing UI code (web pages, mobile screens, admin
+dashboards, components) — OR — is backend-only / infra / data / tooling.
+
+CRITICAL distinction: many specs mention UI as EXCLUSION ("UI portal in Phase 6/7/8"
+or "KHÔNG làm trong phase này: UI portal"). That means UI is OUT of scope here.
+Similarly "consumed by Phase X" or "Phase X owns UI" means UI is downstream.
+
+You output ONLY a single-line JSON object. No prose, no code fence, no preamble.
+
+Schema:
+{{
+  "has_ui": true|false,
+  "confidence": 0.0-1.0,
+  "evidence": "<one-sentence quote or paraphrase from SPECS/CONTEXT supporting the decision>",
+  "deferred_to": "<Phase X>" or null,
+  "ui_kinds": ["dashboard","form","modal","table","wizard","sidebar"] or []
+}}
+
+Confidence guide:
+  0.9-1.0 — explicit clause "this phase has UI" or "this phase is backend-only / no UI"
+  0.7-0.9 — strong inference from actor list (merchant clicks form) or file paths (.tsx)
+  0.5-0.7 — mixed signals or short SPECS
+  0.0-0.5 — ambiguous, not enough evidence
+
+═════════════════════════════════════════════════════════════════════════
+SPECS.md
+═════════════════════════════════════════════════════════════════════════
+{specs}
+
+═════════════════════════════════════════════════════════════════════════
+CONTEXT.md (decisions excerpt)
+═════════════════════════════════════════════════════════════════════════
+{context}
+
+═════════════════════════════════════════════════════════════════════════
+
+Output the JSON object on a single line. Nothing else.
+"""
+
+
+def trim(text: str, max_lines: int = 200) -> str:
+    """Limit prompt context to keep token cost low + Haiku focused."""
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    head = lines[: max_lines * 2 // 3]
+    tail = lines[-(max_lines // 3):]
+    return "\n".join(head + ["", f"... [{len(lines) - max_lines} lines truncated] ...", ""] + tail)
+
+
+def parse_haiku_output(raw: str) -> dict | None:
+    """Extract single JSON object from Haiku stdout. Tolerate prose preamble."""
+    raw = raw.strip()
+    # Try whole output first
+    try:
+        return json.loads(raw)
+    except Exception:
+        pass
+    # Find first `{...}` block
+    m = re.search(r"\{[^{}]*\"has_ui\"[^{}]*\}", raw, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except Exception:
+            pass
+    # Fallback: try line-by-line
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("{") and "has_ui" in line:
+            try:
+                return json.loads(line)
+            except Exception:
+                continue
+    return None
+
+
+def grep_fallback(specs: str, context: str) -> dict:
+    """Legacy heuristic — only used when AI unavailable. Conservative.
+
+    Inclusion signals: actor list + file paths + UI verbs.
+    Exclusion signals: "Phase này CHỈ build backend", "UI portal ở Phase X",
+    "no UI", "API only".
+    """
+    text = (specs + "\n" + context).lower()
+
+    # Strong exclusions first
+    exclusion_patterns = [
+        r"\bui portal\b.*\bphase\b",
+        r"\bphase này chỉ build\b.*\bbackend\b",
+        r"\bbackend[- ]only\b",
+        r"\bno ui\b",
+        r"\bapi only\b",
+        r"\bui.*ở phase \d+\b",
+        r"\bdefer.*ui.*to phase\b",
+    ]
+    for pat in exclusion_patterns:
+        if re.search(pat, text, re.IGNORECASE):
+            return {
+                "has_ui": False,
+                "confidence": 0.7,
+                "evidence": f"grep matched exclusion pattern: {pat}",
+                "deferred_to": None,
+                "ui_kinds": [],
+            }
+
+    # Inclusion signals (count weighted)
+    score = 0
+    if re.search(r"\.tsx\b|\.jsx\b|\.vue\b|\.svelte\b", text):
+        score += 3
+    if re.search(r"\bapps/(admin|merchant|vendor|web)/", text):
+        score += 3
+    if re.search(r"\b(dashboard|form|modal|wizard|sidebar|topbar)\b", text):
+        score += 2
+    if re.search(r"\bgiao diện\b|\bmàn hình\b", text):
+        score += 2
+
+    has_ui = score >= 3
+    return {
+        "has_ui": has_ui,
+        "confidence": min(0.6, score / 10),  # cap fallback confidence at 0.6
+        "evidence": f"grep heuristic score={score}",
+        "deferred_to": None,
+        "ui_kinds": [],
+    }
+
+
+def invoke_haiku(specs: str, context: str) -> tuple[dict | None, str]:
+    """Invoke Haiku via `claude --model haiku -p`. Returns (parsed_json, raw_stdout)."""
+    prompt = PROMPT_TEMPLATE.format(
+        specs=trim(specs, 250),
+        context=trim(context, 200),
+    )
+
+    cmd = [
+        "claude",
+        "--model", HAIKU_MODEL,
+        "-p",
+        prompt,
+    ]
+
+    # CRITICAL: run subprocess from /tmp so VG Stop hook doesn't fire on exit
+    # (Stop hook lives in .claude/settings.json under project root and would
+    # intercept stdout to inject orchestrator verifier output otherwise).
+    # Using --bare instead would skip auth/keychain — fails in interactive setups.
+    import tempfile
+    sandbox_cwd = tempfile.gettempdir()
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CLAUDE_CLI_TIMEOUT_S,
+            cwd=sandbox_cwd,
+        )
+    except FileNotFoundError:
+        return None, "claude CLI not found in PATH"
+    except subprocess.TimeoutExpired:
+        return None, f"claude CLI timeout after {CLAUDE_CLI_TIMEOUT_S}s"
+    except Exception as e:
+        return None, f"claude CLI error: {e}"
+
+    if proc.returncode != 0:
+        return None, f"claude exit={proc.returncode} stderr={proc.stderr[:500]}"
+
+    parsed = parse_haiku_output(proc.stdout)
+    return parsed, proc.stdout
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--phase-dir", required=True, help="phase directory (contains SPECS.md, CONTEXT.md)")
+    p.add_argument("--output", default=".ui-scope.json", help="output JSON path (relative to phase-dir)")
+    p.add_argument("--force", action="store_true", help="bypass cache, re-detect")
+    p.add_argument("--grep-fallback", action="store_true", help="skip AI, use legacy grep heuristic")
+    p.add_argument("--quiet", action="store_true", help="suppress narrative; emit only JSON to stdout")
+    args = p.parse_args()
+
+    phase_dir = Path(args.phase_dir).resolve()
+    out_path = phase_dir / args.output
+
+    if not phase_dir.is_dir():
+        print(f"⛔ phase dir not found: {phase_dir}", file=sys.stderr)
+        return 1
+
+    # Cache hit
+    if out_path.exists() and not args.force:
+        cached = json.loads(out_path.read_text(encoding="utf-8"))
+        if not args.quiet:
+            print(f"✓ cached: has_ui={cached.get('has_ui')} confidence={cached.get('confidence')} ({out_path})", file=sys.stderr)
+        print(json.dumps(cached))
+        return 0
+
+    specs_path = phase_dir / "SPECS.md"
+    context_path = phase_dir / "CONTEXT.md"
+
+    if not specs_path.exists():
+        print(f"⛔ SPECS.md not found: {specs_path}", file=sys.stderr)
+        return 1
+
+    specs = specs_path.read_text(encoding="utf-8", errors="ignore")
+    context = context_path.read_text(encoding="utf-8", errors="ignore") if context_path.exists() else ""
+
+    if args.grep_fallback:
+        result = grep_fallback(specs, context)
+        result["model"] = "fallback-grep"
+        result["method"] = "fallback-grep"
+    else:
+        if not args.quiet:
+            print(f"▸ Detecting UI scope via Haiku ({HAIKU_MODEL})...", file=sys.stderr)
+        parsed, raw = invoke_haiku(specs, context)
+        if parsed is None:
+            print(f"⚠ Haiku failed ({raw[:200]}), falling back to grep heuristic", file=sys.stderr)
+            result = grep_fallback(specs, context)
+            result["model"] = "fallback-grep"
+            result["method"] = "fallback-grep-after-ai-failure"
+            result["ai_error"] = raw[:200]
+        else:
+            result = parsed
+            result["model"] = HAIKU_MODEL
+            result["method"] = "ai-semantic"
+
+    # Required fields normalization
+    result.setdefault("has_ui", False)
+    result.setdefault("confidence", 0.0)
+    result.setdefault("evidence", "")
+    result.setdefault("deferred_to", None)
+    result.setdefault("ui_kinds", [])
+    result["detected_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+    result["phase_dir"] = str(phase_dir)
+
+    # Confidence band routing
+    confidence = float(result.get("confidence", 0.0))
+    if confidence >= 0.8:
+        result["band"] = "auto"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"✓ has_ui={result['has_ui']} confidence={confidence:.2f} (AUTO-APPLY)\n"
+                f"  evidence: {result['evidence'][:120]}\n"
+                f"  written: {out_path}",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 0
+    elif confidence >= 0.5:
+        result["band"] = "tie-break-needed"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"⚠ has_ui={result['has_ui']} confidence={confidence:.2f} (TIE-BREAK NEEDED)\n"
+                f"  caller should spawn second AI with adversarial prompt or AskUserQuestion",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 2
+    else:
+        result["band"] = "user-confirmation-needed"
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        if not args.quiet:
+            print(
+                f"⛔ has_ui={result['has_ui']} confidence={confidence:.2f} (USER CONFIRMATION REQUIRED)\n"
+                f"  caller should AskUserQuestion: 'Phase này có UI không?'",
+                file=sys.stderr,
+            )
+        print(json.dumps(result))
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validators/_traceability.py
+++ b/scripts/validators/_traceability.py
@@ -1,0 +1,248 @@
+"""Shared helpers for traceability validators (v2.46+).
+
+Closes Phase 3.2 dogfood gap: AI bịa goal/decision/business-rule. Each
+validator forms one link in the chain SPECS → CONTEXT → BLUEPRINT → BUILD
+→ REVIEW → TEST → ACCEPT. Helpers here parse upstream artifacts so each
+validator can cross-check downstream claims.
+
+Migration: validators support `--severity warn` for pre-2026-05-01 phases
+that don't have new traceability fields populated yet. Defaults to block.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def parse_yaml_frontmatter_block(body: str, key: str) -> str:
+    """Extract YAML-style field value from goal block body.
+
+    Goals in TEST-GOALS.md use `**Key:**` markdown OR `key:` YAML format.
+    Tries both. Returns raw value (string) or empty string if not found.
+    """
+    # Try **Key:** markdown format
+    m = re.search(
+        rf"^\*\*{re.escape(key)}:?\*\*\s*(.+?)(?=^\*\*|\n##|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if m:
+        return m.group(1).strip()
+    # Try YAML key: value format
+    m = re.search(
+        rf"^{re.escape(key)}:\s*(.+?)(?=^\w+:|\n##|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if m:
+        return m.group(1).strip()
+    return ""
+
+
+def parse_list_field(raw: str) -> list[str]:
+    """Parse YAML inline list `[a, b, c]` OR comma-separated OR bullet list."""
+    if not raw:
+        return []
+    raw = raw.strip().rstrip(",")
+    # Inline list: [a, b, c]
+    m = re.match(r"^\[(.*)\]$", raw, re.DOTALL)
+    if m:
+        items = [
+            x.strip().strip('"').strip("'") for x in m.group(1).split(",") if x.strip()
+        ]
+        return items
+    # Bullet list (markdown)
+    if raw.lstrip().startswith("-"):
+        return [
+            line.lstrip("- ").strip().strip('"').strip("'")
+            for line in raw.splitlines()
+            if line.strip().startswith("-")
+        ]
+    # Comma-separated
+    if "," in raw:
+        return [x.strip().strip('"').strip("'") for x in raw.split(",") if x.strip()]
+    # Single item
+    return [raw.strip().strip('"').strip("'")]
+
+
+def find_decision_in_context(decision_id: str, context_text: str) -> str | None:
+    """Search CONTEXT.md for decision heading. Returns matched line or None.
+
+    Decision IDs: D-XX (same-phase) or P3.D-XX (cross-phase). Strip the
+    phase prefix to find local heading.
+    """
+    local_id = decision_id.split(".")[-1]  # "P3.D-46" → "D-46"
+    pat = re.compile(
+        rf"^##+\s*(?:\*\*)?{re.escape(local_id)}\b.*$",
+        re.MULTILINE,
+    )
+    m = pat.search(context_text)
+    if m:
+        return m.group(0).strip()
+    # Fallback — scan for "D-46" / "P3.D-46" anywhere in text
+    if decision_id in context_text or local_id in context_text:
+        return f"<inline reference to {decision_id} found, but no heading>"
+    return None
+
+
+def find_business_rule_in_log(rule_id: str, log_text: str) -> str | None:
+    """Search DISCUSSION-LOG.md for business rule definition.
+
+    Convention: "BR-NN: <statement>" or "**BR-NN**: <statement>".
+    """
+    pat = re.compile(
+        rf"^[*]*\*?{re.escape(rule_id)}\*?[*]*:?\s*(.+?)$",
+        re.MULTILINE,
+    )
+    m = pat.search(log_text)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def find_section_anchor(spec_ref: str, repo_root: Path) -> bool:
+    """Verify SPEC ref like 'SPECS.md#section-anchor' resolves to a heading.
+
+    Walks the file path component, then checks for matching heading.
+    """
+    if "#" not in spec_ref:
+        return False
+    file_part, anchor = spec_ref.split("#", 1)
+    # Resolve relative to current phase dir or repo root
+    candidates = [
+        repo_root / file_part,
+        Path(os.environ.get("PHASE_DIR", "")) / file_part if os.environ.get("PHASE_DIR") else None,
+    ]
+    for path in candidates:
+        if path and path.exists():
+            text = path.read_text(encoding="utf-8", errors="replace")
+            # Convert anchor (slug) to heading variants
+            anchor_norm = anchor.lower().replace("_", "-").replace(" ", "-")
+            for line in text.splitlines():
+                if not line.startswith("#"):
+                    continue
+                heading = line.lstrip("#").strip()
+                heading_slug = re.sub(r"[^\w\s-]", "", heading.lower()).strip().replace(" ", "-")
+                if heading_slug == anchor_norm or anchor_norm in heading_slug:
+                    return True
+    return False
+
+
+def text_similarity(a: str, b: str) -> float:
+    """Naive Jaccard similarity on word tokens. 0..1.
+
+    Used to check `expected_assertion` vs `asserted_quote` match without
+    requiring exact verbatim (which would be too brittle).
+    """
+    if not a or not b:
+        return 0.0
+    tokens_a = set(re.findall(r"\w+", a.lower()))
+    tokens_b = set(re.findall(r"\w+", b.lower()))
+    if not tokens_a or not tokens_b:
+        return 0.0
+    intersection = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    return len(intersection) / len(union)
+
+
+def get_traceability_mode() -> str:
+    """Read VG_TRACEABILITY_MODE env. Default 'block' for new phases.
+
+    Set 'warn' for migration phase — validators emit warnings but don't
+    block run-complete. Per-validator can also accept --severity flag.
+    """
+    return os.environ.get("VG_TRACEABILITY_MODE", "block").lower()
+
+
+def parse_goals_with_frontmatter(goals_text: str) -> list[dict]:
+    """Parse TEST-GOALS.md goals with full frontmatter extraction.
+
+    Returns list of dicts with: id, title, body (full text), and parsed
+    fields: spec_ref, decisions, business_rules, flow_ref, api_contracts,
+    expected_assertion, goal_class, priority, surface, mutation_evidence,
+    persistence_check.
+    """
+    goals = []
+    pattern = re.compile(
+        r"^##\s+Goal\s+(G-[\w.-]+):?\s*(.*?)$"
+        r"(?P<body>(?:(?!^##\s+Goal\s+).)*)",
+        re.MULTILINE | re.DOTALL,
+    )
+    for m in pattern.finditer(goals_text):
+        gid = m.group(1)
+        title = m.group(2).strip()
+        body = m.group("body") or ""
+        goal = {
+            "id": gid,
+            "title": title,
+            "body": body,
+            "priority": parse_yaml_frontmatter_block(body, "Priority").lower() or "important",
+            "surface": parse_yaml_frontmatter_block(body, "Surface").split()[0].strip().lower() or "ui",
+            "spec_ref": parse_yaml_frontmatter_block(body, "spec_ref")
+            or parse_yaml_frontmatter_block(body, "Spec ref"),
+            "decisions": parse_list_field(
+                parse_yaml_frontmatter_block(body, "decisions")
+                or parse_yaml_frontmatter_block(body, "Decisions")
+                or parse_yaml_frontmatter_block(body, "Dependencies")
+            ),
+            "business_rules": parse_list_field(
+                parse_yaml_frontmatter_block(body, "business_rules")
+                or parse_yaml_frontmatter_block(body, "Business rules")
+            ),
+            "flow_ref": parse_yaml_frontmatter_block(body, "flow_ref")
+            or parse_yaml_frontmatter_block(body, "Flow ref"),
+            "api_contracts": parse_list_field(
+                parse_yaml_frontmatter_block(body, "api_contracts")
+                or parse_yaml_frontmatter_block(body, "API contracts")
+            ),
+            "expected_assertion": parse_yaml_frontmatter_block(body, "expected_assertion")
+            or parse_yaml_frontmatter_block(body, "Expected assertion")
+            or parse_yaml_frontmatter_block(body, "Mutation evidence"),
+            "goal_class": parse_yaml_frontmatter_block(body, "goal_class").lower()
+            or parse_yaml_frontmatter_block(body, "Goal class").lower(),
+            "mutation_evidence": parse_yaml_frontmatter_block(body, "Mutation evidence"),
+            "persistence_check": parse_yaml_frontmatter_block(body, "Persistence check"),
+        }
+        goals.append(goal)
+    return goals
+
+
+# Goal class → minimum steps mapping (per scanner-report-contract RCRURD)
+GOAL_CLASS_MIN_STEPS = {
+    "readonly": 3,
+    "mutation": 6,
+    "approval": 8,
+    "wizard": 10,
+    "crud-roundtrip": 14,
+    "webhook": 4,
+}
+
+
+def infer_goal_class(goal: dict) -> str:
+    """Infer goal_class when not explicitly set (migration support)."""
+    explicit = goal.get("goal_class", "").strip().lower()
+    if explicit:
+        return explicit
+    surface = goal.get("surface", "").lower()
+    me = (goal.get("mutation_evidence") or "").lower()
+    title = (goal.get("title") or "").lower()
+    if surface == "webhook" or "webhook" in title:
+        return "webhook"
+    if "approve" in title or "approval" in title or "reject" in title:
+        return "approval"
+    if "wizard" in title or "step 1" in title or "step 2" in title or "multi-step" in title:
+        return "wizard"
+    if "crud" in title or "round-trip" in title:
+        return "crud-roundtrip"
+    if me and any(
+        k in me.lower() for k in ("create", "update", "delete", "submit", "200", "201")
+    ):
+        return "mutation"
+    return "readonly"
+
+
+def min_steps_for_goal(goal: dict) -> int:
+    """Resolve min_steps threshold for a goal."""
+    cls = infer_goal_class(goal)
+    return GOAL_CLASS_MIN_STEPS.get(cls, 3)

--- a/scripts/validators/registry.yaml
+++ b/scripts/validators/registry.yaml
@@ -777,6 +777,15 @@ validators:
     runtime_target_ms: 1500
     added_in: v2.12.0-phase-16
     description: P16 D-02 — classify PLAN tasks as xml/heading/mixed format. mode=legacy (default) PASS heading; mode=structured BLOCK heading; mode=both WARN heading. XML tasks require frontmatter `acceptance:` ≥1 entry. Migration enforcement.
+
+  - id: ui-scope-coherence
+    path: .claude/scripts/validators/verify-ui-scope-coherence.py
+    severity: block
+    phases_active: [blueprint]
+    domain: artifact
+    runtime_target_ms: 1000
+    added_in: v2.43.6
+    description: Cross-check `.ui-scope.json` (AI semantic detection from preflight/detect-ui-scope.py) vs PLAN.md FE-task count. BLOCK on mismatch — declares has_ui=true but PLAN has 0 FE tasks (silent UI gap, L-002 class) OR declares has_ui=false but PLAN has FE tasks (scope leak). Replaces grep heuristic in blueprint step 0_design_discovery.
   - id: crossai-output
     path: .claude/scripts/validators/verify-crossai-output.py
     severity: block

--- a/scripts/validators/verify-acceptance-traceability.py
+++ b/scripts/validators/verify-acceptance-traceability.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Verify full traceability chain at /vg:accept: scanner → goal → decision → spec.
+
+This is the FINAL gate before phase ships. Walks the chain end-to-end:
+  scanner output (RUNTIME-MAP) → goal frontmatter → decision (CONTEXT) →
+  business rule (DISCUSSION-LOG) → spec section (SPECS).
+
+Each link must resolve. Any broken link = BLOCK accept.
+
+Severity: BLOCK at /vg:accept hard gate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    find_business_rule_in_log,
+    find_decision_in_context,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify full traceability chain at accept")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument("--allow-traceability-gaps", action="store_true")
+    args = parser.parse_args()
+
+    out = Output(validator="acceptance-traceability")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        # Load all artifacts
+        goals_text = _read(phase_dir / "TEST-GOALS.md")
+        context_text = _read(phase_dir / "CONTEXT.md")
+        log_text = _read(phase_dir / "DISCUSSION-LOG.md")
+        specs_text = _read(phase_dir / "SPECS.md")
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+
+        if not goals_text:
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(goals_text)
+        try:
+            runtime = json.loads(_read(runtime_path)) if runtime_path.exists() else {}
+        except json.JSONDecodeError:
+            runtime = {}
+        sequences = runtime.get("goal_sequences") or {}
+
+        violations = 0
+        chain_status: list[tuple[str, str, str]] = []  # (goal_id, link, status)
+
+        for goal in goals:
+            gid = goal["id"]
+            seq = sequences.get(gid)
+            result = str(seq.get("result", "") if isinstance(seq, dict) else "").lower()
+            # Only verify goals claiming pass
+            if result not in {"passed", "pass", "ready"}:
+                continue
+
+            # Link 1: scanner output → goal
+            if not isinstance(seq, dict) or not seq.get("steps"):
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="chain_broken_scanner_to_goal",
+                        message=f"{gid}: scanner output missing or empty",
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_traceability_gaps),
+                )
+                continue
+
+            # Link 2: goal → decision
+            for d_ref in goal.get("decisions") or []:
+                local_id = d_ref.split(".")[-1]
+                # Same-phase decisions resolved in CONTEXT
+                if "." not in d_ref or d_ref.startswith("D-"):
+                    if not find_decision_in_context(local_id, context_text):
+                        violations += 1
+                        out.add(
+                            Evidence(
+                                type="chain_broken_goal_to_decision",
+                                message=f"{gid}: cites {d_ref} but not in CONTEXT.md",
+                            ),
+                            escalate=(args.severity == "block" and not args.allow_traceability_gaps),
+                        )
+
+            # Link 3: goal → business rule (DISCUSSION-LOG)
+            if log_text:
+                for rule_id in goal.get("business_rules") or []:
+                    if not find_business_rule_in_log(rule_id, log_text):
+                        violations += 1
+                        out.add(
+                            Evidence(
+                                type="chain_broken_goal_to_rule",
+                                message=f"{gid}: cites {rule_id} but not in DISCUSSION-LOG.md",
+                            ),
+                            escalate=(args.severity == "block" and not args.allow_traceability_gaps),
+                        )
+
+            # Link 4: goal → spec section
+            spec_ref = goal.get("spec_ref", "")
+            if spec_ref and "#" in spec_ref:
+                _, anchor = spec_ref.split("#", 1)
+                anchor_norm = anchor.lower().replace("_", "-").replace(" ", "-")
+                found = False
+                if specs_text:
+                    for line in specs_text.splitlines():
+                        if line.startswith("#"):
+                            heading = line.lstrip("#").strip()
+                            slug = re.sub(r"[^\w\s-]", "", heading.lower()).strip().replace(" ", "-")
+                            if slug == anchor_norm or anchor_norm in slug:
+                                found = True
+                                break
+                if not found:
+                    violations += 1
+                    out.add(
+                        Evidence(
+                            type="chain_broken_goal_to_spec",
+                            message=f"{gid}: spec_ref='{spec_ref}' anchor not found in SPECS.md",
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_traceability_gaps),
+                    )
+
+        if violations and (args.severity == "warn" or args.allow_traceability_gaps):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} traceability gap(s) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-asserted-rule-match.py
+++ b/scripts/validators/verify-asserted-rule-match.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Verify scanner asserted_quote per step matches business rule statement.
+
+Closes Phase 3.2 dogfood gap: scanner can claim "passed" but assert against
+its own paraphrase rather than the actual business rule. Code/test then
+appear to verify the rule but actually verify a drifted statement.
+
+Mechanism:
+  1. Parse TEST-GOALS.md `expected_assertion` per goal (verbatim BR-NN text)
+  2. Parse RUNTIME-MAP.json goal_sequences[gid].steps[].asserted_quote
+  3. Cross-check Jaccard similarity ≥ 0.5 (allows minor wording but blocks
+     drift like 'count threshold' → 'amount threshold')
+  4. Cross-check `asserted_rule` field references actual BR-NN in DISCUSSION-LOG.md
+
+Severity: BLOCK at /vg:review Phase 4.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    text_similarity,
+    find_business_rule_in_log,
+    infer_goal_class,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def collect_asserted_quotes(seq: dict) -> list[dict]:
+    """Walk sequence steps and collect asserted_quote / asserted_rule fields.
+
+    Scanner output schema (post-v2.46): each mutation step should have
+    `asserted_quote: <verbatim BR-NN text>` and `asserted_rule: BR-NN`.
+    """
+    quotes: list[dict] = []
+    steps = seq.get("steps") or []
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        aq = step.get("asserted_quote") or step.get("assertion") or step.get("expected")
+        ar = step.get("asserted_rule") or step.get("rule_id")
+        if aq or ar:
+            quotes.append(
+                {
+                    "step_idx": i,
+                    "do": step.get("do") or step.get("action") or "?",
+                    "asserted_quote": str(aq) if aq else "",
+                    "asserted_rule": str(ar) if ar else "",
+                }
+            )
+    return quotes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify asserted_quote matches BR text")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=0.5,
+    )
+    parser.add_argument(
+        "--allow-asserted-drift",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="asserted-rule-match")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        log_path = phase_dir / "DISCUSSION-LOG.md"
+        if not goals_path.exists() or not runtime_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError:
+            emit_and_exit(out)
+
+        log_text = _read(log_path) if log_path.exists() else ""
+        sequences = runtime.get("goal_sequences") or {}
+        if not isinstance(sequences, dict):
+            emit_and_exit(out)
+
+        violations = 0
+        for goal in goals:
+            gid = goal["id"]
+            seq = sequences.get(gid)
+            if not isinstance(seq, dict):
+                continue
+            result = str(seq.get("result", "")).lower()
+            if result not in {"passed", "pass", "ready", "yes"}:
+                continue
+
+            cls = infer_goal_class(goal)
+            # Only mutation/approval/crud goals need asserted_quote
+            if cls not in {"mutation", "approval", "crud-roundtrip", "wizard", "webhook"}:
+                continue
+
+            expected_assertion = goal.get("expected_assertion", "").strip()
+            if not expected_assertion:
+                continue  # No expected assertion declared; goal-traceability validator handles
+
+            quotes = collect_asserted_quotes(seq)
+            if not quotes:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="asserted_quote_missing",
+                        message=(
+                            f"{gid}: passed mutation goal but goal_sequences.steps has no "
+                            f"asserted_quote field. Scanner must record verbatim quote of "
+                            f"business rule per mutation step."
+                        ),
+                        file=str(runtime_path),
+                        expected=f"steps[].asserted_quote matching expected_assertion",
+                        fix_hint=(
+                            "Update vg-haiku-scanner SKILL to record asserted_quote per "
+                            "mutation step. See scanner-report-contract Section 2.X."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_asserted_drift),
+                )
+                continue
+
+            # Cross-check: at least one quote should ≥ similarity threshold
+            best_sim = 0.0
+            for q in quotes:
+                if q["asserted_quote"]:
+                    sim = text_similarity(expected_assertion, q["asserted_quote"])
+                    if sim > best_sim:
+                        best_sim = sim
+
+            if best_sim < args.similarity_threshold:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="asserted_quote_drift",
+                        message=(
+                            f"{gid}: asserted_quote drift — best similarity {best_sim:.2f} "
+                            f"< threshold {args.similarity_threshold} vs expected_assertion"
+                        ),
+                        file=str(runtime_path),
+                        expected=expected_assertion[:120],
+                        actual=quotes[0]["asserted_quote"][:120] if quotes else "",
+                        fix_hint=(
+                            "Scanner paraphrased rule; rerun and require verbatim quote. "
+                            "Banned: scanner inventing assertion text."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_asserted_drift),
+                )
+
+            # Cross-check: asserted_rule (if present) must exist in DISCUSSION-LOG
+            for q in quotes:
+                if q["asserted_rule"] and log_text:
+                    if not find_business_rule_in_log(q["asserted_rule"], log_text):
+                        violations += 1
+                        out.add(
+                            Evidence(
+                                type="asserted_rule_unknown",
+                                message=(
+                                    f"{gid} step[{q['step_idx']}]: asserted_rule="
+                                    f"'{q['asserted_rule']}' not found in DISCUSSION-LOG.md"
+                                ),
+                                file=str(runtime_path),
+                                fix_hint="Define rule in DISCUSSION-LOG.md or fix asserted_rule field.",
+                            ),
+                            escalate=(args.severity == "block" and not args.allow_asserted_drift),
+                        )
+
+        if violations and (args.severity == "warn" or args.allow_asserted_drift):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} asserted_quote drift(s) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-business-rule-implemented.py
+++ b/scripts/validators/verify-business-rule-implemented.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Verify code implements business rule constants matching CONTEXT decisions.
+
+Closes Phase 3.2 dogfood gap: D-46 says "5 topups in 24h" but code may
+implement THRESHOLD=3 (drift). All downstream tests/scans align with code,
+not with decision → bug ships.
+
+Mechanism: parse `expected_assertion` per goal, extract numeric/string
+constants (e.g., "5", "24h", "$100"), grep code under apps/ + packages/ +
+infra/ for matching constants near rule-related identifiers (e.g.,
+SUSPICIOUS_COUNT_THRESHOLD).
+
+Severity: BLOCK at /vg:build end-of-wave.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import parse_goals_with_frontmatter  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def extract_constants(assertion: str) -> list[str]:
+    """Extract numeric/duration/currency constants from assertion text.
+
+    Examples:
+      "5 topups in 24h"       → ["5", "24"]
+      "amount sum >= $100"    → ["100"]
+      "threshold of 5 topups" → ["5"]
+    """
+    constants: list[str] = []
+    # Numbers (integer or decimal)
+    constants.extend(re.findall(r"\b(\d+(?:\.\d+)?)\b", assertion))
+    # Currency ($X / X USD)
+    constants.extend(re.findall(r"\$(\d+(?:\.\d+)?)", assertion))
+    # Time durations (24h, 7d, 5m)
+    constants.extend(re.findall(r"\b(\d+)\s*(?:h|hrs|hour|d|day|m|min|s|sec|w|week|month)\b", assertion, re.IGNORECASE))
+    return list(dict.fromkeys(constants))  # dedupe preserving order
+
+
+def grep_code_for_constants(constants: list[str], repo_root: Path) -> dict[str, list[str]]:
+    """Use `git grep` to find files containing each constant.
+
+    Restricts to source files (apps/, packages/, infra/) and excludes
+    test fixtures + node_modules.
+    """
+    found: dict[str, list[str]] = {}
+    if not constants:
+        return found
+    src_dirs = ["apps", "packages", "infra"]
+    src_dirs_present = [d for d in src_dirs if (repo_root / d).is_dir()]
+    if not src_dirs_present:
+        return found
+
+    for c in constants:
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "grep",
+                    "-l",
+                    "--no-color",
+                    rf"\b{re.escape(c)}\b",
+                    "--",
+                ]
+                + [f"{d}/" for d in src_dirs_present]
+                + [
+                    f":!{d}/**/test*"
+                    for d in src_dirs_present
+                ]
+                + [f":!{d}/**/__tests__/**" for d in src_dirs_present],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
+            if files:
+                found[c] = files[:5]
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    return found
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify business rule constants in code")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument("--allow-rule-not-implemented", action="store_true")
+    args = parser.parse_args()
+
+    out = Output(validator="business-rule-implemented")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        if not goals_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        repo_root = Path.cwd()
+        violations = 0
+
+        for goal in goals:
+            assertion = goal.get("expected_assertion", "").strip()
+            if not assertion or len(assertion) < 20:
+                continue
+            constants = extract_constants(assertion)
+            if not constants:
+                continue
+            found = grep_code_for_constants(constants, repo_root)
+            missing = [c for c in constants if c not in found]
+            if missing:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="rule_constants_not_in_code",
+                        message=(
+                            f"{goal['id']}: expected_assertion has constants {constants} "
+                            f"but {len(missing)} not found in apps/packages/infra source: {missing}"
+                        ),
+                        file=str(goals_path),
+                        expected=f"Source code constants matching {constants}",
+                        actual=f"Found: {list(found.keys())}, missing: {missing}",
+                        fix_hint=(
+                            "Verify code implements business rule with these specific values. "
+                            "Drift between expected_assertion and code → bug ships."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_rule_not_implemented),
+                )
+
+        if violations and (args.severity == "warn" or args.allow_rule_not_implemented):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} rule(s) not in code, downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-cross-phase-decision-validity.py
+++ b/scripts/validators/verify-cross-phase-decision-validity.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Verify cross-phase D-XX references are still active (not revoked by amend).
+
+Closes Phase 3.2 dogfood gap: Phase X goal cites D-AA from Phase Y. A later
+amend in Phase Z revokes D-AA. Phase X stale but no validator catches.
+
+Mechanism: parse goals with cross-phase decision refs (e.g., "P3.D-46").
+For each, walk to source phase CONTEXT.md + AMEND-LOG.md to confirm decision
+still active.
+
+Severity: BLOCK at /vg:review (and /vg:amend for cascade).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import parse_goals_with_frontmatter  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def parse_cross_phase_ref(decision_ref: str) -> tuple[str, str] | None:
+    """Parse "P3.D-46" → ("3", "D-46"); "D-46" → None (same-phase)."""
+    m = re.match(r"^P?(\d+(?:\.\d+)?)\.(D-\d+)$", decision_ref)
+    if m:
+        return (m.group(1), m.group(2))
+    return None
+
+
+def find_phase_dir_by_number(phase_num: str, phases_root: Path) -> Path | None:
+    """Resolve phase number to dir under phases_root."""
+    candidates = sorted(phases_root.glob(f"{phase_num}-*"))
+    if candidates:
+        return candidates[0]
+    # Try zero-padded
+    if "." in phase_num:
+        major, minor = phase_num.split(".")
+        padded = f"{int(major):02d}.{minor}"
+        candidates = sorted(phases_root.glob(f"{padded}-*"))
+    else:
+        padded = f"{int(phase_num):02d}"
+        candidates = sorted(phases_root.glob(f"{padded}-*"))
+    return candidates[0] if candidates else None
+
+
+def is_decision_revoked(phase_dir: Path, decision_id: str) -> tuple[bool, str]:
+    """Check if D-XX has been revoked by amendment.
+
+    Convention: AMEND-LOG.md or CONTEXT.md may have:
+      "## Revoked: D-46" or "**Status:** revoked" or "REVOKED in P5"
+    """
+    for fname in ("AMEND-LOG.md", "CONTEXT.md"):
+        path = phase_dir / fname
+        if not path.exists():
+            continue
+        text = _read(path)
+        # Look for explicit revocation markers near D-XX
+        patterns = [
+            rf"#{2,4}\s*Revoked:?\s*{re.escape(decision_id)}\b",
+            rf"\*\*Status:\*\*\s*revoked.*\b{re.escape(decision_id)}\b",
+            rf"\b{re.escape(decision_id)}\b.*\*\*Status:\*\*\s*revoked",
+            rf"\bREVOKED\b.*\b{re.escape(decision_id)}\b",
+        ]
+        for pat in patterns:
+            if re.search(pat, text, re.IGNORECASE | re.DOTALL):
+                return (True, f"{fname} marks {decision_id} revoked")
+    return (False, "")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify cross-phase D-XX still active")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument("--allow-stale-decisions", action="store_true")
+    args = parser.parse_args()
+
+    out = Output(validator="cross-phase-decision-validity")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        if not goals_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        phases_root = phase_dir.parent
+        violations = 0
+
+        for goal in goals:
+            for d_ref in goal["decisions"]:
+                parsed = parse_cross_phase_ref(d_ref)
+                if not parsed:
+                    continue  # Same-phase reference — separate validator handles
+                src_phase_num, decision_id = parsed
+                src_dir = find_phase_dir_by_number(src_phase_num, phases_root)
+                if src_dir is None:
+                    violations += 1
+                    out.add(
+                        Evidence(
+                            type="cross_phase_dir_not_found",
+                            message=f"{goal['id']}: cites {d_ref} but source phase '{src_phase_num}' dir not found",
+                            file=str(goals_path),
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_stale_decisions),
+                    )
+                    continue
+
+                # Verify D-XX still active in source phase
+                src_context = src_dir / "CONTEXT.md"
+                if not src_context.exists():
+                    continue
+                src_text = _read(src_context)
+                if not re.search(rf"^#{{2,4}}\s*{re.escape(decision_id)}\b", src_text, re.MULTILINE):
+                    violations += 1
+                    out.add(
+                        Evidence(
+                            type="cross_phase_decision_missing",
+                            message=(
+                                f"{goal['id']}: cites {d_ref} but {decision_id} not found in "
+                                f"{src_dir.name}/CONTEXT.md"
+                            ),
+                            file=str(goals_path),
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_stale_decisions),
+                    )
+                    continue
+
+                revoked, reason = is_decision_revoked(src_dir, decision_id)
+                if revoked:
+                    violations += 1
+                    out.add(
+                        Evidence(
+                            type="cross_phase_decision_revoked",
+                            message=f"{goal['id']}: cites {d_ref} but it was revoked — {reason}",
+                            file=str(goals_path),
+                            fix_hint=(
+                                "Amend goal to cite replacement decision OR remove if no longer relevant. "
+                                "Run /vg:amend on this phase to update CONTEXT."
+                            ),
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_stale_decisions),
+                    )
+
+        if violations and (args.severity == "warn" or args.allow_stale_decisions):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} stale cross-phase decision(s) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-decisions-to-goals.py
+++ b/scripts/validators/verify-decisions-to-goals.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Verify every CONTEXT.md D-XX maps to ≥1 goal in TEST-GOALS.md.
+
+Closes Phase 3.2 dogfood gap: decisions exist in CONTEXT but no goal verifies
+them → code may implement decision but no automated verification.
+
+Severity: BLOCK at /vg:blueprint plan-checker.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import parse_goals_with_frontmatter  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify D-XX → goals coverage")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument(
+        "--allow-uncovered-decisions",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="decisions-to-goals")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        context_path = phase_dir / "CONTEXT.md"
+        goals_path = phase_dir / "TEST-GOALS.md"
+        if not context_path.exists() or not goals_path.exists():
+            emit_and_exit(out)
+
+        context_text = _read(context_path)
+        decision_ids = sorted(set(re.findall(r"^#{2,4}\s*(D-\d+)", context_text, re.MULTILINE)))
+        if not decision_ids:
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+
+        # Build coverage map: decision → list of goals citing it
+        coverage: dict[str, list[str]] = {did: [] for did in decision_ids}
+        for goal in goals:
+            cited = set()
+            # Frontmatter decisions field
+            for d in goal["decisions"]:
+                local = d.split(".")[-1]  # "P3.D-46" → "D-46"
+                if local in coverage:
+                    cited.add(local)
+            # Title parenthetical (e.g. "G-12: Foo (P3.D-46)")
+            for m in re.finditer(r"\bD-\d+\b", goal["title"]):
+                if m.group(0) in coverage:
+                    cited.add(m.group(0))
+            for d in cited:
+                coverage[d].append(goal["id"])
+
+        violations = 0
+        for did, gids in coverage.items():
+            if not gids:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="decision_uncovered_by_goal",
+                        message=f"{did}: not cited by any goal in TEST-GOALS.md",
+                        file=str(context_path),
+                        fix_hint=(
+                            f"Add a goal verifying {did} OR add 'decisions: [{did}]' to "
+                            f"existing goal that implicitly covers it."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_uncovered_decisions),
+                )
+
+        if violations and (args.severity == "warn" or args.allow_uncovered_decisions):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} decision(s) without goal coverage, WARN mode.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-decisions-to-tasks.py
+++ b/scripts/validators/verify-decisions-to-tasks.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Verify every CONTEXT.md D-XX maps to ≥1 task in PLAN.md.
+
+Closes Phase 3.2 dogfood gap: AI may write CONTEXT decisions but skip
+implementing them in PLAN. Validator cross-checks coverage.
+
+Convention: tasks in PLAN.md should cite decisions via:
+  - "Per CONTEXT.md D-46" in task description
+  - "**Decisions:**: [D-46]" frontmatter
+  - "(D-46)" inline reference
+
+Severity: BLOCK at /vg:blueprint plan-checker.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify D-XX → tasks coverage")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument(
+        "--allow-uncovered-decisions",
+        action="store_true",
+        help="Override: allow D-XX without task. Logs OVERRIDE-DEBT.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="decisions-to-tasks")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        context_path = phase_dir / "CONTEXT.md"
+        if not context_path.exists():
+            emit_and_exit(out)
+
+        context_text = _read(context_path)
+        decision_ids = re.findall(r"^#{2,4}\s*(D-\d+)", context_text, re.MULTILINE)
+        decision_ids = sorted(set(decision_ids))
+
+        if not decision_ids:
+            emit_and_exit(out)
+
+        # Aggregate text from PLAN.md + PLAN-*.md (multi-file plans)
+        plan_files = list(phase_dir.glob("PLAN*.md"))
+        plan_text = "\n".join(_read(p) for p in plan_files)
+        if not plan_text:
+            out.add(
+                Evidence(
+                    type="no_plan_files",
+                    message="CONTEXT.md has decisions but no PLAN*.md files found",
+                    file=str(phase_dir),
+                ),
+                escalate=(args.severity == "block"),
+            )
+            emit_and_exit(out)
+
+        violations = 0
+        for did in decision_ids:
+            # Look for D-XX reference in plan text
+            pattern = re.compile(rf"\b{re.escape(did)}\b")
+            if not pattern.search(plan_text):
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="decision_uncovered_by_task",
+                        message=f"{did}: not referenced in any PLAN*.md task",
+                        file=str(context_path),
+                        fix_hint=(
+                            f"Add task implementing {did} OR cite '{did}' in existing task body. "
+                            f"Format: 'Per CONTEXT.md {did}' OR 'Decisions: [{did}]'."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_uncovered_decisions),
+                )
+
+        if violations and (args.severity == "warn" or args.allow_uncovered_decisions):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} decision(s) without task coverage, WARN mode.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-decisions-trace.py
+++ b/scripts/validators/verify-decisions-trace.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Verify CONTEXT.md D-XX decisions trace to user answer in DISCUSSION-LOG.md.
+
+Closes Phase 3.2 dogfood gap: AI may paraphrase user answer incorrectly into
+D-XX, producing decisions that drift from user intent. All downstream
+artifacts (goals, code, tests) inherit the drift.
+
+Mechanism: each D-XX in CONTEXT.md must have a `quote_source:` field citing
+DISCUSSION-LOG.md round + user answer text, and the D-XX statement must be
+≥80% similar to that user answer (Jaccard token overlap).
+
+Severity: BLOCK at /vg:scope completion. Override --severity warn for
+phases without enriched DISCUSSION-LOG (pre-2026-05-01).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import text_similarity  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def parse_decisions(context_text: str) -> list[dict]:
+    """Parse CONTEXT.md D-XX entries.
+
+    Convention: each decision is a section starting with `## D-XX:` or
+    `### D-XX:`, optionally followed by `**Decision:**` body and
+    `**Quote source:**` reference.
+    """
+    decisions = []
+    pattern = re.compile(
+        r"^#{2,4}\s*(D-\d+)[:\s]\s*(.+?)$"
+        r"(?P<body>(?:(?!^#{2,4}\s*D-\d+).)*)",
+        re.MULTILINE | re.DOTALL,
+    )
+    for m in pattern.finditer(context_text):
+        did = m.group(1)
+        title = m.group(2).strip()
+        body = m.group("body") or ""
+        decisions.append(
+            {
+                "id": did,
+                "title": title,
+                "body": body.strip(),
+                "quote_source": _extract_field(body, "Quote source")
+                or _extract_field(body, "quote_source")
+                or _extract_field(body, "Source")
+                or _extract_field(body, "Trace"),
+                "decision_text": _extract_field(body, "Decision")
+                or _extract_field(body, "Choice")
+                or body[:500],
+            }
+        )
+    return decisions
+
+
+def _extract_field(body: str, name: str) -> str:
+    m = re.search(
+        rf"^\*\*{re.escape(name)}:?\*\*\s*(.+?)(?=^\*\*|\n##|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if m:
+        return m.group(1).strip()
+    m = re.search(
+        rf"^{re.escape(name)}:\s*(.+?)(?=^\w+:|\n##|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if m:
+        return m.group(1).strip()
+    return ""
+
+
+def parse_discussion_rounds(log_text: str) -> dict[str, str]:
+    """Parse DISCUSSION-LOG.md rounds. Returns {round_id: combined_text}.
+
+    Convention: rounds start with `## Round N:` or `### Round N:`.
+    """
+    rounds: dict[str, str] = {}
+    pattern = re.compile(
+        r"^#{2,4}\s*Round\s+(\d+)[:\s].*?$"
+        r"(?P<body>(?:(?!^#{2,4}\s*Round\s+\d+).)*)",
+        re.MULTILINE | re.DOTALL,
+    )
+    for m in pattern.finditer(log_text):
+        rounds[f"round-{m.group(1)}"] = (m.group("body") or "").strip()
+    return rounds
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify D-XX trace to DISCUSSION-LOG user answers")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument(
+        "--severity",
+        choices=["block", "warn"],
+        default="block",
+    )
+    parser.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=0.4,
+        help="Min Jaccard similarity D-XX text vs user answer (default 0.4)",
+    )
+    parser.add_argument(
+        "--allow-decisions-untraced",
+        action="store_true",
+        help="Override: skip trace check. Logs OVERRIDE-DEBT.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="decisions-trace")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        context_path = phase_dir / "CONTEXT.md"
+        log_path = phase_dir / "DISCUSSION-LOG.md"
+        if not context_path.exists():
+            emit_and_exit(out)
+
+        context_text = _read(context_path)
+        log_text = _read(log_path) if log_path.exists() else ""
+        decisions = parse_decisions(context_text)
+        rounds = parse_discussion_rounds(log_text) if log_text else {}
+
+        violations = 0
+        for d in decisions:
+            did = d["id"]
+            issues: list[str] = []
+
+            # Required: quote_source citation
+            if not d["quote_source"]:
+                # Migration: if log doesn't exist, can't enforce
+                if not log_text:
+                    continue  # Pre-discussion-log phase
+                issues.append(
+                    f"missing 'Quote source:' field — should cite DISCUSSION-LOG round/answer "
+                    f"that drove this decision (e.g., 'DISCUSSION-LOG.md#round-3-user-answer')"
+                )
+            else:
+                # Verify quote_source resolves to an actual round
+                src_lower = d["quote_source"].lower()
+                round_match = re.search(r"round[-\s]*(\d+)", src_lower)
+                if round_match:
+                    round_id = f"round-{round_match.group(1)}"
+                    if round_id not in rounds:
+                        issues.append(
+                            f"quote_source references {round_id} but DISCUSSION-LOG has no such round"
+                        )
+                    else:
+                        # Similarity check: D-XX decision_text vs round body
+                        sim = text_similarity(d["decision_text"], rounds[round_id])
+                        if sim < args.similarity_threshold:
+                            issues.append(
+                                f"decision text drift: similarity {sim:.2f} < threshold "
+                                f"{args.similarity_threshold} vs cited round content. "
+                                f"AI may have paraphrased user answer incorrectly."
+                            )
+
+            if issues:
+                violations += 1
+                for issue in issues:
+                    out.add(
+                        Evidence(
+                            type="decision_trace_gap",
+                            message=f"{did} '{d['title'][:60]}': {issue}",
+                            file=str(context_path),
+                            fix_hint=(
+                                "Add **Quote source:** DISCUSSION-LOG.md#round-N to D-XX. "
+                                "Verbatim quote user's answer text — don't paraphrase."
+                            ),
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_decisions_untraced),
+                    )
+
+        if violations and (args.severity == "warn" or args.allow_decisions_untraced):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} decision(s) untraced, downgraded to WARN (migration mode).",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-goal-traceability.py
+++ b/scripts/validators/verify-goal-traceability.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Verify TEST-GOALS.md frontmatter completeness (blueprint gate).
+
+Each goal MUST cite spec_ref + decisions + business_rules + expected_assertion
++ goal_class to be considered traceable. Closes the "AI bịa goal" gap from
+Phase 3.2 dogfood: AI invents goals not tied to SPECS/CONTEXT/DISCUSSION-LOG.
+
+Migration: --severity warn flag downgrades BLOCK to WARN for pre-2026-05-01
+phases. After backfill, re-run with default block severity.
+
+Per scanner-report-contract Section 1: this validator runs at /vg:blueprint
+plan-checker step. Blocks blueprint exit if any goal lacks traceability.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    find_section_anchor,
+    infer_goal_class,
+    GOAL_CLASS_MIN_STEPS,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify TEST-GOALS frontmatter has full traceability fields"
+    )
+    parser.add_argument("--phase", required=True)
+    parser.add_argument(
+        "--severity",
+        choices=["block", "warn"],
+        default="block",
+        help="block (default) BLOCKs blueprint; warn for migration phases",
+    )
+    parser.add_argument(
+        "--allow-traceability-gaps",
+        action="store_true",
+        help="Override: allow missing fields. Logs OVERRIDE-DEBT.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="goal-traceability")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(
+                type="phase_not_found",
+                message=f"Phase directory not found for {args.phase}",
+            ))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        if not goals_path.exists():
+            # No goals = no traceability to verify
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        violations = 0
+
+        for goal in goals:
+            gid = goal["id"]
+            issues: list[str] = []
+
+            # Required: spec_ref
+            if not goal["spec_ref"]:
+                issues.append("missing spec_ref (which SPECS.md section drives this goal?)")
+
+            # Required: expected_assertion (verbatim business rule statement)
+            if not goal["expected_assertion"] or len(goal["expected_assertion"].strip()) < 20:
+                issues.append(
+                    "missing or too-short expected_assertion (need verbatim business "
+                    "rule statement that scanner/test must verify, ≥20 chars)"
+                )
+
+            # Required: goal_class (drives min_steps threshold)
+            if not goal["goal_class"]:
+                inferred = infer_goal_class(goal)
+                issues.append(
+                    f"missing goal_class field (inferred '{inferred}' from title/surface, "
+                    f"but explicit declaration required for downstream validators)"
+                )
+            elif goal["goal_class"] not in GOAL_CLASS_MIN_STEPS:
+                issues.append(
+                    f"invalid goal_class='{goal['goal_class']}' "
+                    f"(must be one of: {', '.join(sorted(GOAL_CLASS_MIN_STEPS))})"
+                )
+
+            # Conditional: business_rules required for non-trivial mutations
+            cls = infer_goal_class(goal)
+            if cls in {"mutation", "approval", "crud-roundtrip", "wizard", "webhook"}:
+                if not goal["business_rules"]:
+                    issues.append(
+                        f"goal_class={cls} but no business_rules cited. "
+                        f"Mutation/approval goals must reference DISCUSSION-LOG BR-NN entries."
+                    )
+
+            # Conditional: decisions required if any decision cited in title
+            # (e.g., "G-12: Foo (P3.D-46)" implies decisions: [P3.D-46])
+            import re
+            title_decisions = re.findall(r"\b(P?\d*\.?D-\d+)\b", goal["title"])
+            if title_decisions and not goal["decisions"]:
+                issues.append(
+                    f"title references decisions {title_decisions} but decisions: field empty. "
+                    f"Add decisions: [{', '.join(title_decisions)}] to frontmatter."
+                )
+
+            # Conditional: api_contracts for surface=api or mutation goals
+            if goal["surface"] == "api" and not goal["api_contracts"]:
+                issues.append(
+                    "surface=api but no api_contracts cited. List endpoints from API-CONTRACTS.md."
+                )
+
+            # Conditional: flow_ref for surface=ui multi-step goals
+            if goal["surface"] in {"ui", "ui-mobile"} and cls in {"wizard", "crud-roundtrip", "approval"}:
+                if not goal["flow_ref"]:
+                    issues.append(
+                        f"surface=ui + goal_class={cls} → flow_ref required. "
+                        f"Cite FLOW-SPEC.md anchor."
+                    )
+
+            # Cross-check: spec_ref resolves to an actual SPECS.md heading
+            if goal["spec_ref"]:
+                from _traceability import find_section_anchor
+                # Check both repo root and phase dir
+                phase_relative = phase_dir / "SPECS.md"
+                repo_root = Path.cwd()
+                if "#" in goal["spec_ref"]:
+                    file_part, anchor = goal["spec_ref"].split("#", 1)
+                    # Try phase-local SPECS.md first
+                    if phase_relative.exists():
+                        text = phase_relative.read_text(encoding="utf-8", errors="replace")
+                        anchor_norm = anchor.lower().replace("_", "-").replace(" ", "-")
+                        found = False
+                        for line in text.splitlines():
+                            if line.startswith("#"):
+                                heading = line.lstrip("#").strip()
+                                heading_slug = re.sub(r"[^\w\s-]", "", heading.lower()).strip().replace(" ", "-")
+                                if heading_slug == anchor_norm or anchor_norm in heading_slug:
+                                    found = True
+                                    break
+                        if not found:
+                            issues.append(
+                                f"spec_ref='{goal['spec_ref']}' anchor not found as heading in {phase_relative}"
+                            )
+
+            if issues:
+                violations += 1
+                for issue in issues:
+                    out.add(
+                        Evidence(
+                            type="goal_traceability_gap",
+                            message=f"{gid}: {issue}",
+                            file=str(goals_path),
+                            fix_hint=(
+                                "See commands/vg/_shared/templates/TEST-GOAL-enriched-template.md "
+                                "section 'v2.46 Phase 6 enrichment' for required fields."
+                            ),
+                        ),
+                        escalate=(args.severity == "block" and not args.allow_traceability_gaps),
+                    )
+
+        if violations and (args.severity == "warn" or args.allow_traceability_gaps):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=(
+                        f"{violations} goal(s) lack traceability fields, downgraded to WARN "
+                        f"(severity={args.severity}, allow_gaps={args.allow_traceability_gaps}). "
+                        f"Migration mode — backfill spec_ref/decisions/business_rules/expected_assertion "
+                        f"in TEST-GOALS.md before next milestone."
+                    ),
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-mutation-actually-submitted.py
+++ b/scripts/validators/verify-mutation-actually-submitted.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Verify mutation goals were ACTUALLY submitted, not just modal-opened.
+
+Closes the "performative review" meta-bug surfaced in Phase 3.2 dogfood
+(2026-05-01): scanner agents Cancel modals to avoid destructive sandbox
+mutations → never test happy path → CSRF/auth/idempotency bugs slip through →
+matrix marks goal `READY` based on modal-opened evidence alone.
+
+This validator complements verify-runtime-map-crud-depth.py:
+- crud-depth: requires POST/PUT/PATCH/DELETE network entry with 2xx
+- this validator: ALSO requires the goal_sequences[].steps[] to contain
+  the actual click on submit/approve/reject button — not just cancel-only
+
+Catches:
+1. Goals where steps[] only has `do=click target=cancel` (modal opened, cancelled)
+2. Goals where scanner observed CSRF/auth error but classified `result=passed`
+   with rationalization vocabulary ("expected security", "as designed")
+3. Goals where mutation_evidence is declared in TEST-GOALS but goal_sequences
+   shows no submit attempt
+
+Severity: BLOCK (default) when --severity not passed. Override per-phase via
+--allow-cancel-only-mutations CLI flag (logs OVERRIDE-DEBT).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+
+REPO_ROOT = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+
+# Patterns suggesting a step is the SUBMIT/OK branch (not cancel/close)
+SUBMIT_TARGET_RE = re.compile(
+    r"\b(submit|approve|confirm|save|create|update|delete|reject|send|"
+    r"đồng\s*ý|duyệt|xác\s*nhận|gửi|tạo|cập\s*nhật|xóa|từ\s*chối)\b",
+    re.IGNORECASE,
+)
+CANCEL_TARGET_RE = re.compile(
+    r"\b(cancel|close|dismiss|abort|back|hủy|đóng|bỏ\s*qua|quay\s*lại)\b",
+    re.IGNORECASE,
+)
+RATIONALIZATION_RE = re.compile(
+    r"(expected\s+security|as\s+designed|expected\s+behavior|"
+    r"working\s+as\s+intended|correct\s+behavior|csrf\s+token\s+prevented)",
+    re.IGNORECASE,
+)
+MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+EMPTY_FIELD_VALUES = {"", "none", "n/a", "na", "null", "-", "[]", "{}"}
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def _field(body: str, name: str) -> str:
+    m = re.search(
+        rf"^\*\*{re.escape(name)}:\*\*\s*(.+?)(?:\n\*\*|\n##|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    return m.group(1).strip() if m else ""
+
+
+def _meaningful(value: str) -> bool:
+    compact = re.sub(r"\s+", " ", value.strip()).lower()
+    return compact not in EMPTY_FIELD_VALUES and not compact.startswith(
+        ("none:", "n/a:", "na:")
+    )
+
+
+def _parse_goals(text: str) -> list[dict[str, Any]]:
+    """Parse TEST-GOALS.md → list of goals with mutation metadata."""
+    goals: list[dict[str, Any]] = []
+    for match in re.finditer(
+        r"^##\s+Goal\s+(G-[\w.-]+):?\s*(.*?)$"
+        r"(?P<body>(?:(?!^##\s+Goal\s+).)*)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    ):
+        gid = match.group(1)
+        title = match.group(2).strip()
+        body = match.group("body") or ""
+        priority = _field(body, "Priority").lower() or "important"
+        surface = _field(body, "Surface").split()[0].strip().lower() or "ui"
+        mutation_evidence = _field(body, "Mutation evidence")
+        mutation_required_field = _field(body, "Mutation required").lower()
+        # Default: mutation_required=true if mutation_evidence is declared
+        if mutation_required_field in {"true", "yes", "1"}:
+            mutation_required = True
+        elif mutation_required_field in {"false", "no", "0"}:
+            mutation_required = False
+        else:
+            mutation_required = _meaningful(mutation_evidence)
+        goals.append(
+            {
+                "id": gid,
+                "title": title,
+                "body": body,
+                "priority": priority,
+                "surface": surface,
+                "mutation_evidence": mutation_evidence,
+                "mutation_required": mutation_required,
+            }
+        )
+    return goals
+
+
+def _walk(value: Any) -> Iterable[Any]:
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _network_entries(seq: dict[str, Any]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for node in _walk(seq):
+        if not isinstance(node, dict):
+            continue
+        network = node.get("network")
+        if isinstance(network, list):
+            entries.extend(x for x in network if isinstance(x, dict))
+        elif isinstance(network, dict):
+            entries.append(network)
+    return entries
+
+
+def _status_ok(status: Any) -> bool:
+    try:
+        code = int(status)
+    except (TypeError, ValueError):
+        return False
+    return 200 <= code < 400
+
+
+def _has_submit_step(seq: dict[str, Any]) -> bool:
+    """Check goal_sequences[gid].steps[] has at least one submit-class action."""
+    steps = seq.get("steps") or []
+    if not isinstance(steps, list):
+        return False
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        action = str(step.get("do") or step.get("action") or "").lower()
+        if action not in {"click", "tap", "press", "submit"}:
+            continue
+        target_text = " ".join(
+            str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+        )
+        if SUBMIT_TARGET_RE.search(target_text) and not CANCEL_TARGET_RE.search(
+            target_text
+        ):
+            return True
+    return False
+
+
+def _has_only_cancel_steps(seq: dict[str, Any]) -> bool:
+    """Detect cancel-only sequences (modal opened, cancelled, never submitted)."""
+    steps = seq.get("steps") or []
+    if not isinstance(steps, list) or not steps:
+        return False
+    saw_cancel = False
+    saw_submit = False
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        target_text = " ".join(
+            str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+        )
+        if CANCEL_TARGET_RE.search(target_text):
+            saw_cancel = True
+        if SUBMIT_TARGET_RE.search(target_text) and not CANCEL_TARGET_RE.search(
+            target_text
+        ):
+            saw_submit = True
+    return saw_cancel and not saw_submit
+
+
+def _has_rationalization(seq: dict[str, Any]) -> tuple[bool, str]:
+    """Detect rationalization vocabulary in reason/observed/notes fields."""
+    blob_parts: list[str] = []
+    for node in _walk(seq):
+        if isinstance(node, dict):
+            for k in ("reason", "observed", "note", "notes", "summary", "expected"):
+                v = node.get(k)
+                if isinstance(v, str):
+                    blob_parts.append(v)
+        elif isinstance(node, str):
+            blob_parts.append(node)
+    blob = " ".join(blob_parts)
+    m = RATIONALIZATION_RE.search(blob)
+    return (bool(m), m.group(0) if m else "")
+
+
+def _has_mutation_network(seq: dict[str, Any]) -> bool:
+    for entry in _network_entries(seq):
+        method = str(entry.get("method") or entry.get("verb") or "").upper()
+        if method in MUTATION_METHODS and _status_ok(
+            entry.get("status", entry.get("status_code"))
+        ):
+            return True
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify mutation goals were actually submitted, not modal-opened-then-cancelled"
+    )
+    parser.add_argument("--phase", required=True)
+    parser.add_argument(
+        "--severity",
+        choices=["block", "warn"],
+        default="block",
+        help="block (default) = exit 1 on violations; warn = exit 0 with evidence emitted",
+    )
+    parser.add_argument(
+        "--allow-cancel-only-mutations",
+        action="store_true",
+        help="Override: allow goals to be marked passed without submit step. Logs OVERRIDE-DEBT.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="mutation-actually-submitted")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(
+                Evidence(
+                    type="phase_not_found",
+                    message=f"Phase directory not found for {args.phase}",
+                    expected=".vg/phases/<phase>-*",
+                )
+            )
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not goals_path.exists() or not runtime_path.exists():
+            emit_and_exit(out)
+
+        goals = _parse_goals(_read(goals_path))
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError as exc:
+            out.add(
+                Evidence(
+                    type="runtime_map_json_invalid",
+                    message=f"RUNTIME-MAP.json parse failed: {exc}",
+                    file=str(runtime_path),
+                )
+            )
+            emit_and_exit(out)
+
+        sequences = runtime.get("goal_sequences") or {}
+        if not isinstance(sequences, dict):
+            emit_and_exit(out)
+
+        violations = 0
+        for goal in goals:
+            if not goal["mutation_required"]:
+                continue
+            gid = goal["id"]
+            seq = sequences.get(gid)
+            if not isinstance(seq, dict):
+                # Missing sequence — caller (matrix-evidence-link / crud-depth) handles
+                continue
+
+            result = str(seq.get("result", "")).lower()
+            if result not in {"passed", "pass", "ready", "yes"}:
+                # Goal not claimed passing — nothing to falsify
+                continue
+
+            # Violation 1: cancel-only sequence (modal opened, cancelled, no submit)
+            if _has_only_cancel_steps(seq):
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="mutation_passed_but_cancel_only",
+                        message=(
+                            f"{gid}: marked passed but goal_sequences.steps shows cancel-only "
+                            "path — never executed submit. Performative review."
+                        ),
+                        file=str(runtime_path),
+                        expected="Step with do=click target~submit/approve/confirm + 2xx network",
+                        actual=f"steps={len(seq.get('steps') or [])} all-cancel-or-no-submit",
+                        fix_hint=(
+                            "Re-run /vg:review with scanner directed to SUBMIT (sandbox = "
+                            "disposable seed). Update prompt to ban 'Cancel modals only'."
+                        ),
+                    )
+                )
+                continue
+
+            # Violation 2: no submit step at all
+            if not _has_submit_step(seq):
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="mutation_passed_without_submit_step",
+                        message=(
+                            f"{gid}: marked passed but goal_sequences.steps has no "
+                            "submit/approve/confirm click action. Mutation goal requires "
+                            "actual submit attempt."
+                        ),
+                        file=str(runtime_path),
+                        expected="At least 1 step with do=click target~submit pattern",
+                        fix_hint="Scanner must execute Submit/Approve/Confirm button click.",
+                    )
+                )
+                continue
+
+            # Violation 3: submit step exists but no 2xx mutation network observed
+            if not _has_mutation_network(seq):
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="mutation_passed_without_2xx_network",
+                        message=(
+                            f"{gid}: marked passed with submit step but no successful "
+                            "POST/PUT/PATCH/DELETE network entry. Likely server "
+                            "rejected (CSRF/auth/validation) — scanner classified "
+                            "the rejection as 'passed' incorrectly."
+                        ),
+                        file=str(runtime_path),
+                        expected="Mutation method + 2xx status",
+                        actual=f"network_entries={len(_network_entries(seq))}",
+                        fix_hint=(
+                            "Check goal_sequences for 4xx/5xx responses. Reclassify "
+                            "result=blocked with verbatim error code. Investigate root cause."
+                        ),
+                    )
+                )
+                continue
+
+            # Violation 4: rationalization vocabulary in reason/observed
+            has_rat, rat_phrase = _has_rationalization(seq)
+            if has_rat:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="mutation_passed_with_rationalization",
+                        message=(
+                            f"{gid}: passed result paired with rationalization vocabulary "
+                            f"\"{rat_phrase}\". Banned per scanner-report-contract Section 1 — "
+                            "scanner CANNOT classify mismatch as expected. Commander adjudicates."
+                        ),
+                        file=str(runtime_path),
+                        expected=(
+                            "match: no with verbatim error; commander cross-references "
+                            "TEST-GOALS to determine if observation is bug or correct security"
+                        ),
+                        fix_hint=(
+                            "Re-run with banned vocabulary filter. Scanner must record "
+                            "\"expected: 200 + status approved; observed: 403 CSRF_MISSING; "
+                            "match: no\" — let commander decide if 403 is correct security "
+                            "or FE bug missing CSRF token."
+                        ),
+                    )
+                )
+
+        # Severity downgrade: if --allow-cancel-only-mutations OR --severity=warn,
+        # convert BLOCK verdict to WARN so orchestrator continues (override-debt
+        # logged by /vg:review wrapper).
+        if (args.allow_cancel_only_mutations or args.severity == "warn") and \
+                out.verdict == "BLOCK":
+            out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=(
+                        f"{violations} violation(s) detected but downgraded to WARN "
+                        f"(severity={args.severity}, "
+                        f"allow_cancel_only={args.allow_cancel_only_mutations}). "
+                        "Logged for trust calibration. Run with --severity=block to enforce."
+                    ),
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-rcrurd-depth.py
+++ b/scripts/validators/verify-rcrurd-depth.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify scanner output meets RCRURD step-depth threshold per goal class.
+
+Closes Phase 3.2 dogfood gap: scanners stop after 4-5 steps even on
+mutation/crud-roundtrip goals that need 6-14 steps. AI rationalizes
+"modal opened" as completion, marks goal passed, moves on.
+
+This validator counts goal_sequences[gid].steps[] length and compares
+against goal_class threshold (per scanner-report-contract Section 2.X).
+
+Goal class thresholds:
+  readonly: ≥3 (navigate → snapshot → assert)
+  mutation: ≥6 (pre-snapshot → submit → wait → refresh → re-read → diff)
+  approval: ≥8 (read pending → drawer → approve → confirm → submit → wait → refresh → assert)
+  wizard: ≥10 (multi-step form transitions)
+  crud-roundtrip: ≥14 (Read empty → C(4) → Read populated → U(4) → Read updated → D(3) → Read empty)
+  webhook: ≥4 (trigger → wait → query downstream → assert)
+
+Severity: BLOCK at /vg:review Phase 4.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    infer_goal_class,
+    min_steps_for_goal,
+    GOAL_CLASS_MIN_STEPS,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify RCRURD step depth per goal class")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument(
+        "--allow-shallow-scans",
+        action="store_true",
+        help="Override: allow goals with insufficient steps. Logs OVERRIDE-DEBT.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="rcrurd-depth")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not goals_path.exists() or not runtime_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError as e:
+            out.add(Evidence(type="runtime_map_invalid", message=f"Parse failed: {e}"))
+            emit_and_exit(out)
+
+        sequences = runtime.get("goal_sequences") or {}
+        if not isinstance(sequences, dict):
+            emit_and_exit(out)
+
+        violations = 0
+        for goal in goals:
+            gid = goal["id"]
+            seq = sequences.get(gid)
+            if not isinstance(seq, dict):
+                continue  # Caller (matrix-evidence-link) handles missing sequences
+
+            result = str(seq.get("result", "")).lower()
+            if result not in {"passed", "pass", "ready", "yes"}:
+                continue  # Goal already not passing — nothing to falsify
+
+            cls = infer_goal_class(goal)
+            min_steps = GOAL_CLASS_MIN_STEPS.get(cls, 3)
+            actual_steps = len(seq.get("steps") or [])
+
+            if actual_steps < min_steps:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="rcrurd_steps_insufficient",
+                        message=(
+                            f"{gid}: marked passed but goal_sequences.steps has only "
+                            f"{actual_steps} entries. goal_class='{cls}' requires ≥{min_steps}."
+                        ),
+                        file=str(runtime_path),
+                        expected=f"≥{min_steps} steps for goal_class={cls}",
+                        actual=f"{actual_steps} steps",
+                        fix_hint=(
+                            f"Re-run /vg:review with scanner directed to complete RCRURD "
+                            f"lifecycle. Sandbox = disposable_seed_data; mutate freely. "
+                            f"See scanner-report-contract.md 'RCRURD Lifecycle Protocol'."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_shallow_scans),
+                )
+
+        if violations and (args.severity == "warn" or args.allow_shallow_scans):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} shallow scan(s) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-replay-evidence.py
+++ b/scripts/validators/verify-replay-evidence.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Verify scanner-claimed network calls actually return claimed responses.
+
+Closes Phase 3.2 dogfood gap: scanner output may claim
+  network: [{method: POST, url: /api/x, status: 200}]
+without actually receiving a 200. Adversarial fabrication detection.
+
+Mechanism: for each scanner-claimed mutation network entry, replay via curl
+(if config.environments[ENV].api_base reachable) + compare status code.
+Mismatch = scanner fabricated.
+
+NOTE: This validator is opt-in (--enable-replay) because it requires:
+  1. Auth fixture (cookies/tokens) to authenticate replay
+  2. Live env reachability
+  3. Idempotency tolerance (some mutations can't be replayed safely)
+
+Default: structural-only check (URL + method exists in API-CONTRACTS).
+
+Severity: BLOCK at /vg:review Phase 4 when --enable-replay; else WARN.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def parse_contract_endpoints(contracts_text: str) -> set[tuple[str, str]]:
+    """Extract (method, path) tuples from API-CONTRACTS.md."""
+    endpoints: set[tuple[str, str]] = set()
+    pattern = re.compile(
+        r"(GET|POST|PUT|PATCH|DELETE)\s+(/api/[^\s|`'\"]+)",
+        re.IGNORECASE,
+    )
+    for m in pattern.finditer(contracts_text):
+        endpoints.add((m.group(1).upper(), m.group(2)))
+    return endpoints
+
+
+def normalize_path(url: str) -> str:
+    """Strip query string + replace IDs with :id placeholder for comparison."""
+    path = url.split("?")[0].split("#")[0]
+    # Replace 24-char hex IDs (Mongo ObjectId) with :id
+    path = re.sub(r"/[a-f0-9]{24}\b", "/:id", path)
+    # Replace numeric IDs
+    path = re.sub(r"/\d{6,}\b", "/:id", path)
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify scanner network claims (structural + optional replay)")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="warn")
+    parser.add_argument(
+        "--enable-replay",
+        action="store_true",
+        help="Live curl-replay (requires auth fixture + reachable env)",
+    )
+    parser.add_argument("--allow-replay-mismatch", action="store_true")
+    args = parser.parse_args()
+
+    out = Output(validator="replay-evidence")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        contracts_path = phase_dir / "API-CONTRACTS.md"
+        if not runtime_path.exists():
+            emit_and_exit(out)
+
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError:
+            emit_and_exit(out)
+
+        sequences = runtime.get("goal_sequences") or {}
+        contracts_text = _read(contracts_path) if contracts_path.exists() else ""
+        contract_endpoints = parse_contract_endpoints(contracts_text) if contracts_text else set()
+
+        violations = 0
+        for gid, seq in sequences.items():
+            if not isinstance(seq, dict):
+                continue
+            steps = seq.get("steps") or []
+            for i, step in enumerate(steps):
+                if not isinstance(step, dict):
+                    continue
+                network = step.get("network")
+                entries = network if isinstance(network, list) else [network] if network else []
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    method = str(entry.get("method") or entry.get("verb") or "").upper()
+                    url = str(entry.get("url") or "")
+                    if not method or not url:
+                        continue
+
+                    # Structural check: claimed method+path exists in API-CONTRACTS
+                    if contract_endpoints:
+                        norm_path = normalize_path(url)
+                        if not any(
+                            (m == method) and (norm_path == p or norm_path.endswith(p) or p.endswith(norm_path))
+                            for m, p in contract_endpoints
+                        ):
+                            violations += 1
+                            out.add(
+                                Evidence(
+                                    type="network_endpoint_unknown",
+                                    message=(
+                                        f"{gid} step[{i}]: scanner claims {method} {url} "
+                                        f"but no matching endpoint in API-CONTRACTS.md"
+                                    ),
+                                    file=str(runtime_path),
+                                    expected=f"Method+path in API-CONTRACTS.md",
+                                    actual=f"{method} {norm_path}",
+                                    fix_hint="Either scanner fabricated the call OR API-CONTRACTS.md is incomplete.",
+                                ),
+                                escalate=(args.severity == "block" and not args.allow_replay_mismatch),
+                            )
+
+        if args.enable_replay:
+            # TODO Wave 3: implement live curl replay with auth fixture loaded
+            # For now, document the intent
+            out.add(
+                Evidence(
+                    type="replay_not_implemented",
+                    message=(
+                        "--enable-replay requested but live replay deferred to Wave 3. "
+                        "Structural check completed."
+                    ),
+                ),
+                escalate=False,
+            )
+
+        if violations and (args.severity == "warn" or args.allow_replay_mismatch):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} replay/structural mismatch(es) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-scanner-business-alignment.py
+++ b/scripts/validators/verify-scanner-business-alignment.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Adversarial verifier: did scanner test the SAME flow goal claimed?
+
+Closes Phase 3.2 dogfood gap: scanner can RCRURD-correctly walk through a
+flow but the flow tested is NOT the flow goal claims to verify. Validators
+above (rcrurd-depth, asserted-rule-match) catch structural drift but not
+semantic drift like "tested generic flag, not specifically count threshold".
+
+This validator spawns an isolated Haiku subagent (zero parent context) to
+read goal frontmatter + scanner steps + expected_assertion, then adjudicate:
+  Q: "Did scanner steps actually verify expected_assertion or did they
+      shortcut/drift to a different verification path?"
+
+The fresh-context constraint prevents echo chamber — verifier doesn't see
+why scanner made its choices, only the artifact text.
+
+Severity: BLOCK at /vg:review Phase 4. Tunable via VG_VERIFIER_TIMEOUT_S.
+
+Implementation: this validator emits a structured prompt to a stdout
+"verifier_request" record. The orchestrator (review.md Phase 4) reads
+records, spawns Haiku via Agent tool, feeds prompt, parses verdict, and
+re-runs this validator with --verifier-results consuming the verdict file.
+This decouples the spawn (orchestrator-only capability) from the gate logic.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    infer_goal_class,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def build_verifier_prompt(goal: dict, seq: dict) -> str:
+    """Build adversarial verifier prompt for one goal."""
+    steps = seq.get("steps") or []
+    return f"""You are an adversarial verifier with ZERO parent context. Your only job:
+adjudicate whether the scanner output below ACTUALLY verifies the goal's
+expected_assertion, or drifted to a different verification path.
+
+# Goal {goal['id']}
+Title: {goal['title']}
+Priority: {goal.get('priority')}
+Surface: {goal.get('surface')}
+Goal class: {goal.get('goal_class') or infer_goal_class(goal)}
+
+## Expected assertion (verbatim from business rule)
+{goal.get('expected_assertion', '<not declared>')}
+
+## Decisions cited
+{', '.join(goal.get('decisions') or ['<none>'])}
+
+## Business rules cited
+{', '.join(goal.get('business_rules') or ['<none>'])}
+
+# Scanner steps[]  ({len(steps)} entries)
+{json.dumps(steps, indent=2, ensure_ascii=False)[:4000]}
+
+# Adjudicate (return JSON)
+{{
+  "goal_id": "{goal['id']}",
+  "alignment": "yes" | "no" | "partial",
+  "drift_type": "none" | "wrong_flow" | "shallow" | "fabricated" | "rationalized",
+  "evidence": "<verbatim quote from scanner steps that proves OR disproves alignment>",
+  "missing_actions": ["<action expected by assertion but absent from steps>", "..."],
+  "summary": "<1-sentence verdict>"
+}}
+
+Hard rules:
+- alignment="yes" ONLY if steps clearly perform the action described in
+  expected_assertion AND verify the postcondition.
+- alignment="no" if steps test something different, even partially.
+- "rationalized" drift = scanner classified error as 'expected security' or
+  similar, instead of recording verbatim error.
+- "fabricated" drift = steps claim outcomes not supported by network/console evidence.
+- Be skeptical. Default to "no" / "partial" unless evidence is unambiguous.
+
+Output ONLY the JSON object. No prose.
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Adversarial scanner-business alignment verifier")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument(
+        "--verifier-results",
+        type=Path,
+        help="Path to JSONL file with verifier verdicts (one per goal). "
+             "When provided, validator gates on these. When absent, validator "
+             "emits prompts only (orchestrator must spawn verifier separately).",
+    )
+    parser.add_argument(
+        "--prompts-out",
+        type=Path,
+        help="Path to write verifier prompts JSONL (orchestrator consumes to spawn).",
+    )
+    parser.add_argument(
+        "--allow-business-drift",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="scanner-business-alignment")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not goals_path.exists() or not runtime_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError:
+            emit_and_exit(out)
+        sequences = runtime.get("goal_sequences") or {}
+
+        # Phase 1: emit prompts for each goal that needs verification
+        prompts: list[dict] = []
+        for goal in goals:
+            gid = goal["id"]
+            seq = sequences.get(gid)
+            if not isinstance(seq, dict):
+                continue
+            if str(seq.get("result", "")).lower() not in {"passed", "pass", "ready"}:
+                continue
+            cls = infer_goal_class(goal)
+            if cls not in {"mutation", "approval", "crud-roundtrip", "wizard", "webhook"}:
+                continue
+            if not goal.get("expected_assertion"):
+                continue
+            prompts.append(
+                {
+                    "goal_id": gid,
+                    "prompt": build_verifier_prompt(goal, seq),
+                }
+            )
+
+        # If --prompts-out, write and exit (orchestrator will spawn verifier)
+        if args.prompts_out:
+            args.prompts_out.parent.mkdir(parents=True, exist_ok=True)
+            with args.prompts_out.open("w", encoding="utf-8") as f:
+                for p in prompts:
+                    f.write(json.dumps(p, ensure_ascii=False) + "\n")
+            out.add(
+                Evidence(
+                    type="prompts_emitted",
+                    message=f"Emitted {len(prompts)} verifier prompts to {args.prompts_out}",
+                ),
+                escalate=False,
+            )
+            emit_and_exit(out)
+
+        # Phase 2: gate on verifier-results if provided
+        if not args.verifier_results or not args.verifier_results.exists():
+            # No verdicts available — degrade to advisory
+            out.add(
+                Evidence(
+                    type="verifier_not_run",
+                    message=(
+                        f"{len(prompts)} goal(s) need adversarial verification but no "
+                        f"--verifier-results provided. Orchestrator must spawn verifier first."
+                    ),
+                    fix_hint=(
+                        "Run validator twice: (1) --prompts-out=path emits prompts, "
+                        "(2) orchestrator spawns Haiku per prompt, (3) re-run with "
+                        "--verifier-results=results.jsonl to gate."
+                    ),
+                ),
+                escalate=False,
+            )
+            emit_and_exit(out)
+
+        # Parse verdicts
+        verdicts: dict[str, dict] = {}
+        for line in args.verifier_results.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                v = json.loads(line)
+                if "goal_id" in v:
+                    verdicts[v["goal_id"]] = v
+            except json.JSONDecodeError:
+                continue
+
+        violations = 0
+        for p in prompts:
+            gid = p["goal_id"]
+            verdict = verdicts.get(gid)
+            if not verdict:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="verifier_verdict_missing",
+                        message=f"{gid}: no verifier verdict in {args.verifier_results}",
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_business_drift),
+                )
+                continue
+
+            alignment = verdict.get("alignment", "unknown").lower()
+            if alignment != "yes":
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="business_alignment_failed",
+                        message=(
+                            f"{gid}: adversarial verifier returned alignment='{alignment}' "
+                            f"drift_type='{verdict.get('drift_type', '?')}'. "
+                            f"Summary: {verdict.get('summary', '')}"
+                        ),
+                        actual=str(verdict.get("evidence", ""))[:200],
+                        expected=str(verdict.get("missing_actions", "")),
+                        fix_hint=(
+                            "Re-run /vg:review for this goal with explicit instruction to "
+                            "perform missing_actions. Scanner shortcut detected."
+                        ),
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_business_drift),
+                )
+
+        if violations and (args.severity == "warn" or args.allow_business_drift):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} alignment failures downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-test-traces-to-rule.py
+++ b/scripts/validators/verify-test-traces-to-rule.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Verify generated .spec.ts files cite goal_id + business_rule + assertion.
+
+Closes Phase 3.2 dogfood gap: test codegen produces tests that pass green
+without verifying the actual business rule. Test header should cite parent
+goal + rule. Test body should reference rule constant.
+
+Required test header format:
+  // Goal: G-XX | Rule: BR-NN | Assertion: <verbatim quote>
+
+Severity: BLOCK at /vg:test post-codegen.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+from _traceability import (  # noqa: E402
+    parse_goals_with_frontmatter,
+    text_similarity,
+)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def find_spec_files(phase_dir: Path) -> list[Path]:
+    """Locate .spec.ts files for this phase.
+
+    Convention: tests live under apps/*/e2e/<phase>/*.spec.ts or
+    apps/web/e2e/generated/<phase>/*.spec.ts.
+    """
+    repo_root = Path.cwd()
+    candidates: list[Path] = []
+    patterns = [
+        f"apps/**/e2e/{phase_dir.name}/*.spec.ts",
+        f"apps/**/e2e/generated/{phase_dir.name}/*.spec.ts",
+        f"apps/**/e2e/**/{phase_dir.name.split('-')[0]}*.spec.ts",
+    ]
+    for pat in patterns:
+        candidates.extend(repo_root.glob(pat))
+    # Dedupe
+    return list(dict.fromkeys(candidates))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify .spec.ts traces goal+rule")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    parser.add_argument("--allow-test-untraced", action="store_true")
+    args = parser.parse_args()
+
+    out = Output(validator="test-traces-to-rule")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        if not goals_path.exists():
+            emit_and_exit(out)
+
+        goals = parse_goals_with_frontmatter(_read(goals_path))
+        spec_files = find_spec_files(phase_dir)
+        if not spec_files:
+            # No tests yet — /vg:test hasn't run. Not a violation here.
+            emit_and_exit(out)
+
+        # Build goal_id → expected text map
+        goal_map = {g["id"]: g for g in goals}
+        violations = 0
+
+        for spec in spec_files:
+            text = _read(spec)
+            # Find which goal(s) this test claims to cover
+            cited_goals = set(re.findall(r"\bG-\d+\b", text[:2000]))  # header zone
+            if not cited_goals:
+                violations += 1
+                out.add(
+                    Evidence(
+                        type="spec_no_goal_cited",
+                        message=f"{spec.name}: no Goal G-XX citation in first 2KB (header)",
+                        file=str(spec),
+                        fix_hint="Add `// Goal: G-XX | Rule: BR-NN | Assertion: <quote>` header",
+                    ),
+                    escalate=(args.severity == "block" and not args.allow_test_untraced),
+                )
+                continue
+
+            for gid in cited_goals:
+                goal = goal_map.get(gid)
+                if not goal:
+                    continue
+                # Check business_rules cited
+                if goal.get("business_rules"):
+                    cited_rules = re.findall(r"\bBR-[\w]+\b", text[:2000])
+                    expected_rules = set(goal["business_rules"])
+                    if not (set(cited_rules) & expected_rules):
+                        violations += 1
+                        out.add(
+                            Evidence(
+                                type="spec_no_rule_cited",
+                                message=(
+                                    f"{spec.name} cites {gid} but doesn't cite expected "
+                                    f"business_rules {expected_rules}"
+                                ),
+                                file=str(spec),
+                                fix_hint=f"Add `// Rule: {next(iter(expected_rules))}` to header",
+                            ),
+                            escalate=(args.severity == "block" and not args.allow_test_untraced),
+                        )
+
+                # Check expected_assertion text similarity to spec content
+                if goal.get("expected_assertion"):
+                    sim = text_similarity(goal["expected_assertion"], text[:5000])
+                    if sim < 0.3:
+                        violations += 1
+                        out.add(
+                            Evidence(
+                                type="spec_assertion_drift",
+                                message=(
+                                    f"{spec.name} cites {gid} but content similarity "
+                                    f"{sim:.2f} vs expected_assertion is low"
+                                ),
+                                file=str(spec),
+                                expected=goal["expected_assertion"][:120],
+                                fix_hint="Test body should verify expected_assertion semantics",
+                            ),
+                            escalate=False,  # Soft warning — body similarity is weak signal
+                        )
+
+        if violations and (args.severity == "warn" or args.allow_test_untraced):
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{violations} test trace gap(s) downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-ui-scope-coherence.py
+++ b/scripts/validators/verify-ui-scope-coherence.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Validator: verify-ui-scope-coherence — UI scope vs PLAN coherence gate.
+
+Cross-checks `.ui-scope.json` (authoritative AI semantic detection from
+preflight/detect-ui-scope.py) against PLAN.md FE-task count to catch the
+class of bugs where:
+
+  A) SPECS says "phase has UI" but planner ships zero FE tasks
+     → silent UI gap, build produces backend only, UAT fails (L-002)
+
+  B) SPECS says "phase is backend-only" but planner spawns FE tasks anyway
+     → scope violation, FE leaks into wrong phase, design refs missing
+
+Mismatch → BLOCK with explicit fix hints.
+PASS = scope decision matches PLAN reality.
+
+Usage:  verify-ui-scope-coherence.py --phase 4.3
+        verify-ui-scope-coherence.py --phase 6 --strict
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, timer, emit_and_exit, find_phase_dir  # noqa: E402
+
+
+FE_PATH_RE = re.compile(
+    r"<file-path>\s*("
+    r"apps/(admin|merchant|vendor|web)/[^<\s]+|"
+    r"packages/ui/[^<\s]+|"
+    r"[^<\s]+\.(tsx|jsx|vue|svelte)"
+    r")\s*</file-path>",
+    re.IGNORECASE,
+)
+
+# Tasks that touch FE patterns even if file path uses generic naming
+FE_DESC_HINT_RE = re.compile(
+    r"\b(React component|JSX|TSX|page component|Tailwind|Shadcn|Zustand|TanStack|"
+    r"sidebar|topbar|navbar|modal|drawer|wizard|stepper|form component|UI component|"
+    r"frontend route|FE route|client-side router)\b",
+    re.IGNORECASE,
+)
+
+
+def count_fe_tasks(plan_text: str) -> tuple[int, list[str]]:
+    """Return (count, examples). Splits PLAN by `### Task N` and checks each."""
+    task_blocks = re.split(r"(?m)^### Task \d+", plan_text)
+    fe_tasks = []
+    for i, block in enumerate(task_blocks[1:], 1):
+        if FE_PATH_RE.search(block):
+            # Extract file-path for evidence
+            m = FE_PATH_RE.search(block)
+            fe_tasks.append(f"Task {i}: {m.group(1)[:80]}")
+    return len(fe_tasks), fe_tasks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--strict", action="store_true",
+                        help="treat low-confidence (<0.5) ui-scope as BLOCK")
+    parser.add_argument("--allow-mismatch", action="store_true",
+                        help="downgrade BLOCK to WARN (logs override-debt elsewhere)")
+    args = parser.parse_args()
+
+    out = Output(validator="ui-scope-coherence")
+
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(
+                type="phase_dir_not_found",
+                message=f"Phase {args.phase} directory not found",
+                fix_hint="Verify phase number; run /vg:scope <phase> first.",
+            ))
+            return emit_and_exit(out) or 1
+
+        ui_scope_path = phase_dir / ".ui-scope.json"
+        plan_path = phase_dir / "PLAN.md"
+
+        if not plan_path.exists():
+            out.warn(Evidence(
+                type="plan_not_found",
+                message=f"PLAN.md not found at {plan_path}",
+                fix_hint="Run /vg:blueprint <phase> step 2a first.",
+            ))
+            return emit_and_exit(out) or 0
+
+        if not ui_scope_path.exists():
+            out.add(Evidence(
+                type="ui_scope_missing",
+                message=f".ui-scope.json not found at {ui_scope_path}",
+                fix_hint=(
+                    "Run preflight/detect-ui-scope.py --phase-dir <phase_dir> to "
+                    "generate authoritative UI scope decision before validation."
+                ),
+            ))
+            return emit_and_exit(out) or 1
+
+        try:
+            scope = json.loads(ui_scope_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            out.add(Evidence(
+                type="ui_scope_parse_error",
+                message=f".ui-scope.json invalid JSON: {e}",
+                file=str(ui_scope_path),
+                fix_hint="Re-run preflight/detect-ui-scope.py --force to regenerate.",
+            ))
+            return emit_and_exit(out) or 1
+
+        has_ui_declared: bool = bool(scope.get("has_ui", False))
+        confidence: float = float(scope.get("confidence", 0.0))
+        evidence_quote: str = scope.get("evidence", "")[:200]
+        deferred_to: str | None = scope.get("deferred_to")
+        method: str = scope.get("method", "unknown")
+        ui_kinds: list[str] = scope.get("ui_kinds") or []
+
+        # Strict-mode confidence floor
+        if args.strict and confidence < 0.5:
+            out.add(Evidence(
+                type="low_confidence_strict",
+                message=f"ui-scope confidence={confidence:.2f} below 0.5 threshold (--strict)",
+                expected="confidence >= 0.5",
+                actual=str(confidence),
+                fix_hint=(
+                    "Re-run detect-ui-scope.py with --force, or run an "
+                    "AskUserQuestion fallback to confirm 'has_ui' manually."
+                ),
+            ))
+
+        # Count FE tasks in PLAN
+        plan_text = plan_path.read_text(encoding="utf-8")
+        fe_count, fe_examples = count_fe_tasks(plan_text)
+
+        # Decision matrix
+        if has_ui_declared and fe_count == 0:
+            # Case A: silent UI gap
+            out.add(Evidence(
+                type="ui_declared_no_fe_tasks",
+                message=(
+                    f"ui-scope declares has_ui=true (confidence={confidence:.2f}, "
+                    f"method={method}, kinds={ui_kinds}) but PLAN.md has ZERO FE "
+                    f"tasks (file paths matching apps/admin|merchant|vendor|web/, "
+                    f"packages/ui/, or .tsx/.jsx/.vue/.svelte)."
+                ),
+                file=str(plan_path),
+                expected=f"FE tasks > 0 (UI scope: {ui_kinds})",
+                actual="0 FE tasks",
+                fix_hint=(
+                    "Either (a) re-run /vg:blueprint to add FE tasks covering the "
+                    "declared UI surface; or (b) if UI is actually deferred, edit "
+                    "SPECS.md to clarify and re-run preflight/detect-ui-scope.py "
+                    "--force; or (c) run with --allow-mismatch (logs override-debt) "
+                    "if scope is intentionally split (FE in a sibling phase)."
+                ),
+            ))
+        elif not has_ui_declared and fe_count > 0:
+            # Case B: scope violation — FE leaked into BE-only phase
+            out.add(Evidence(
+                type="be_only_with_fe_leak",
+                message=(
+                    f"ui-scope declares has_ui=false (confidence={confidence:.2f}, "
+                    f"deferred_to={deferred_to or 'N/A'}) but PLAN.md has {fe_count} "
+                    f"FE task(s) — FE leaked into a backend-only phase."
+                ),
+                file=str(plan_path),
+                expected="0 FE tasks (phase is backend-only)",
+                actual=f"{fe_count} FE tasks: {fe_examples[:3]}",
+                fix_hint=(
+                    "Either (a) re-plan and remove FE tasks (move to the phase "
+                    "named in deferred_to); or (b) edit SPECS to include UI "
+                    "scope and re-run preflight/detect-ui-scope.py --force; "
+                    "or (c) --allow-mismatch (log override-debt) if FE files "
+                    "are intentional (e.g., shared component used by future phase)."
+                ),
+            ))
+        else:
+            # Coherent: both true (UI phase with FE tasks) or both false (BE phase, no FE)
+            pass
+
+        # Downgrade BLOCK → WARN under --allow-mismatch
+        if args.allow_mismatch and out.verdict == "BLOCK":
+            # Convert all evidence to WARN-level
+            out.verdict = "WARN"
+
+        # If no findings at all, emit positive evidence so the operator sees the gate ran
+        if not out.evidence:
+            out.evidence.append(Evidence(
+                type="coherent",
+                message=(
+                    f"PASS: ui-scope (has_ui={has_ui_declared}, "
+                    f"confidence={confidence:.2f}, method={method}) "
+                    f"matches PLAN ({fe_count} FE tasks). "
+                    f"Evidence: {evidence_quote}"
+                ),
+            ))
+
+    return emit_and_exit(out) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/skills/vg-haiku-scanner/SKILL.md
+++ b/skills/vg-haiku-scanner/SKILL.md
@@ -422,6 +422,12 @@ optional fields — no breaking change for web.
 - Fill and submit EVERY form you find.
 - **After EVERY form submit → run Persistence Probe (Layer 4). Record `persistence_probe: {persisted, pre, post, diff}`. No exceptions except read-only forms + final-step-of-wizard + file-upload (document skip reason).**
 - Test BOTH branches of EVERY confirm dialog (Cancel first, then OK).
+- **⛔ ANTI-CANCEL ENFORCEMENT (v2.46+ — closes Phase 3.2 dogfood meta-bug):**
+  - For ANY goal with `mutation_evidence` declared in TEST-GOALS — scanner MUST execute the OK/Submit path AT LEAST ONCE per goal. Cancelling without ever submitting = AUTOMATIC `match: no` for the goal step, NOT `match: yes`.
+  - Sandbox is a mutation environment by design (`disposable_seed_data: true` in ENV-CONTRACT). Refusing to submit because "destructive" or "modify real data" is a CONTRACT VIOLATION — sandbox seed regenerates per /vg:test run.
+  - If orchestrator (commander) prompt explicitly tells you "Cancel modals only" or "do not submit", you MUST still record `observations[].observed: "scanner_skipped_submit_per_orchestrator_directive"` with `match: unknown`. NEVER `match: yes` when submit was skipped — that fabricates passing evidence.
+  - On submit, capture FULL network chain (preflight CSRF/auth GET + mutation POST + post-mutation GET for persistence). Server errors (403 CSRF, 401 AUTH, 5xx) are FACTUAL OBSERVATIONS — record them with `match: no` + verbatim error code. NEVER classify them as "expected security check" or "as designed" (banned vocabulary per scanner-report-contract Section 1).
+  - Exception (only valid skip): goal explicitly declares `mutation_required: false` in TEST-GOALS frontmatter. Default for goals with `mutation_evidence` is `mutation_required: true`.
 - Record console errors after EVERY action.
 - Record network requests after EVERY action.
 - Re-snapshot after EVERY click and append new elements.


### PR DESCRIPTION
## Problem (Phase 3.2 dogfood — 2026-05-01)

User báo bug: Admin bấm Approve Topup → fill modal → bấm Approve → 403 AUTH_CSRF_MISSING.

Truy nguyên trong RUNTIME-MAP cũ thì G-10 (Admin approve topup) marked READY, scanner ghi nhận:
> "Reject drawer shows. Reason field validates 3-char minimum. Form accepts input. **CSRF token prevented actual submission (expected - security check)**."

Scanner SAW CSRF block, classified as "expected security check", mark goal `passed`. Matrix passed → /vg:test reads matrix passed → bug ships.

Quá khắp Phase 3.2: 5 goals (G-31, G-34, G-35, G-44, G-52) marked passed mà goal_sequences.steps[] không có submit click. Performative review pattern.

## Root cause

Scanner trong /vg:review (vg-haiku-scanner skill) Cancel modal mặc định để tránh mutate sandbox data. Nhưng sandbox declares `disposable_seed_data: true` — đó là môi trường ĐỂ mutate. Scanner refuse to submit → never test happy path → CSRF/auth/idempotency bugs slip through.

## 4 enforcement layers

### 1. scanner-report-contract.md — banned vocabulary mới
- ` expected security`, `as designed`, `expected behavior`, `working as intended`
- `cancel` (khi explaining mutation goal không submit)

Scanner KHÔNG được self-rationalize — observation only, commander adjudicates.

### 2. vg-haiku-scanner/SKILL.md — Anti-Cancel Enforcement
- Goal có `mutation_evidence` → MUST submit ≥1 lần
- Cancel-only mà không submit = AUTOMATIC `match: no`, NEVER `match: yes`
- Sandbox = disposable seed → mutate thoải mái

### 3. verify-mutation-actually-submitted.py (validator mới)
4 violation types:
- cancel-only steps
- no submit-class step
- submit step but no 2xx mutation network
- rationalization vocabulary

Default severity=BLOCK; override --allow-cancel-only-mutations (logs OVERRIDE-DEBT).

### 4. review.md Phase 4 — wire validator
Sau matrix-evidence-link, trước run-complete. Block run-complete nếu detect violation.

## Dogfood verification

Test trên Phase 3.2 hiện tại:
\`\`\`
$ python3 .claude/scripts/validators/verify-mutation-actually-submitted.py --phase 3.2 --severity warn
{
  "verdict": "WARN",
  "evidence": [
    {"type": "mutation_passed_without_submit_step", "message": "G-31: marked passed but goal_sequences.steps has no submit/approve/confirm click action..."},
    {"type": "mutation_passed_without_submit_step", "message": "G-34: ..."},
    ...
  ]
}
\`\`\`

Bắt được 5 false-PASS goals. Validator works as intended.

## Test plan
- [ ] Re-run /vg:review 3.2 với new enforcement → expect block run-complete on existing fabricated matrix
- [ ] Re-spawn Haiku scanners với new SKILL — expect goals submit + capture CSRF error verbatim
- [ ] Apply Phase 3.2 actual fixes (CSRF FE setup) → re-review → expect mutations succeed → matrix legit READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)