### PR TITLE
RFC: test-data prerequisites for review/test workflow

### DIFF
--- a/docs/discussions/test-data-prerequisites-crossai-review.md
+++ b/docs/discussions/test-data-prerequisites-crossai-review.md
@@ -1,0 +1,138 @@
+# Cross-AI review synthesis: RFC #80 + Wave-3.x harness
+
+**Date:** 2026-05-02
+**Reviewers:** Codex GPT-5.5 (full review), Claude Sonnet 4.6 (full review), Gemini Pro 3.1 (quota exhausted, skipped)
+**Scope:** RFC test-data-prerequisites D1-D8 + wave-3.x harness fixes (PR #79)
+**Verdict:** RFC direction sound but has 5 HIGH-severity correctness/safety holes that should land BEFORE PR-A is written.
+
+## Convergent findings (both reviewers flagged HIGH)
+
+These show up in both Codex and Claude reviews independently. Treat as load-bearing concerns.
+
+### 1. D7 preflight non-convergence — shared trigger entity (CORRECTNESS BUG)
+
+Both reviewers identified this as a core algorithm bug, not an edge case.
+
+**Scenario:** G-10 (admin approves tier2 topup) and G-11 (admin rejects tier2 topup) both declare `setup_recipe: G-10` invariant "≥1 tier2 pending exists". Preflight creates 1 row. Concurrent scanners run. G-10 approves → row leaves pending. G-11 finds 0 rows → SUSPECTED. `--retry-failed` re-runs preflight, creates another row, G-11 passes. But if G-10 was also in retry set for any reason, scanners ping-pong forever.
+
+**Why it's worse than it looks:** the invariant schema treats "≥1 row" as the success condition, but mutation goals CONSUME their trigger entity. N consumers = need N rows, not 1.
+
+**Fix (both reviewers converged):** preflight counts consumers per invariant from the matrix, creates N entities, stores each in `.fixture-cache.json` keyed by `G-XX` not by invariant. Schema needs `setup_recipe` to express consumer count or per-goal isolation.
+
+**Impact:** changes both D5 schema and D7 algorithm. Must resolve before PR-A is written.
+
+### 2. Wave-3.2.2 evidence provenance hole — already shipped, hotfix needed
+
+Claude flagged HIGH; Codex flagged separately as "spoofable promotion."
+
+**Scenario:** wave-3.2.2 promotes SUSPECTED → READY when `goal_sequence has submit + 2xx`. But the goal_sequence JSON is writable by executor agents, scanner agents, and orchestrator code paths. An executor can hand-write a fake submit step with status 200 — sync flips status to READY, no re-validation, no scanner ever ran.
+
+**Why critical:** this is currently live in PR #79. The matrix-staleness validator we shipped relies on goal_sequence integrity. Without provenance, the verification model PR #79 was supposed to repair has a back door.
+
+**Fix:** add `evidence_source: "scanner" | "executor" | "orchestrator"` field to goal_sequence steps. Bidirectional sync only promotes on `scanner`-sourced evidence. Other sources are informational, never trigger status change.
+
+**Impact:** independent hotfix to PR #79. Not blocked by RFC #80 implementation. Should land before PR-A so PR-A can rely on the trust model.
+
+### 3. Sandbox accumulation + financial side effects
+
+Both reviewers flagged HIGH. RFC's "richer = easier" stance is too optimistic for billing domains.
+
+**Concrete risks:**
+- Phase 3.2 fixtures POST to `/wallet/topup-requests` → real wallet balance entries. Even sandbox, accumulates over time. Dashboards see inflated topup volume.
+- Live gateway webhooks fire on sandbox topups (common). External side effects.
+- Reconciliation jobs see fixture-created amounts.
+- Unique constraints, rate limits, pagination degrade after N runs.
+- Admin queue UI shows fixture rows mixed with real merchant requests — finance team can't distinguish.
+
+**Fix (both reviewers):**
+- Hard environment safety gate in runner: refuse unless `environment.kind: sandbox` + server confirms via `/health` header `X-VGFlow-Sandbox: true`
+- Required fixture sentinel values: amount ≤ 0.01 for currency-like fields, email domain `@fixture.vgflow.test`, reference prefix `VG_FIXTURE_`
+- Add `side_effect_risk: money_like` field on recipe steps; runner refuses on prod-like envs
+
+**Impact:** schema additions; gate code in runner. Must land in PR-A.
+
+### 4. D8 tag-based delete assumes a metadata column that often doesn't exist
+
+Both reviewers questioned this. Many real schemas — especially financial ledger rows, immutable audit records, join tables, external payment objects — cannot accept arbitrary metadata fields.
+
+**Codex suggestion:** support external tag registries — `.fixture-cache.json` records `{resource, id, run_id}` even when entity can't store metadata. Prune deletes by registry first, optional marker fields second.
+
+**Claude suggestion:** change contract to "creation timestamp + reference pattern + explicit per-entity-type tag-field mapping in `vg.config.fixtures.entity_types`." Project configures which field per entity. Fallback: time-window delete.
+
+**Impact:** D8 contract changes. Schema implications for D2 (`reference` field becomes mandatory + standardized). Must specify before PR-A bakes the schema.
+
+### 5. D2 schema gaps — multi-value capture, loops, run_id collisions
+
+Both flagged that the strawman schema doesn't handle real cases:
+
+- **JSONPath cardinality undefined** (Claude HIGH): `$.items[*].id` returns array. Strawman shows scalars only. What does runner do — first element? Silent truncation? Loop semantics?
+- **Loop steps missing** (both): G-52 IMAP CRUD needs N existing configs. No `kind: loop` step type.
+- **run_id collision** (Claude MEDIUM): two concurrent `/vg:review` against same sandbox both compute "0 tier2 pending" → both create rows → both write `.fixture-cache.json` → race. Unspecified format.
+- **Optional/conditional steps** (Codex): no escape hatch for "create only if doesn't exist."
+
+**Fix:**
+- Specify cardinality rules: 0 matches = fail unless `optional: true`; 1 match = scalar; >1 = array
+- Add `kind: loop` step with `over: [...]` and `count: N`
+- `run_id` format: `{timestamp_ms}-{random_4hex}` mandated
+- Atomic file writes for `.fixture-cache.json` (write tmp + rename) OR per-run files `.fixture-cache-{run_id}.json`
+
+**Impact:** schema spec extensions. Must land in PR-A.
+
+## Codex-unique observations worth integrating
+
+- **Auth gaps are bigger than 4 kinds.** Public-framework adoption needs SAML, mTLS, HMAC signing, refresh-token rotation, MFA flows, CSRF, tenant-scoped auth. Recommended escape hatch in v1: `auth.kind: command` returning headers/cookies JSON. Keeps default declarative, unblocks exotic stacks without forcing upstream contributions.
+- **Recovery commands need test coverage.** `/vg:doctor recovery` prints recovery commands to user. Each violation→command mapping should have a test fixture asserting the command actually changes the violation state, or explicitly marks itself manual-only. Otherwise commands rot into cargo-cult.
+- **Backend goals excluded from matrix-staleness need equivalent backend evidence validation.** Filter to UI-only is necessary; replacing it with "we trust replay-evidence + surface-probe will catch backend gaps" needs a parallel backend-staleness validator, not just exemption.
+- **`fixture_intent` cross-reference.** Add a block linking fixture fields back to `mutation_evidence` requirements declared in TEST-GOALS, so a separate validator can compare blueprint intent vs fixture reality (catches "fixture passes scanner but doesn't match test-goal intent").
+
+## Claude-unique observations worth integrating
+
+- **Token refresh inside multi-step recipes.** 15-min JWT expires mid-recipe (step 3 of 5 hits 401). Auth module needs to track issue time + expiry, re-authenticate when TTL < 10% remaining before each step. Currently silent failure mode.
+- **Build-time fixture smoke-execution, not just schema validation.** `verify-build-fixtures-present.py` validates YAML structure but not semantic correctness — executor can write a fixture pointing to wrong endpoint. Build wave gate should *execute* the fixture against sandbox at build time. Adds ~30s/goal, catches broken fixtures immediately at build, not 3 PRs later at preflight.
+- **Single recipe runtime hides two protocols.** `/vg:review` preflight = once-per-phase shared state. `/vg:test` `beforeEach` = once-per-test isolated state. The YAML works structurally for both, but `EXPECTED_ROW_ID` injection has different lifecycle for each consumer. Add explicit `review_mode` / `test_mode` sections OR `semantics: shared | isolated` field. Hiding two protocols in one schema makes "no drift" superficially true but structurally fragile.
+- **Auth escape hatch should be local hook, not upstream PR.** Project with custom OAuth/HMAC modifies vgflow core = fork + PR + review + merge cycle. Blocks dogfood-stage adoption. Local plugin file (`fixture-auth-plugin.{py,sh}` in project root) loaded by runner unblocks fast adoption without forcing upstream contributions.
+- **Docker image as universal portability layer.** Solves both "Python in CI" and "JS-only shop" concerns. Ship `Dockerfile` for the runner.
+- **Concurrent /vg:review races on .fixture-cache.json.** Two developers on shared sandbox both run preflight, both create rows, last-writer-wins on cache file → first runner's scanner uses wrong ID. Atomic writes or per-run files mandatory.
+- **DEFERRED status compounds across phases.** 8% in Phase 3.2 grows as billing-domain phases stack. After 5 phases possibly 15+ DEFERRED goals. Add `blocked_since_phase` field; surface in health checks as technical debt.
+
+## TOP-5 priorities BEFORE PR-A is opened
+
+Synthesizing both reviewer rankings + my own filter:
+
+1. **Fix wave-3.2.2 evidence provenance hole (independent hotfix to PR #79).** Add `evidence_source` field; only `scanner`-sourced evidence triggers READY promotion. Current code is exploitable.
+2. **Resolve D7 preflight non-convergence — preflight counts N consumers, creates N entities.** Algorithm bug, must fix before any schema is written.
+3. **Specify D2 schema gaps fully** — JSONPath cardinality rules, `kind: loop` step type, `run_id` format, atomic cache writes, optional steps. Schema is foundational; getting it right prevents cascade rework in PR-B/D/E.
+4. **Sandbox safety guardrails** — environment kind check, sentinel values, side_effect_risk field. Public-framework grade can't ship a billing fixture runner without safety rails.
+5. **D8 tag-based prune contract revision** — registry-based + per-entity-type field mapping + time-window fallback. Schema implications cascade into D2 (reference field becomes mandatory + standardized).
+
+## Items to defer to follow-up (not PR-A blockers)
+
+- Auth escape hatch via local plugin (D1 — addressable in PR-A or PR-B without rework)
+- Build-time fixture smoke-execution (refinement to PR-B, not PR-A)
+- Token refresh in auth module (PR-A scope, but standard pattern)
+- Schema versioning + deprecation policy (PR-A scope, low risk)
+- Recovery command test coverage (separate harness PR)
+- DEFERRED tracking with `blocked_since_phase` (small wave-3.2.3 patch)
+- `fixture_intent` cross-reference (PR-B refinement)
+
+## What both reviewers said WAS solid
+
+- D6 codegen runtime call (vs transpile) — DRY wins, both endorsed
+- Authoring at /vg:build is directionally right (executor knows API shape)
+- Single source-of-truth YAML is good anti-drift principle if schema boundaries explicit
+- Rejecting scanner self-help (option D) is correct — non-deterministic
+- D7 making invariant gaps BLOCK (not silent SUSPECTED) directly fixes original failure mode
+- Bidirectional sync is necessary; one-way SUSPECTED would trap valid fixes
+- Recovery paths are strong UX improvement IF treated as code (validated, tested)
+
+## Reviewer caveats
+
+- **Codex GPT-5.5** delivered the most thorough review (56KB output, full A-E coverage + TOP-3).
+- **Claude Sonnet 4.6** delivered detailed review with strong concrete scenarios (G-10/G-15 ping-pong example).
+- **Gemini Pro 3.1** quota-exhausted (HTTP 429), no review obtained. Re-run when quota resets if user wants 3rd voice.
+
+## Recommended next move
+
+Open a focused **wave-3.2.3 hotfix PR** for evidence provenance (item 1 above) — fast, independent of RFC. Then revise RFC #80 with items 2-5 baked in (single commit, big diff). Only AFTER that, open PR-A.
+
+Estimated impact on RFC implementation timeline: +1 week pre-PR-A for hotfix + RFC revision; net result is fewer rework PRs later.

--- a/docs/discussions/test-data-prerequisites.md
+++ b/docs/discussions/test-data-prerequisites.md
@@ -1,14 +1,16 @@
-# Discussion: Test-data prerequisites for review/test workflow
+# RFC: Test-data prerequisites for review/test workflow
 
-**Status:** RFC — discussion only, no code yet
+**Status:** Direction chosen 2026-05-02, design questions remain
 **Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2.x dogfood run
 **Related:** PR #79 (recovery paths + matrix-staleness), PR #74 (anti-performative-review)
+
+---
 
 ## The problem in one paragraph
 
 `/vg:review` and `/vg:test` need realistic application **state** to verify mutation goals. Phase 3.2 G-10 says "Admin approves tier2 topup request"; sandbox seed has 12 tier1 rows and 0 tier2 rows. Scanner navigates to `/billing/topup-queue`, sees only tier1 rows showing "Auto via webhook" placeholder, can't click an Approve button that doesn't exist for tier1, and reports `no_submit_step`. The matrix-staleness validator correctly flags SUSPECTED. But the **root cause is missing data**, not missing UI or missing code. We can re-run scanners forever without ever creating the data they need to exercise.
 
-This is the meta-bug behind ~21 of the 36 mutation goals flagged in the dogfood run: not "scanner missed it" but "nothing to scan because the trigger entity doesn't exist in seed".
+This is the meta-bug behind ~21 of 36 mutation goals flagged in the dogfood run: not "scanner missed it" but "nothing to scan because the trigger entity doesn't exist in seed".
 
 ## Concrete failure modes observed in Phase 3.2
 
@@ -16,9 +18,8 @@ This is the meta-bug behind ~21 of the 36 mutation goals flagged in the dogfood 
 |---|---|---|---|
 | G-10 admin approve tier2 topup | tier2 topup row in `pending` | only tier1 rows | scanner sees no Approve button → SUSPECTED |
 | G-19 merchant cancels pending withdraw | merchant has pending withdraw | empty wallet, no withdraws | route renders empty state → SUSPECTED |
-| G-20 admin approve withdraw | admin sees withdraw queue with rows | (TypeError on the route, separate bug) | unrelated infra fail |
 | G-23 admin resets cooling period | merchant currently cooling | no cooling-period state | reset button never appears → SUSPECTED |
-| G-31 admin transfer group CRUD | existing transfer group OR new-group flow | empty list, no groups | only "create" path testable, edit/delete dead → partial submit only |
+| G-31 admin transfer group CRUD | existing transfer group OR new-group flow | empty list | only "create" path testable → partial submit |
 | G-34 linked accounts CRUD | linked accounts exist | empty | edit/delete unreachable |
 | G-35 bank accounts CRUD | bank accounts exist | empty | edit/delete unreachable |
 | G-44 admin sets FX rate | rate exists for given gateway×currency | inconsistent seed | sometimes editable, sometimes not |
@@ -39,194 +40,209 @@ Not all "needs data" cases are equal. From the Phase 3.2 sample:
 
 Each needs a different setup mechanism. A "tier2 topup row" might be a single API POST as merchant. A "7-day chargeback timeout" may need time-travel or a fake-clock test mode. A "frozen wallet" needs prior chargeback webhook + freeze logic to have run.
 
-## Six options for the discussion
+---
 
-### Option A: Data factories baked into seed.ts
+## Direction chosen (2026-05-02)
 
-**Idea:** Extend `apps/api/src/modules/auth/seed/sampleUsers.seed.ts` (and add similar for other modules) so the sandbox seed creates ONE of every interesting state combination — 1 tier1 topup row in pending, 1 tier2 in pending, 1 approved, 1 rejected, 1 flagged; 1 merchant in cooling period; 1 frozen wallet; etc.
+After surveying 6 options (A through F — preserved at the bottom of this doc for context), the chosen path is:
 
-Pros:
-- Simple, runs once at deploy
-- Deterministic, scanner just reads what's there
-- Easy to debug ("why is row X like this? grep seed.ts")
+> **Recipes authored at `/vg:build` time, executed before `/vg:review` scanner spawn and reused by `/vg:test` Playwright codegen. No inline cleanup — sandbox accumulates data; cleanup is a separate command users run on their own cadence. Single source-of-truth recipe artifact per mutation goal, public-framework grade.**
 
-Cons:
-- Seed file balloons (one row per state × tier × role × edge case → hundreds of records)
-- Time-driven states still hard (a "1 hour ago" row needs the seed to backdate timestamps)
-- Cross-entity relationships fragile (delete one row → cascades break)
-- Test pollution: side-effects from other tests mutate seed; G-11 reject in this dogfood run rejected one of the 12 tier1 rows, leaving 11 — next run sees inconsistent state
+### Decision 1 — Authoring lives in `/vg:build`
 
-Verdict: works for static reference data, fails for dynamic/lifecycle states.
+Executor authors fixture recipe alongside the goal it implements, because that's the only point where the API shape is concrete (handler signed, routes registered, schemas final). Blueprint-time authoring would force the planner to predict API details it hasn't designed yet; review-time authoring would force the scanner to know API shapes it shouldn't care about.
 
-### Option B: Per-goal `**Required data:**` field in TEST-GOALS.md
+Concretely: when `/vg:build` finishes a goal that has `**Mutation evidence:**` declared in TEST-GOALS.md, an additional executor sub-step writes `FIXTURES/{G-XX}.yaml` next to the goal artifacts. Build is not "done" for a mutation goal until its fixture exists. This becomes a new wave-verify gate in `/vg:build`.
 
-**Idea:** Each mutation goal declares the data it needs as a setup recipe in TEST-GOALS.md frontmatter or body section:
+Cost: yes, `/vg:build` grows. We accept it because (a) recipes need API knowledge the executor already has, (b) duplicating this knowledge into a separate `/vg:fixture` step would reorder pipeline and add a new artifact dependency, and (c) tests authored at build-time match the implementation they describe — drift is harder.
 
-```markdown
-## Goal G-10: Admin approve tier2 topup request
+### Decision 2 — Cleanup is external, not inline
 
-**Surface:** ui
-**Required data:**
+Sandbox is "richer = easier". A sandbox with 200 rows across all states is more useful for review than one with 12 rows that get rejected and disappear. We don't transactional-cleanup after each scanner run.
+
+Implication: scanner runs are NOT idempotent in the sense of "matrix returns to identical state". Re-running `/vg:review --retry-failed` on the same goal will keep creating new tier2 rows. That's fine — they're cheap. The state space we care about is "≥1 tier2 in pending exists at any given moment", not "exactly 1".
+
+Cleanup is a separate command — call it `/vg:fixture-prune` for now — that runs on user's cadence (after a milestone? Weekly via cron? At sandbox-reset?). It reads run logs, finds fixtures created by VGFlow, deletes them. Out of scope for this RFC; tracked as a follow-up.
+
+This decision **massively simplifies recipe schema** — every recipe is one-shot setup, no rollback, no compensating transaction. We lose nothing real because sandbox = disposable seed by env contract.
+
+### Decision 3 — Recipe runtime serves both `/vg:review` and `/vg:test`
+
+One artifact, two consumers:
+
+- **`/vg:review` scanner preflight** — orchestrator runs the recipe before spawning Haiku for that goal's view. Captures created entity IDs into env vars, injects them into Haiku prompt as `EXPECTED_ROW_ID=...` so scanner targets the right row.
+- **`/vg:test` Playwright codegen** — generates `test.beforeEach()` block in the spec file that runs the same recipe (transpiled from YAML to TypeScript at codegen time, OR called via shared HTTP harness — TBD in question 1).
+
+Single recipe = no drift between review's scanner expectations and test's codegen output. If recipe wrong, both fail same way; fix once.
+
+### Decision 4 — Public-framework grade
+
+VGFlow is positioned as a heavy framework other projects will adopt. Implications for this RFC:
+
+- Schema must be portable — no PrintwayV3-isms, no hardcoded auth assumptions
+- Recipe runtime must be language-agnostic at the boundary — YAML in, HTTP/CLI calls out, no project-specific Python imports
+- Failure modes must be load-bearing — a recipe failure must produce an actionable error, not a silent SUSPECTED
+- Every artifact must have a reason to exist — no `FIXTURE.md` doc that just narrates what `FIXTURES.{G-XX}.yaml` already says
+
+This bars option A (extend seed.ts) as the primary mechanism — that's PrintwayV3-specific seed code we can't ship in vgflow. Option F (data_invariants in ENV-CONTRACT.md) survives because it's declarative + portable.
+
+### Final shape: B + F
+
+- **B (per-goal recipes, build-time authored)** is primary
+- **F (data_invariants preflight gate)** is the cheap declarative wrapper — phase declares "≥1 tier2 pending must exist before scanner spawns" in ENV-CONTRACT.md; preflight verifier walks recipes from all goals in the phase, computes whether invariant is met, runs missing recipes
+- A, C, D, E **rejected for v1** — A is project-specific, C is premature abstraction (revisit after 10+ phases), D is non-deterministic, E is orthogonal (separate time-travel RFC later)
+
+---
+
+## What still needs design (open questions)
+
+These are genuine unknowns the chosen direction surfaces. Each blocks some part of implementation.
+
+### Q1 — Recipe schema specifics
+
+```yaml
+# Strawman shape, not final
+goal: G-10
+description: Admin approves tier2 topup → row must exist in pending tier2 state
+setup:
   - kind: api_call
-    description: Create a pending tier2 topup as merchant
     role: merchant-owner
     method: POST
     endpoint: /api/v1/wallet/topup-requests
-    body: { amount: 100, currency: "USD", gateway: "sunrate", reference: "test-G-10-{run_id}" }
-    capture: { request_id: "$.id" }
-**Cleanup:**
-  - kind: api_call
-    description: Revert via admin reject (so re-runs don't accumulate)
-    role: admin
-    method: POST
-    endpoint: /api/v1/admin/topup-requests/{request_id}/reject
-    body: { reason: "test cleanup", internal_note: "G-10 cleanup" }
+    body:
+      amount: 100
+      currency: USD
+      gateway: sunrate
+      reference: "vgflow-fixture-G10-{run_id}"
+    capture:
+      request_id: $.id
+expects:
+  invariant: "topup_requests.where(status=pending, tier=tier2).count >= 1"
+  capture_into:
+    EXPECTED_ROW_ID: $request_id
 ```
 
-Before the Haiku scanner spawns for that goal, orchestrator runs the recipe → captures IDs → injects into Haiku prompt as `EXPECTED_ROW_ID=...`. After scanner completes, cleanup recipe runs.
+Open: should `endpoint` be relative (vgflow resolves base URL from env) or absolute? Should `role` be a string lookup into `vg.config.credentials[env]` (current pattern) or a typed enum? How are auth tokens captured/refreshed inside multi-step recipes? Does `capture` use JSONPath, jq syntax, or YAML-native? Each impacts portability.
 
-Pros:
-- Explicit, traceable, version-controlled with the goal
-- Goal-scoped — no global seed bloat
-- Cleanup keeps sandbox clean across runs
-- Recipes can chain (G-23 cooling period needs G-22 first)
+### Q2 — Multi-step recipe support
 
-Cons:
-- One more authoring burden per goal
-- Recipes need a runtime to execute (curl harness or thin Python lib)
-- Cross-goal dependencies (graph) must be tracked
-- If recipe is wrong, you get "scanner failed" but root cause is in TEST-GOALS
+Some goals need 2+ steps to set up state — G-23 admin reset cooling period needs (a) merchant exists, (b) merchant performed N failed withdraws, (c) cooling-period flag was raised. Three sequential API calls, each capturing IDs the next uses. Recipe schema must support `steps: [...]` not just one `setup:`.
 
-Verdict: most explicit; aligns with how /vg:test will eventually want recipes for codegen anyway.
+But chained recipes have failure modes — if step 2 fails, what happens to step 1's created entity? With "no cleanup" rule (Decision 2), nothing — leave the orphan. Is that acceptable, or do we need at least best-effort cleanup on partial recipe failure?
 
-### Option C: Persona-based data wallets
+### Q3 — Recipe runtime — vgflow-side or project-side?
 
-**Idea:** Define a small set of "personas" with prebuilt complete state — `merchant-cooling`, `merchant-frozen-wallet`, `admin-with-pending-tier2-queue`. Each persona is a seed package. Test goals declare which persona's state they need.
+Two architectures:
 
-```yaml
-personas:
-  admin-tier2-queue:
-    description: Admin role, sandbox has ≥1 pending tier2 topup, ≥1 approved, ≥1 rejected
-    setup: scripts/personas/admin-tier2-queue.sh
-    used_by: [G-10, G-11, G-12]
+**(a) vgflow ships a generic recipe runner** (`scripts/run-fixture.py`) that reads YAML, makes HTTP calls, captures IDs. Project provides only the YAML content. Most portable — projects don't write code.
 
-  merchant-cooling:
-    description: Merchant currently in cooling period, with prior failed withdraw
-    setup: scripts/personas/merchant-cooling.sh
-    used_by: [G-22, G-23]
-```
+**(b) vgflow ships only the schema; projects provide their own runner** in their `scripts/fixtures/` dir. Projects can use whatever language/HTTP lib fits their stack.
 
-Goals reference persona by name; setup runs once per persona per session.
+Option (a) means vgflow has to handle every project's auth pattern (cookie? JWT header? SSO? OAuth? mTLS?). Option (b) duplicates runner code across projects but keeps vgflow language-agnostic.
 
-Pros:
-- Reusable across goals
-- Mirrors real user states ("a merchant who is cooling")
-- Lower per-goal authoring burden than B
-- Can be hand-crafted realistic scenarios, not just minimum data
+Probably (a) with a pluggable auth strategy. But pluggable how — Python entrypoints? Sub-shell scripts? YAML-declarative auth blocks?
 
-Cons:
-- Personas overlap and conflict (admin-tier2-queue creates rows; merchant-cooling deletes them?)
-- Order matters — running personas in wrong sequence breaks state
-- Not goal-scoped — debugging "which persona broke G-10" indirect
+### Q4 — Time-driven state (option E re-entry)
 
-Verdict: good middle ground; closer to how QA teams actually structure test environments.
+Decision rejected E (time-travel) for v1, but Phase 3.2 has goals like G-22 (cooling period blocks new withdraw — needs merchant with `last_failed_withdraw_at < 1h ago`), G-42 (7-day chargeback deadline), G-58 (BullMQ retry — needs job at retry attempt N).
 
-### Option D: Just-in-time data generation via scanner self-help
+These cannot be solved by API calls alone. Either:
+- Backend exposes a `X-Sandbox-Time-Advance: 8d` header that fast-forwards
+- Recipe creates entity with backdated timestamp directly via raw DB write (bypasses domain logic)
+- Defer those goals — mark them "needs time-travel infrastructure", separate RFC, accept SUSPECTED for now
 
-**Idea:** Haiku scanner detects "empty state I need to test" (no tier2 rows on /billing/topup-queue), spawns a sub-helper agent that creates the missing row via API as the right role, then continues. No setup recipe declared — scanner figures it out from goal text.
+Which path? If we defer, ~5 of 36 dogfood goals stay SUSPECTED indefinitely.
 
-Pros:
-- Zero setup overhead per goal
-- Scanner handles new goals without recipe maintenance
-- Works for unanticipated states
+### Q5 — `data_invariants` schema in ENV-CONTRACT.md
 
-Cons:
-- Scanner needs to know API endpoints — couples scanner to API contract knowledge
-- Non-deterministic: "Haiku decided to call POST /topup with these fields" — hard to reproduce failure
-- No cleanup — sandbox accumulates trash across runs
-- LLM creativity = correctness risk (scanner POSTs wrong fields → 422 → flags fake bug)
-
-Verdict: too clever; loses determinism. Reserve for prototype-only paths.
-
-### Option E: Time-travel + fake-clock test mode
-
-**Idea:** Backend exposes a "test-mode time advance" header (`X-Test-Time: 2026-05-08T00:00:00Z`) only when `NODE_ENV=sandbox` (and never in prod). Scanner sets the header to push virtual clock past 7-day deadlines, cooling periods, etc.
-
-Pros:
-- Solves the time-driven state problem (G-22, G-42, G-58) elegantly
-- No data setup overhead — just rewinds clock
-- Real production code paths exercised
-
-Cons:
-- Backend has to support fake clocks everywhere (cron jobs, scheduled tasks, retry queues)
-- Sandbox-only header risk — if it leaks to prod, time bombs
-- Doesn't help for non-time states (frozen wallet, tier2 queue)
-
-Verdict: orthogonal complement to A/B/C, not a replacement. Probably needed eventually, but separate.
-
-### Option F: ENV-CONTRACT.md declares data invariants
-
-**Idea:** Each phase declares in `ENV-CONTRACT.md` what data invariants the sandbox must maintain:
+Decision 3 says invariants live there. But the schema isn't designed yet. Strawman:
 
 ```yaml
 data_invariants:
-  topup_requests:
-    - status: pending, tier: tier2, count: ">=1"
-    - status: pending, tier: tier1, count: ">=1"
-  withdraws:
-    - status: pending, role: merchant-owner, count: ">=1"
-  merchants:
-    - cooling_period_active: true, count: ">=1"
+  - resource: topup_requests
+    where: { status: pending, tier: tier2 }
+    count: ">=1"
+    setup_recipe: G-10  # which goal's recipe creates this
 ```
 
-Before review starts, a verifier checks these invariants against the running sandbox. If any miss → emit a clear error: "Data invariant 'topup pending tier2 ≥1' not met. Run: `pnpm seed:fixture topup-tier2-pending`". A separate `pnpm seed:fixture` script library (one fixture per invariant gap) lets dev or CI fill the gap.
+Multiple goals may share an invariant (G-10 and G-12 both need tier2 pending). Whose recipe is "owner"? First in alphabetical order? First declared in TEST-GOALS? Manual `owner: G-10` field?
 
-Pros:
-- Pre-flight gate, fails fast with actionable error
-- Decouples "what data must exist" (declared) from "how to create it" (fixture script)
-- Goal authors don't write API recipes; they declare data shape
-- Fixtures composable, reusable across phases
+### Q6 — `/vg:test` codegen consumption format
 
-Cons:
-- Two artifacts to maintain (invariants + fixtures) instead of one
-- "Run pnpm seed:fixture X" still manual unless wired into deploy
+Recipe is YAML. Playwright spec is TypeScript. Two paths:
 
-Verdict: closest to how mature QA frameworks work. Invariants are declarative; fixtures are procedural.
+**(a) Codegen transpiles YAML → TS at codegen time** — every recipe becomes inline TS in the `.spec.ts` file. Spec is self-contained.
 
-## Recommended direction (pre-discussion strawman)
+**(b) Codegen emits import + call** — `await runFixture('G-10')` in the spec, the runtime imports a TS helper that reads YAML at test-run time. Spec depends on runtime + YAML files at runtime.
 
-**Hybrid A + F + opt-in B**, in that order of priority:
+Option (a) is simpler for users running the spec standalone. Option (b) is DRY — change YAML once, both review and test see new behavior. Probably (b) but adds runtime dependency.
 
-1. **Baseline (A)** — extend seed.ts to cover the static reference set per phase: 1 row per status × tier combination at minimum. Solves ~50% of cases for low cost.
+### Q7 — Preflight verifier architecture
 
-2. **Phase-level invariants (F)** — every phase declares `data_invariants` block in ENV-CONTRACT.md. `/vg:review` pre-flight verifies them before spawning Haiku. If invariant miss → BLOCK with "run fixture X" hint, not silent SUSPECTED. This is the gate that prevents the "scanner ran but had nothing to test" failure.
+Phase 2c-pre already runs `verify-env-contract.py` (preflight checks for app reachable + login works). The new `data_invariants` check fits naturally there as a third check. But:
 
-3. **Goal-level recipes (B) for stateful goals only** — opt-in per goal where the static seed cannot represent the state (cooling period, frozen wallet, recently-failed payment). Recipe runs as preflight to that one goal's scanner spawn, with cleanup after.
+- Current verifier is "smoke a thing, fail or pass" — invariant check is "query state, run recipe if missing, re-query, fail if still missing". Different shape.
+- If invariant fails AND its setup recipe also fails, what's the user-facing error? "Fixture for G-10 failed — see runs/G-10.fixture-error.json"?
+- Preflight runs once before all scanners. Should each scanner also run its own goal's recipe just-before-spawn (in case prior scanners' actions invalidated the invariant — e.g., G-11 reject removed the row G-10 needs)?
 
-Time-travel (E) deferred to a separate RFC when we hit a goal that genuinely needs it.
+### Q8 — `/vg:fixture-prune` cleanup command spec
 
-Persona model (C) deferred — not needed yet at our scale; revisit when we have 10+ phases sharing setup.
+Decision 2 puts cleanup in a separate command. Spec needed:
 
-Just-in-time (D) rejected — too non-deterministic for a verification harness.
+- What does prune delete? Only entities tagged with `vgflow-fixture-{run_id}` reference? Anything older than N days? Anything matching naming convention?
+- When does user run it? Manual after each `/vg:accept`? Scheduled? Tied to sandbox-reset?
+- How does it know which entities are fixture-created vs real test data the user wants to keep?
+- Auth: which role runs the prune? Admin with hard-delete? Or a dedicated `fixture-cleanup` role to limit blast radius?
 
-## Open questions for discussion
+This is its own mini-RFC. For now, accept that it's TBD.
 
-1. **Where does the fixture script library live?** `scripts/fixtures/` per project? Or in vgflow as a generic harness with project-supplied recipes?
-2. **Is "ENV-CONTRACT.md data_invariants" a new section or replaces CRUD-SURFACES.md `state_matrix`?** They overlap.
-3. **Cleanup contract:** if a goal's setup creates a row, is cleanup MUST or SHOULD? What happens when scanner crashes mid-test?
-4. **Idempotency:** if `/vg:review --retry-failed` re-runs a goal whose previous setup row still exists from last run — skip, replace, or fail?
-5. **Who writes recipes?** Goal author at `/vg:blueprint` time, or executor at `/vg:build` time? Different incentives — author knows intent, executor knows implementation.
-6. **Backend test-mode boundary:** if we go (E) time-travel later, what's the contract for sandbox-only test endpoints? `X-Sandbox-*` header pattern? Allow-list of test-only routes?
-7. **Cost concern:** option B/F adds a recipe-runtime per goal scanner spawn. For Phase 3.2's 36 mutation goals × 1 setup + 1 cleanup = 72 extra API calls per `/vg:review` run. Acceptable?
-8. **Scope creep:** does this RFC also cover `/vg:test` codegen (fixture-aware Playwright tests) or just `/vg:review` scanner runs?
+---
 
-## What this RFC does NOT cover
+## Out of scope (explicit non-goals)
 
 - Production data — never. Sandbox only.
 - Performance testing fixtures (different shape — 100K rows, not 1 row per state).
 - Visual regression baselines (separate concern).
 - Migration test data (handled by schema-verify profile).
+- Time-travel infrastructure (deferred to separate RFC per Q4).
+- Sandbox reset / database snapshot mechanics — outside vgflow's responsibility, project's deploy pipeline handles.
 
-## Next step
+---
 
-Discuss the strawman + open questions, pick a direction, then split into implementation PRs (likely 3-4 small ones across vgflow + PrintwayV3).
+## Implementation plan (after questions resolved)
+
+Once Q1-Q8 are answered, split into PRs:
+
+1. **PR-A: Recipe schema + JSON-Schema validator** — write the canonical YAML schema, ship as `schemas/fixture-recipe.schema.yaml`, add validator script. No runtime yet.
+2. **PR-B: `/vg:build` fixture-write step** — executor writes `FIXTURES/{G-XX}.yaml` for every goal with `mutation_evidence`. New wave-verify validator: build incomplete if mutation goal lacks fixture.
+3. **PR-C: ENV-CONTRACT.md `data_invariants` block + preflight verifier** — declarative invariant schema, runner that reads recipes + queries state + reports gaps.
+4. **PR-D: `/vg:review` scanner preflight integration** — orchestrator runs invariant check, runs missing recipes, captures IDs, injects into Haiku prompt.
+5. **PR-E: `/vg:test` codegen integration** — Playwright spec emits `runFixture(G-XX)` calls in `beforeEach`, runtime helper reads YAML.
+6. **PR-F (separate)** — `/vg:fixture-prune` cleanup command (Q8).
+7. **PR-G (separate, future)** — time-travel test-mode infrastructure (Q4).
+
+Estimated 5-7 small PRs over 2-3 weeks once Q1-Q8 land.
+
+---
+
+## Appendix: 6 options surveyed (rejected)
+
+For context — preserved from initial RFC.
+
+### Option A: Data factories baked into seed.ts
+**Rejected** — project-specific, can't ship in vgflow framework.
+
+### Option B: Per-goal `**Required data:**` recipes in TEST-GOALS.md
+**Adopted as primary** (with build-time authoring per Decision 1).
+
+### Option C: Persona-based data wallets
+**Rejected for v1** — premature abstraction. Revisit when 10+ phases share setup patterns.
+
+### Option D: Just-in-time scanner self-help
+**Rejected** — non-deterministic. Scanner inventing API calls = correctness risk.
+
+### Option E: Time-travel + fake-clock test mode
+**Deferred** — orthogonal to recipes. Separate RFC when first goal genuinely blocks (Q4).
+
+### Option F: ENV-CONTRACT.md `data_invariants` + fixture library
+**Adopted as preflight gate wrapper** around B.

--- a/docs/discussions/test-data-prerequisites.md
+++ b/docs/discussions/test-data-prerequisites.md
@@ -1,7 +1,8 @@
 # RFC: Test-data prerequisites for review/test workflow
 
-**Status:** Direction + design decisions chosen 2026-05-02, ready to split into implementation PRs
+**Status (v4, 2026-05-02):** Direction + decisions D1-D10 chosen, cross-AI reviewed (Codex GPT-5.5 + Claude Sonnet 4.6), 5 HIGH findings baked in, ready to bundle with wave-3.2.3 hotfix and split into implementation PRs.
 **Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2.x dogfood run
+**Cross-AI review:** see [`test-data-prerequisites-crossai-review.md`](test-data-prerequisites-crossai-review.md) for full synthesis
 **Related:** PR #79 (recovery paths + matrix-staleness), PR #74 (anti-performative-review)
 
 ---
@@ -98,84 +99,165 @@ This bars option A (extend seed.ts) as the primary mechanism — that's Printway
 
 The 8 questions surfaced after Decisions 1-4 are now answered. Each decision below has rationale + immediate implication for implementation.
 
-### D1 (was Q3) — Runtime architecture: vgflow ships generic runner, pluggable auth via YAML
+### D1 (was Q3) — Runtime: generic Python runner, declarative auth + escape hatch + Docker
 
-Vgflow ships `scripts/run-fixture.py` (or equivalent — language TBD at PR-A time but Python likely) that reads recipe YAML, performs HTTP calls, captures responses. Project supplies only YAML content; no project-side runner code.
+Vgflow ships `scripts/run-fixture.py` (Python 3.11+) that reads recipe YAML, performs HTTP calls, captures responses. Also ships `Dockerfile` so JS-only / Python-less CI environments can run it as a container — solves "stack pollution" objection.
 
-Auth pluggability is **YAML-declarative**, not Python entrypoints. Project declares in `vg.config.environments.{env}.auth`:
+**Auth pluggability — three layers, declarative-first:**
 
 ```yaml
+# Layer 1: declarative (covers ~80% — built into runner)
 auth:
-  kind: cookie       # or: bearer, session, api-key
+  kind: cookie | bearer | api-key | oauth-client-credentials
   login_endpoint: /api/v1/auth/login
   body_template:
     email: "{role.email}"
     password: "{role.password}"
   capture:
-    cookie: connect.sid          # for kind=cookie
-    # or token_path: $.token     # for kind=bearer
+    cookie: connect.sid
+    # or: token_path: $.token
+  # NEW: token lifecycle (Claude review — solves mid-recipe 401 on JWT expiry)
+  token_ttl_hint_seconds: 900           # optional, runner re-auths when TTL < 10%
+  refresh_endpoint: /api/v1/auth/refresh # optional
+
+# Layer 2: command escape hatch (covers exotic stacks — SAML/mTLS/HMAC/MFA)
+auth:
+  kind: command
+  run: scripts/auth-plugin.sh           # local plugin, NOT upstream PR
+  expected_output: json                 # must return {"headers": {...}, "cookies": [...]}
+  refresh_run: scripts/auth-plugin.sh --refresh   # optional
+
+# Layer 3: vendor-deep (only if both above don't fit)
+# Project forks runner. Tracked as adoption signal — drives roadmap.
 ```
 
-Runner supports 4 auth kinds covering ~90% of stacks (cookie session, bearer JWT, header api-key, OAuth client-credentials). Project with exotic auth → upstream contribution to runner.
+**Rationale (revised after cross-AI review):**
+- Codex flagged 4 declarative kinds insufficient for SAML/mTLS/MFA/HMAC at framework scale → escape hatch added
+- Claude flagged auth escape via upstream PR blocks fast adoption → local plugin path (project's own `scripts/auth-plugin.sh`)
+- Claude flagged JWT mid-recipe expiry silent failure → `token_ttl_hint_seconds` + auto-refresh logic
+- Claude flagged Python-only runner blocks JS shops → Dockerfile shipped from PR-A
 
-**Rationale:** matches "public framework" (Decision 4). Python entrypoints would couple recipes to vgflow's language choice. Sub-shell would be portable but ugly to debug.
+**Rejected:**
+- Project-side runner (duplicates code, defeats framework)
+- Python entrypoint plugins (couples language)
 
-**Rejected alternatives:**
-- (b) project-side runner — duplicates HTTP+auth+capture code per project; defeats framework adoption
-- Python entrypoints — coupling vgflow language to recipe consumers
-
-### D2 (was Q1) — Recipe schema
+### D2 (was Q1) — Recipe schema (cross-AI revisions baked in)
 
 ```yaml
+schema_version: "1.0"                    # NEW: mandatory; runner rejects unknown majors
 goal: G-10
 description: Admin approves tier2 topup — row must exist in pending tier2 state
+fixture_intent:                          # NEW: cross-ref to TEST-GOALS.md mutation_evidence
+  declared_in: TEST-GOALS.md#G-10
+  validates: "tier2 topup row visible in admin queue, approve button shown"
+
 steps:
   - id: create_tier2_topup
     kind: api_call
     role: merchant-owner                 # lookup into vg.config.credentials[env]
     method: POST
-    endpoint: /api/v1/wallet/topup-requests   # relative; runner resolves base from config
+    endpoint: /api/v1/wallet/topup-requests
     body:
-      amount: 100
+      amount: 0.01                       # NEW: must use sandbox-safe sentinel (D9)
       currency: USD
       gateway: sunrate
-      reference: "vgflow-fixture-{run_id}-{step.id}"
+      reference: "VG_FIXTURE_{run_id}_{step.id}"   # NEW: standardized prefix (D8)
+    side_effect_risk: money_like         # NEW: gate via D9 sandbox safety
     capture:
-      request_id: $.id                   # JSONPath syntax (RFC 9535)
+      request_id:
+        path: $.id                        # JSONPath (RFC 9535)
+        cardinality: scalar               # NEW: scalar | array | optional_scalar
+        on_empty: fail                    # NEW: fail | skip | null
+    validate_after:                       # NEW: read-only assertion (Claude review)
+      kind: api_call
+      method: GET
+      endpoint: /api/v1/admin/topup-requests/{request_id}
+      expect_status: 200
+      assert_jsonpath:
+        - path: $.tier
+          equals: tier2
+        - path: $.status
+          equals: pending
+
+  # NEW: loop step type (Claude review — covers CRUD goals like G-52 IMAP)
+  - id: create_imap_configs
+    kind: loop
+    over: ["primary", "secondary", "fallback"]   # or: count: 3
+    each:
+      kind: api_call
+      role: admin
+      method: POST
+      endpoint: /api/v1/admin/imap-configs
+      body:
+        name: "{loop.value}"
+        host: "test-{loop.index}.fixture.vgflow.test"
+    capture:
+      config_ids:
+        path: $.id
+        from_each: true                   # NEW: collect into array
+
 expects:
   capture_into:
     EXPECTED_ROW_ID: "{steps.create_tier2_topup.request_id}"
 ```
 
-**Decisions baked in:**
-- `endpoint`: **relative**, runner resolves `api_base` from `vg.config.environments.{env}.api_base`. Portable across local/sandbox/staging.
-- `role`: **string lookup** into existing `vg.config.credentials[env]` array. No new typed enum — reuses established pattern.
-- `capture`: **JSONPath** (RFC 9535 standard). Not jq — that's a project-side tool dependency we won't ship.
-- `body` template variables: `{run_id}`, `{step.id}`, `{steps.<step_id>.<capture_name>}`, `{role.email}` — minimal interpolation, no full templating engine.
-- Auth tokens: **handled by runtime, not in recipe**. Recipe declares `role: merchant-owner`; runner logs in once per role per session, attaches creds to subsequent calls.
-- Multi-step: `steps: [...]` array, each step has `id`, later steps reference prior captures via `{steps.<id>.<name>}`.
+**Decisions baked in (with cross-AI revisions):**
+- `schema_version` **mandatory** at top. Runner rejects recipes whose major version it doesn't support. Hard error, not silent. Closes Codex+Claude convergent concern about schema evolution.
+- `endpoint`: **relative**, runner resolves `api_base` from `vg.config.environments.{env}.api_base`.
+- `role`: string lookup into `vg.config.credentials[env]`.
+- `capture` cardinality rules (Claude review):
+  - `scalar` — exactly 1 match required (`on_empty: fail` default)
+  - `array` — collect all matches (zero matches OK if `on_empty: skip`)
+  - `optional_scalar` — 0 or 1 match, null if 0
+- `kind: loop` step type (Claude review) — `over: [...]` for explicit values OR `count: N` for indexed; capture supports `from_each: true` to collect array.
+- `body` template variables: `{run_id}`, `{step.id}`, `{steps.<id>.<name>}`, `{role.email}`, `{loop.value}`, `{loop.index}` — minimal interpolation, documented set, no templating engine.
+- `validate_after` block (Claude review) — read-only assertion runs after step. Catches partial-orphan inconsistent state at recipe time, not at scanner time. Optional but recommended for multi-step recipes.
+- `fixture_intent` block (Codex review) — cross-references TEST-GOALS.md `mutation_evidence` declaration. Separate validator can compare blueprint intent vs fixture reality.
+- `side_effect_risk: money_like | volume_change | external_call | none` — gates via D9 sandbox safety. Runner refuses risky steps on non-sandbox envs.
+- `reference` field is **standardized**: `VG_FIXTURE_{run_id}_{step.id}`. Becomes basis for D8 tag-based prune.
+- `run_id` format: **mandatory** `{timestamp_ms}-{random_4hex}` (e.g. `1714683724891-a3f2`). Closes Claude's concurrency concern.
+- `.fixture-cache.json` writes are **atomic** (write tmp + rename) OR per-run files `.fixture-cache-{run_id}.json`. Closes Claude's concurrent-runs race.
+- Auth tokens: handled by runtime per D1 (not in recipe).
 
-**Rejected alternatives:** absolute URLs (breaks portability), typed role enums (premature abstraction), jq syntax (tool dep), in-recipe secrets (security smell).
+**Rejected alternatives:** absolute URLs (breaks portability), typed role enums (premature), jq syntax (tool dep), in-recipe secrets (security smell), unbounded templating engine (Jinja-class — feature creep).
 
-### D3 (was Q2) — Multi-step failure: no rollback, log orphans
+### D3 (was Q2) — Multi-step failure: no rollback, validate-after + orphan log
 
 Step N fails → recipe overall fails → goal marked BLOCKED in matrix with reason `fixture step N/M failed: <error>`. Steps 1..N-1 already executed leave their entities behind (per Decision 2 "no cleanup").
 
-One concession to debugging: orphan IDs captured before failure get logged to `runs/G-{XX}.fixture-orphans.json`. `/vg:fixture-prune` (D8) reads this when cleaning up.
+**Cross-AI addition (Claude review):** orphans alone are insufficient. Inconsistent partial state can satisfy invariant queries → false-pass at preflight → scanner finds broken row → unexplained SUSPECTED. Mitigation: `validate_after` block on each step (D2) acts as a checkpoint. If validate_after fails, recipe fails AT that step with a clear "step N produced invalid state" error, not "step N+1 timed out and we don't know why."
 
-**Rationale:** transactional rollback would require compensating-call infrastructure per entity type — engineering cost too high for sandbox-disposable model. Logging orphans is ~10 lines, gives prune the data it needs.
+**Concrete output on partial failure:**
+- `runs/G-{XX}.fixture-orphans.json`: IDs captured before failure
+- `runs/G-{XX}.fixture-error.json`: error context — which step failed, why, validate_after assertion that triggered if any
+- Goal status: BLOCKED with reason linking to error file
+- Recovery path: `/vg:doctor recovery` shows "fix recipe step N, re-run /vg:review --retry-failed"
 
-### D4 (was Q4) — Time-driven goals deferred to separate RFC
+**Rationale:** transactional rollback per entity type is engineering cost we don't justify for sandbox-disposable model. validate_after + orphan log + error context cover the diagnostic gap at ~50 lines runner code total.
 
-Goals requiring backdated timestamps or fast-forward (cooling period, 7-day chargeback deadline, BullMQ retry-attempt-N) are NOT solved by recipes in v1. They need backend cooperation (test-only headers, sandbox-only env detection) — a separate multi-week design.
+### D4 (was Q4) — Time-driven goals deferred to parallel RFC (open immediately)
 
-**For now:** affected goals declare `requires_time_travel: true` in TEST-GOALS frontmatter. Surface filter in `/vg:review` classifies them as **DEFERRED** (not SUSPECTED, not BLOCKED) with reason "needs time-travel infra (separate RFC)". Matrix verdict treats DEFERRED as a valid endpoint per existing v1.14.0+ scope-tag model.
+Goals requiring backdated timestamps or fast-forward (cooling period, 7-day chargeback deadline, BullMQ retry-attempt-N) are NOT solved by recipes in v1. They need backend cooperation (test-only headers, sandbox-only env detection) — separate multi-week design.
 
-**Affected from Phase 3.2 dogfood:** G-22 (withdraw cooling period), G-42 (chargeback 7d auto-suspend), G-58 (BullMQ retry + DLQ). 3 of 36, ~8%.
+**Cross-AI revision (Codex):** open the time-travel RFC **immediately as design-only**, not "after first non-3.2 phase blocks." Both reviewers flagged that 8% won't stay constant — billing/fraud/SLA/lifecycle workflows accumulate time-driven goals. After 5 phases possibly 15-20% DEFERRED. Designing in parallel (even if implementation ships later) lets time-travel goal authors know what's coming.
 
-**Follow-up:** open `RFC: time-travel test infrastructure` once first non-Phase-3.2 phase blocks on this class.
+**For now:** affected goals declare `requires_time_travel: true` in TEST-GOALS frontmatter. Matrix classifies as **DEFERRED** with cross-AI revision: also carry `blocked_since_phase: 3.2` field (Claude review) so health checks can surface long-DEFERRED goals as technical debt.
 
-### D5 (was Q5) — `data_invariants` schema with explicit owner
+```markdown
+## Goal G-22: Withdraw cooling period blocks new request
+**Surface:** ui
+**Requires time travel:** true
+**Blocked since phase:** 3.2
+**Time travel reason:** Need merchant with last_failed_withdraw_at < 1h ago
+```
+
+**Affected from Phase 3.2 dogfood:** G-22, G-42, G-58 — 3 of 36 (~8%). Expected to grow.
+
+**Follow-up:** open `RFC: time-travel test infrastructure` **as part of this RFC bundle**, design-only, separate document. Implementation tracked as PR-G with no firm date.
+
+### D5 (was Q5) — `data_invariants` schema (REVISED for N-consumer + cycle detection)
+
+**Major revision after both reviewers flagged D7 non-convergence.** Original "≥1 row" semantics fails when N goals each consume one trigger entity. Now: invariants declare per-consumer entity creation, not per-invariant.
 
 ```yaml
 # In ENV-CONTRACT.md
@@ -185,69 +267,242 @@ data_invariants:
     where:
       status: pending
       tier: tier2
-    count: ">=1"
-    setup_recipe: G-10                   # 1:1 case — single goal owns
+    consumers:                           # NEW: list of goals that NEED a row
+      - goal: G-10
+        recipe: G-10                     # owning recipe
+        consume_semantics: destructive   # NEW: scanner mutation removes the row
+      - goal: G-11
+        recipe: G-10                     # inherits same recipe template
+        consume_semantics: destructive
+      - goal: G-15                       # hypothetical edit goal
+        recipe: G-10
+        consume_semantics: read_only     # scanner mutates but doesn't remove from query
+    isolation: per_consumer              # NEW: per_consumer | shared_when_read_only
+    # Preflight rule: count consumers with consume_semantics=destructive,
+    # create that many entities. Each entity ID stored separately keyed by goal.
 
   - id: linked_account_exists
     resource: linked_accounts
     where: { status: active }
-    count: ">=1"
-    setup_recipe: [G-34]                 # list form — same syntax as multi-owner
-    # When multiple goals share: setup_recipe: [G-34, G-36]
-    # First entry = owner, rest declare `inherits: G-34` in their own FIXTURES/{G-XX}.yaml
+    consumers:
+      - goal: G-34
+        recipe: G-34
+        consume_semantics: read_only     # scanner reads but doesn't delete
+    isolation: shared_when_read_only     # 1 entity, all read-only consumers share
 ```
 
-**Decisions baked in:**
-- Owner is **explicit**, not auto-derived. First entry in `setup_recipe` list owns the recipe; others reference via `inherits` field in their own fixture YAML.
-- `where` is conjunction-only (AND semantics across keys). Disjunction (OR) → multiple invariant entries. Keeps query simple.
-- `count` accepts `>=N`, `==N`, `>N` (string syntax — runner parses).
+**Decisions baked in (CROSS-AI REVISIONS — D7 algorithm fix):**
+- `consumers` block lists every goal that depends on this invariant + each goal's consume semantics
+- `consume_semantics`: `destructive` (scanner mutation removes/transitions entity) | `read_only` (scanner observes only)
+- `isolation`: `per_consumer` (preflight creates N entities, each goal gets unique ID) | `shared_when_read_only` (one entity, multiple read-only consumers share)
+- Preflight algorithm: count `destructive` consumers in matrix, create that many entities, store each in `.fixture-cache.json` keyed by `G-XX` (not by invariant)
+- Inheritance with cycle detection: runner walks `recipe` chain, detects cycles via DFS visited-set, fails build if depth > 5 OR cycle found
+- Diamond inheritance: same-owner = OK (dedup), different-owner = build error
+- `where` is conjunction-only (AND). OR → separate invariants.
+- `count` removed from schema — implicit from `len(consumers)`. Hard-coded counts were the source of the non-convergence bug.
 
-**Rationale:** auto-derived ownership (alphabetical, declaration order, etc.) creates surprise when goals are reordered. Explicit field = grep-able, refactor-safe.
+**Rationale:** Both reviewers independently flagged "1 row for N consumers" as a correctness bug. Original D5 had `count: ">=1"` semantics that satisfied invariant query but starved sequential scanners. Now: invariant declares its consumers, preflight creates entities per-consumer, scanner cache is per-goal, ping-pong eliminated by construction.
 
-### D6 (was Q6) — Codegen emits `runFixture()` runtime call (option b)
+**Side benefit:** `consume_semantics` annotation makes the matrix self-documenting — anyone reading ENV-CONTRACT.md sees which goals destroy state vs only observe.
+
+### D6 (was Q6) — Codegen emits `runFixture()` runtime call + semantics field
 
 `/vg:test` Playwright codegen emits:
 
 ```typescript
-test.beforeEach(async ({ request }) => {
-  await runFixture(request, 'G-10');     // resolves to FIXTURES/G-10.yaml at test-run time
+test.beforeEach(async ({ request, page }) => {
+  await runFixture(request, page, 'G-10', { semantics: 'isolated' });
 });
 ```
 
-`runFixture` is a TS helper (~30 LOC) shipped with vgflow as `@vgflow/fixture-runtime` (or vendor-copied — packaging TBD at PR-E time). Reads YAML, makes HTTP calls via Playwright's `request` fixture, returns capture map.
+`runFixture` is a TS helper (~30 LOC) shipped with vgflow as `@vgflow/fixture-runtime` (or vendor-copied at PR-E time). Reads YAML, makes HTTP calls, returns capture map.
 
-**Rationale:** option (a) transpile-to-inline-TS means changing YAML doesn't update emitted specs until codegen re-runs — drift waiting to happen. Option (b) keeps YAML as single source of truth; tests pick up changes on next run automatically.
+**Cross-AI revision (Claude review):** review and test have different protocol semantics (review = once-per-phase shared state, test = once-per-test isolated state). Hiding both in one schema makes "no drift" superficially true but structurally fragile. Solution: explicit `semantics` field on `runFixture` call OR top-level `consumer_modes` block in recipe YAML acknowledging both modes.
 
-**Trade-off accepted:** specs depend on a runtime helper + YAML files. For projects checking specs into a vendor folder, the helper vendors with them — minimal friction.
+```yaml
+# Recipe declares which semantics it supports
+consumer_modes:
+  review:
+    semantics: shared
+    cache_key: G-10
+  test:
+    semantics: isolated_per_test
+    cache_key: "{test_uuid}"
+```
 
-### D7 (was Q7) — Preflight runs once, scanner reads cache
+**Cross-AI revision (Claude review) — Playwright context:** `runFixture(request, page, ...)` accepts both APIRequestContext (for HTTP calls) AND Page (for cookie sync). Helper auto-syncs cookies between contexts when fixture login sets cookies that test must use. Avoids silent auth-context-mismatch bug.
 
-Phase 2c-pre adds `verify-data-invariants` step:
-1. Walk all `data_invariants` declared in ENV-CONTRACT.md
-2. Query sandbox state via API for each (read-only).
-3. For each invariant violated: lookup `setup_recipe` (the owning goal), run that goal's `FIXTURES/{G-XX}.yaml`, capture IDs into `${PHASE_DIR}/.fixture-cache.json`.
-4. Re-query each violated invariant. Still violated → BLOCK with actionable error referencing recipe path.
+**Cross-AI revision (Codex+Claude convergent) — schema versioning:**
+- `schema_version: "1.0"` in every YAML (already mandated in D2)
+- `runFixture` rejects YAML whose major version it doesn't support — hard error with clear message
+- Vendor-copied runtime + vgflow schema bump = clear failure, not silent drift
 
-Each Haiku scanner reads `${PHASE_DIR}/.fixture-cache.json` for its goal's `EXPECTED_ROW_ID` and other captures. Injects into prompt as env vars.
+**Rationale:** option (a) transpile-to-inline-TS = drift waiting to happen. Option (b) keeps YAML single source of truth. Trade-off accepted: specs depend on runtime helper + YAML files. Vendor folder OK because schema_version + runtime version both pinned.
 
-**No re-check before each scanner spawn.** If prior scanner's mutation invalidated a later goal's invariant (e.g., G-11 rejects the only tier2 row that G-10 needed), G-10's scanner fails with clear error → matrix BLOCKED → next `/vg:review --retry-failed` re-runs preflight which re-creates the missing entity.
+### D7 (was Q7) — Preflight runs once, creates entities per-consumer (REVISED)
 
-**Rationale:** N scanners × M invariants × API roundtrip = excessive cost for marginal correctness. Once-per-run preflight + retry-failed loop converges in 1-2 iterations for hostile cases.
+**Major revision after both reviewers flagged non-convergence ping-pong.** Original "≥1 row" preflight + `--retry-failed` loop was claimed to converge "in 1-2 iterations." Both reviewers proved it doesn't converge when 2+ retry-set goals share a destructive trigger entity (G-10 + G-15 example, A2 in cross-AI synthesis).
 
-**Order matters:** the preflight check is a first-class verifier, not a soft-warn — invariant gap = BLOCK. This is what prevents the "scanner ran but had nothing to test" failure that started this RFC.
+Phase 2c-pre adds `verify-data-invariants` step (revised algorithm):
 
-### D8 (was Q8) — `/vg:fixture-prune` spec (own mini-RFC, contracts only)
+1. Read all `data_invariants` from ENV-CONTRACT.md
+2. For each invariant: count `destructive` consumers from `consumers[]` block (D5)
+3. Query sandbox state for current matching entity count
+4. If `(destructive_consumer_count - matching_count) > 0`: run owning recipe N times, where N = the gap. Each run captures a fresh ID.
+5. Store IDs in `.fixture-cache.json` keyed by **goal_id**, not invariant_id:
+   ```json
+   {
+     "G-10": { "EXPECTED_ROW_ID": "abc123", "created_at": "2026-05-02T..." },
+     "G-11": { "EXPECTED_ROW_ID": "def456", "created_at": "2026-05-02T..." },
+     "G-15": { "EXPECTED_ROW_ID": "ghi789", "created_at": "2026-05-02T..." }
+   }
+   ```
+6. Re-query invariant. If still failed (rare — recipe broken or auth wrong): BLOCK with actionable error.
 
-Full spec deferred to its own RFC, but commits to these contracts:
+Each Haiku scanner reads cache for **its own goal's** EXPECTED_ROW_ID. No more "all scanners share one row."
 
-- **Tag-based delete only.** Every fixture-created entity carries `vgflow_fixture_run_id` field (or analogous metadata per entity type). Prune matches by tag pattern, never deletes untagged entities.
-- **Manual trigger for v1** — user runs `/vg:fixture-prune` on their cadence. No cron. Default age threshold: 7 days (configurable).
-- **Scoped role** — dedicated `vgflow-fixture-cleaner` credential with hard-delete privilege scoped to fixture-tagged entities only. NOT admin role — limits blast radius if cleaner script bugs out.
-- **Includes orphan list** — reads `runs/G-{XX}.fixture-orphans.json` (from D3) to clean partial-recipe-failure leftovers.
+**Concurrent-runs safety (Claude review):** preflight writes cache atomically (tmp file + rename) OR per-run files `.fixture-cache-{run_id}.json`. Either approach prevents last-writer-wins races between two `/vg:review` processes.
 
-These contracts unblock D2, D3, D5 — they don't have to predict prune behavior.
+**No re-check before each scanner spawn.** Per-consumer entities mean prior scanner mutations don't invalidate later scanners — each has its own. Convergence guaranteed by construction, not by retry loop.
 
-**Follow-up:** `RFC: vg:fixture-prune cleanup command` after D1-D7 ship.
+**Rationale:** original D7 was correct in spirit (preflight-once is right architecture) but wrong in algorithm (1 row for N consumers). Per-consumer creation is cost-equivalent (preflight N HTTP calls instead of 1) but algorithmically convergent.
+
+**Order matters:** invariant gap = BLOCK at preflight, not silent SUSPECTED later. This is what prevents the "scanner ran but had nothing to test" failure that started this RFC.
+
+### D8 (was Q8) — `/vg:fixture-prune` spec (REVISED — registry-first, tag-second)
+
+**Major revision after both reviewers flagged "tag-based assumes metadata column."** Many real schemas (ledger rows, immutable audit, join tables, external payment objects) cannot accept arbitrary `vgflow_fixture_run_id` field. Original D8 baked an assumption that breaks adoption.
+
+**Three-layer prune mechanism (in priority order):**
+
+```yaml
+# In vg.config.md
+fixtures:
+  entity_types:
+    topup_requests:
+      tag_strategy: registry_first       # registry → reference_field → time_window
+      reference_field: reference         # field name in this entity type
+      time_window_field: created_at      # for fallback
+
+    ledger_entries:
+      tag_strategy: registry_only        # immutable, can't tag
+      # only deletable via registry lookup; if registry lost, never deletable
+      retention_policy: keep_forever
+
+    transfer_groups:
+      tag_strategy: tag_field_first      # entity supports metadata
+      tag_field: metadata.vgflow_fixture_run_id
+```
+
+**Layer 1 — Registry (primary):** `runs/fixture-registry.jsonl` accumulates one line per fixture-created entity:
+```json
+{"resource":"topup_requests","id":"abc123","run_id":"1714683724891-a3f2","created_at":"...","goal":"G-10"}
+```
+Prune reads registry, deletes entries by `run_id` age + reference pattern match.
+
+**Layer 2 — Reference field (fallback):** if entity has standardized `reference: VG_FIXTURE_{run_id}_{step.id}` (mandated in D2), prune queries `WHERE reference LIKE 'VG_FIXTURE_%' AND created_at > N days ago`. Used when registry lost or for entity types without metadata support.
+
+**Layer 3 — Time window (last resort):** for entity types that have neither metadata nor reference field, prune deletes by time window only. Requires explicit `tag_strategy: time_window_only` opt-in per entity type — high-blast-radius, ops must approve.
+
+**Other contracts (preserved from v3):**
+- Manual trigger v1, no cron
+- Default age threshold 7 days, configurable
+- Scoped role `vgflow-fixture-cleaner` with hard-delete privilege limited to tagged entities only
+- Reads `runs/G-{XX}.fixture-orphans.json` (from D3) for partial-failure cleanup
+
+**Cross-AI addition:** prune dry-run mode (`/vg:fixture-prune --dry-run`) prints what WOULD be deleted before doing it. Mandatory first run on new env, optional after.
+
+**Follow-up:** full `RFC: vg:fixture-prune cleanup command` after D1-D7 ship. v4 RFC commits to the registry-first contract so PR-A doesn't bake wrong tagging assumptions.
+
+### D9 (NEW) — Sandbox safety guardrails (closes "fixture creates real money" risk)
+
+Cross-AI both flagged HIGH: Phase 3.2 is BILLING. Fixture POST creates real wallet balance, gateway webhooks fire externally, reconciliation reports see fixture amounts. RFC v3 had no coverage. v4 commits to:
+
+**Hard environment gate (runner refuses unless ALL pass):**
+1. `vg.config.environments.{env}.kind` must be `sandbox` (not `local|staging|prod`)
+2. Server must respond to health probe with header `X-VGFlow-Sandbox: true` (project adds this to sandbox deploy; absent on prod)
+3. Recipe steps with `side_effect_risk` ∈ `{money_like, external_call}` blocked unless `kind: sandbox` + `X-VGFlow-Sandbox` header confirmed
+
+**Sentinel value requirements (validator at recipe schema time):**
+- Currency-amount fields must use sandbox-safe values: `amount ≤ 0.01` for any field whose name matches `amount|balance|price|fee|cost`
+- Email fields must use domain `@fixture.vgflow.test`
+- `reference` field must start with `VG_FIXTURE_` (already standardized in D2)
+- Names should include `[FIXTURE]` prefix (warn-level, not block)
+
+**Example block in recipe:**
+```yaml
+steps:
+  - id: create_tier2_topup
+    kind: api_call
+    role: merchant-owner
+    method: POST
+    endpoint: /api/v1/wallet/topup-requests
+    body:
+      amount: 0.01                       # sentinel — would be flagged if 100
+      currency: USD
+      gateway: sunrate
+      reference: "VG_FIXTURE_{run_id}_{step.id}"   # mandatory prefix
+    side_effect_risk: money_like         # gates D9 sandbox check
+```
+
+**Build-time validator** `verify-fixture-sandbox-safety.py`:
+- Walks every `FIXTURES/G-XX.yaml`
+- Reports schema-violations: amount > 0.01 in money fields, email domain != fixture.vgflow.test, missing reference prefix
+- Severity: BLOCK (build wave fails)
+
+**Runtime gate** in runner:
+- Refuses execution unless env kind + sandbox header both confirm
+- Refuses any `side_effect_risk: money_like` step on env without confirmed sandbox status
+- Logs every refusal to telemetry (`fixture.refused_unsafe_env`) so user gets clear "I'm not running on prod" feedback
+
+**Rationale:** "richer = easier" was right for sandbox volume but wrong for safety. Hard gates + sentinel values let projects opt into sandbox-only fixtures with confidence the runner won't accidentally pollute prod.
+
+### D10 (NEW) — Evidence provenance (closes wave-3.2.2 hotfix gap, bundled with this RFC)
+
+Cross-AI both flagged HIGH: wave-3.2.2 bidirectional sync (currently shipped in PR #79) promotes SUSPECTED → READY when goal_sequence has `submit + 2xx`. Goal_sequence JSON is writable by executor agents, scanner agents, and orchestrator code. Executor can hand-write fake submit + 2xx → auto-promote → trust model has back door.
+
+**Fix bundled into this RFC** (was originally going to be standalone wave-3.2.3):
+
+Add `evidence_source` field to every step in `goal_sequence`:
+```json
+{
+  "do": "click",
+  "target": "Approve button",
+  "evidence_source": "scanner",          // NEW
+  "scanner_run_id": "haiku-G10-1714683724",  // NEW
+  "captured_at": "2026-05-02T...",       // NEW (already partial)
+  "network": [...]
+}
+```
+
+**Allowed values for `evidence_source`:**
+- `scanner` — Haiku scanner spawned by `/vg:review` Phase 2b-2 wrote this
+- `executor` — `/vg:build` executor wrote this (informational only — never triggers status change)
+- `orchestrator` — orchestrator code path (preflight, recovery, smoke) wrote this
+- `manual` — user/AI hand-edited (explicitly informational, never triggers)
+
+**Promotion rule (revised wave-3.2.2 logic):**
+- SUSPECTED → READY ONLY when ALL submit + 2xx steps in goal_sequence have `evidence_source: scanner`
+- Mixed-provenance sequences (some scanner, some executor) → READY downgraded to PARTIAL or stays SUSPECTED
+- Hand-written fake → never promotes, even if structurally valid
+
+**Validator** `verify-evidence-provenance.py`:
+- Walks every goal_sequence
+- Asserts every mutation step has `evidence_source` field
+- Asserts `scanner` claims have matching `scanner_run_id` that exists in events.db
+- BLOCKs review-complete if any submit step has unverified provenance
+
+**Migration path:**
+- Existing goal_sequences from PR #79 era lack the field — backfill validator marks them `evidence_source: legacy_pre_provenance`, treats as informational only
+- Dogfood phases (3.2 specifically) re-run scanner for proper attribution
+- New goal_sequences MUST carry `evidence_source` from PR-A onward
+
+**Why bundle into this RFC, not separate hotfix:**
+- PR-A's fixture runtime writes goal_sequence steps with `evidence_source: orchestrator`
+- Without provenance field defined, PR-A's writes would be indistinguishable from scanner output
+- Bundling avoids "PR-A inherits broken trust model, then PR-B fixes it" sequence
+
+**Implementation:** ships in same PR as RFC v4 schema definitions (PR-pre-A). Lands BEFORE PR-A.
 
 ---
 
@@ -262,60 +517,116 @@ These contracts unblock D2, D3, D5 — they don't have to predict prune behavior
 
 ---
 
-## Implementation plan
+## Implementation plan (revised after cross-AI review)
 
-D1-D8 resolved. Split into PRs in dependency order:
+D1-D10 resolved. Splits into PRs in dependency order, with PR-pre-A bundle landing first:
 
-1. **PR-A: Recipe schema + auth-pluggable runner skeleton** (D1, D2, D3)
-   - `schemas/fixture-recipe.schema.yaml` (JSON-Schema for validation)
-   - `scripts/run-fixture.py` skeleton — reads YAML, walks `steps[]`, captures via JSONPath, no-op when API base unreachable
-   - 4 auth-kind handlers: cookie, bearer, api-key, oauth-client-creds
-   - Unit tests on schema validation + JSONPath capture + multi-step variable resolution
-   - Orphan logger writes `runs/G-{XX}.fixture-orphans.json` on partial failure
-   - **No vgflow consumer yet** — runner runs standalone via `python3 run-fixture.py FIXTURES/G-10.yaml`. Validates the engine before wiring anything.
+### PR-pre-A: Foundation bundle — schema + provenance hotfix + sandbox safety contract
+**Lands before PR-A. Bundles wave-3.2.3 hotfix per user direction "revise RFC trước rồi gộp."**
 
-2. **PR-B: `/vg:build` fixture-write step** (D2 authoring side)
-   - New executor sub-step: after implementing a goal with `mutation_evidence`, write `FIXTURES/{G-XX}.yaml`
-   - New wave-verify validator: `verify-build-fixtures-present.py` — build wave not done if mutation goal lacks fixture YAML matching schema
-   - `requires_time_travel: true` recognition — skip fixture requirement, mark goal DEFERRED in matrix instead (D4)
-   - Build can no-op gracefully on phases with no mutation goals (backward compat)
+- `schemas/fixture-recipe.schema.yaml` (JSON-Schema for D2 — full schema spec, no runtime yet)
+- `schemas/data-invariants.schema.yaml` (JSON-Schema for D5)
+- `verify-evidence-provenance.py` validator (D10) — adds `evidence_source` field requirement to goal_sequence steps
+- Update `verify-matrix-staleness.py` (PR #79 wave-3.2.2) — bidirectional sync only triggers on `evidence_source: scanner`
+- Backfill mode: legacy goal_sequences without provenance marked `legacy_pre_provenance`, never auto-promote
+- **No runner code yet** — schema + provenance contract only
+- **Tests:** schema validation + provenance contract + legacy backfill behavior
 
-3. **PR-C: ENV-CONTRACT.md `data_invariants` + preflight verifier** (D5, D7)
-   - Schema for `data_invariants` block in ENV-CONTRACT.md
-   - `verify-data-invariants.py` — queries sandbox per invariant, runs `setup_recipe` if violated, re-queries, BLOCKs if still violated
-   - Hooks into `phase2c_pre_dispatch_gates` step in `/vg:review`
-   - Writes `${PHASE_DIR}/.fixture-cache.json` for downstream scanners
+This closes the wave-3.2.2 trust model hole live in PR #79 BEFORE PR-A's runner inherits it.
 
-4. **PR-D: `/vg:review` scanner preflight integration**
-   - Haiku scanner prompt extended: reads `.fixture-cache.json`, injects `EXPECTED_ROW_ID` etc. as env vars for scanner agent
-   - Matrix-staleness validator gets new `requires_time_travel` filter — those goals never flagged SUSPECTED, classified DEFERRED instead
-   - Recovery paths in `recovery_paths.py` extended with `validator:data-invariants` entries
+### PR-A: Recipe runner + auth + sandbox safety enforcement (D1, D2, D3, D9)
+- `scripts/run-fixture.py` — reads YAML, walks `steps[]`, captures via JSONPath with cardinality rules (scalar/array/optional_scalar)
+- 4 declarative auth-kind handlers: cookie, bearer, api-key, oauth-client-credentials
+- `kind: command` escape hatch handler — invokes local plugin (`scripts/auth-plugin.sh` per project)
+- Token refresh logic: track `token_ttl_hint_seconds`, re-auth when TTL < 10%
+- `kind: loop` step type with `over: [...]` and `count: N` semantics
+- `validate_after` block execution — read-only assertion after each step
+- Orphan logger writes `runs/G-{XX}.fixture-orphans.json` on partial failure
+- **Sandbox safety enforcement:**
+  - Refuses execution unless `vg.config.environments.{env}.kind: sandbox`
+  - Refuses unless server responds with `X-VGFlow-Sandbox: true`
+  - Refuses `side_effect_risk: money_like|external_call` steps on non-sandbox
+  - Sentinel-value validator at schema parse time
+- `Dockerfile` for runner — universal portability layer
+- **Mock consumer (Codex+Claude review):** `test/mock-scanner-consumer.py` reads `.fixture-cache.json` and validates contract that PR-D will rely on. Acts as contract test.
+- **Tests:** unit (schema, JSONPath, interpolation, auth, capture), integration (fake HTTP app), sandbox safety enforcement
 
-5. **PR-E: `/vg:test` codegen integration** (D6)
-   - Playwright codegen emits `await runFixture(request, 'G-XX')` in generated specs
-   - `@vgflow/fixture-runtime` package (or vendor copy) — TS helper that reads YAML at test-run time
-   - Validator: `verify-codegen-fixture-binding.py` — every codegen test for a mutation goal must include `runFixture()` call
+### PR-B: `/vg:build` fixture-write step + smoke-execute gate (D2 authoring)
+- Executor sub-step: after implementing goal with `mutation_evidence`, write `FIXTURES/{G-XX}.yaml`
+- Wave-verify validator: `verify-build-fixtures-present.py` — build incomplete if mutation goal lacks fixture YAML
+- **Smoke-execute gate (Claude review):** wave-verify also runs `run-fixture.py` against sandbox at build time. Catches semantic errors (wrong endpoint, wrong payload shape) immediately at build, not 3 PRs later at preflight. Adds ~30s/goal.
+- `requires_time_travel: true` recognition — skip fixture requirement, mark DEFERRED in matrix with `blocked_since_phase`
 
-6. **PR-F (separate, after D1-E land)** — `RFC + impl: /vg:fixture-prune` cleanup command (D8)
-   - Tag-based scan + delete with `vgflow-fixture-cleaner` role
-   - Reads orphan logs from PR-A
-   - User-triggered, default 7-day age threshold
+### PR-C: ENV-CONTRACT.md `data_invariants` + preflight verifier (D5, D7)
+- Schema for `data_invariants` with `consumers[]` block + `consume_semantics` per consumer
+- `verify-data-invariants.py`:
+  - Reads `data_invariants` from ENV-CONTRACT.md
+  - Counts destructive consumers per invariant from matrix
+  - Queries current state, runs owning recipe N times to fill gap
+  - Stores per-goal entries in `.fixture-cache.json` (atomic write or per-run file)
+  - Hooks into `phase2c_pre_dispatch_gates` step
+- Inheritance cycle detection (DFS visited-set) + diamond resolution
+- Recovery paths in `recovery_paths.py` extended with `validator:data-invariants` entries
 
-7. **PR-G (separate, future)** — `RFC: time-travel test infrastructure` (D4)
-   - Backend `X-Sandbox-Time-*` headers contract
-   - Sandbox-only env detection
-   - Recipe extension: `time_advance:` step kind
-   - Lifts ~8% of dogfood goals from DEFERRED to testable
+### PR-D: `/vg:review` scanner integration (D5, D7 consumer side)
+**Split per Codex review — scanner skill changes are non-trivial:**
+- **PR-D.1:** Cache file contract + prompt injection plumbing (orchestrator side)
+- **PR-D.2:** Haiku scanner skill changes — read `.fixture-cache.json`, inject `EXPECTED_ROW_ID` env var into scanner prompt
+- Matrix-staleness validator gets `requires_time_travel` filter
+- Recovery paths extended with fixture-failure entries
 
-**Sequencing rationale:**
-- PR-A is the foundation — runner works standalone, can be tested without other components
-- PR-B adds the upstream producer (build writes YAML)
-- PR-C adds the downstream consumer (preflight reads YAML)
-- PR-D wires preflight into review scanner spawn
-- PR-E extends to test layer
-- PR-F + PR-G are independent follow-ups
+### PR-E: `/vg:test` codegen integration (D6)
+- Playwright codegen emits `await runFixture(request, page, 'G-XX', { semantics: 'isolated' })`
+- `@vgflow/fixture-runtime` TS helper (~30 LOC + auth context sync)
+- Schema-version compatibility check at runtime — hard fail on major mismatch
+- Validator: `verify-codegen-fixture-binding.py`
 
-**Estimate:** PR-A through PR-E in 2-3 weeks if no surprises. PR-F + PR-G open-ended.
+### PR-Z: Backend staleness validator (Codex review — addresses backend goals exempt from D2 scope)
+**Parallel to wave-3.2.1 surface filter. Currently backend goals "trusted" — Codex flagged need parallel validator.**
+- `verify-backend-mutation-evidence.py` — for goals with `surface: api|data|integration|time-driven`
+- Asserts: route handler hit (grep), mutation request observed (server log), 2xx/expected-error status, state changed (DB query)
+- Closes the gap where backend mutations claimed READY without verification
+
+### PR-F (followup, after D1-E ship): `/vg:fixture-prune` (D8)
+- Registry-first + reference-pattern + time-window fallback (3-layer)
+- `vg.config.fixtures.entity_types[]` per-entity-type strategy mapping
+- Dry-run mode mandatory first run
+- Scoped role `vgflow-fixture-cleaner`
+
+### PR-G (parallel design RFC, immediate per Codex): time-travel infrastructure (D4)
+**Open as RFC alongside this one, design-only.** Both reviewers flagged 8% won't stay constant.
+- Backend test-only header contract (`X-Sandbox-Time-Advance`)
+- Sandbox-only env detection enforcement
+- Recipe extension: `kind: time_advance` step type
+- Implementation deferred until first non-Phase-3.2 phase blocks
+
+### PR-Y (separate, recovery-paths-as-code per Codex): recovery command test coverage
+**Codex flagged: recovery commands rot into cargo-cult without tests.**
+- Each entry in `recovery_paths.py` gets a fixture asserting the command actually changes the violation state, OR explicitly marks itself manual-only
+- Runs as part of CI
+
+**Sequencing rationale (revised):**
+- PR-pre-A first — closes live PR #79 hole + ships schemas without runtime, so reviewers see contract intent
+- PR-A is the foundation — runner standalone with mock consumer + Dockerfile + sandbox safety
+- PR-B adds upstream producer (build writes YAML, smoke-executes immediately)
+- PR-C adds downstream consumer (preflight reads YAML, creates per-consumer entities)
+- PR-D wires preflight into review scanner spawn (split D.1 + D.2)
+- PR-E extends to test layer with semantics field
+- PR-Z parallel to PR-D (backend validator)
+- PR-F + PR-G + PR-Y are independent follow-ups
+
+**Revised estimate (Claude review caught optimism):**
+- PR-pre-A: 3-5 days (schemas + provenance hotfix + tests)
+- PR-A: 1.5-2 weeks (full runner + auth + sandbox safety + Docker + tests + mock consumer)
+- PR-B: 1 week (executor sub-step + smoke-execute gate)
+- PR-C: 1 week (preflight verifier + cache file + recovery paths)
+- PR-D.1 + D.2: 1.5 weeks (scanner skill changes are architecture-invasive)
+- PR-E: 1 week (codegen + TS helper + validator)
+- PR-Z: 5-7 days (parallel to PR-D)
+
+**Total: 5-7 weeks for D1-D10 implementation.** PR-F + PR-G + PR-Y open-ended follow-ups.
+
+Honest revision from RFC v3's "2-3 weeks" — that estimate ignored scanner skill modification + sandbox safety + provenance hotfix scope. Claude's "5-7 weeks" projection accepted as realistic.
 
 ---
 

--- a/docs/discussions/test-data-prerequisites.md
+++ b/docs/discussions/test-data-prerequisites.md
@@ -1,653 +1,1013 @@
-# RFC: Test-data prerequisites for review/test workflow
+# RFC v9 — Test-data prerequisites + workflow enforcement model
 
-**Status (v4, 2026-05-02):** Direction + decisions D1-D10 chosen, cross-AI reviewed (Codex GPT-5.5 + Claude Sonnet 4.6), 5 HIGH findings baked in, ready to bundle with wave-3.2.3 hotfix and split into implementation PRs.
-**Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2.x dogfood run
-**Cross-AI review:** see [`test-data-prerequisites-crossai-review.md`](test-data-prerequisites-crossai-review.md) for full synthesis
-**Related:** PR #79 (recovery paths + matrix-staleness), PR #74 (anti-performative-review)
+**Status (v9, 2026-05-02):** Final consolidated plan. Ready for implementation start (PR-pre-A bundled hotfix).
+**Cross-AI review trail:**
+- v4 reviewed by Codex GPT-5.5 + Claude Sonnet 4.6 → 5 HIGH findings baked in
+- v7 reviewed by Codex GPT-5.5 effort=high → 3 HIGH + 6 MEDIUM concerns baked into v8 (D17-D23 tester pro lens)
+- v9 = v8 + D24-D28 (legacy migration single-advisory, research-augmented blueprint, content depth validators, Diagnostic universal across BLOCK types, aggregate advisory)
+**Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01)
+**Related:** PR #79 (recovery paths + matrix-staleness wave-3.x), PR #74 (anti-performative-review)
 
 ---
 
-## The problem in one paragraph
+## 1. The problem in one paragraph
 
-`/vg:review` and `/vg:test` need realistic application **state** to verify mutation goals. Phase 3.2 G-10 says "Admin approves tier2 topup request"; sandbox seed has 12 tier1 rows and 0 tier2 rows. Scanner navigates to `/billing/topup-queue`, sees only tier1 rows showing "Auto via webhook" placeholder, can't click an Approve button that doesn't exist for tier1, and reports `no_submit_step`. The matrix-staleness validator correctly flags SUSPECTED. But the **root cause is missing data**, not missing UI or missing code. We can re-run scanners forever without ever creating the data they need to exercise.
+`/vg:review` and `/vg:test` need realistic application **state** to verify mutation goals. Phase 3.2 G-10 "Admin approves tier2 topup" — sandbox seed has 12 tier1 rows + 0 tier2 rows. Scanner sees no Approve button (tier1 hidden), reports `no_submit_step` → SUSPECTED. Re-run mãi cũng vô ích — không có gì để click. 21/36 mutation goals dính lỗi này (~58%). Không phải lỗi code, không phải UI, không phải review. Lỗi **data prerequisite** — workflow chưa biết tự tạo state.
 
-This is the meta-bug behind ~21 of 36 mutation goals flagged in the dogfood run: not "scanner missed it" but "nothing to scan because the trigger entity doesn't exist in seed".
+Plus a meta-bug: when validators fire BLOCK, workflow prints generic option menu thay vì advise straight. User loop through retry-failed → fix nothing → menu again. Workflow lacks **diagnostic intelligence + clear single advisory pattern**.
 
-## Concrete failure modes observed in Phase 3.2
+## 2. Concrete failure modes (Phase 3.2)
 
-| Goal | Needs | Sandbox has | Result |
+| Goal | Cần | Sandbox có | Result |
 |---|---|---|---|
-| G-10 admin approve tier2 topup | tier2 topup row in `pending` | only tier1 rows | scanner sees no Approve button → SUSPECTED |
-| G-19 merchant cancels pending withdraw | merchant has pending withdraw | empty wallet, no withdraws | route renders empty state → SUSPECTED |
-| G-23 admin resets cooling period | merchant currently cooling | no cooling-period state | reset button never appears → SUSPECTED |
-| G-31 admin transfer group CRUD | existing transfer group OR new-group flow | empty list | only "create" path testable → partial submit |
-| G-34 linked accounts CRUD | linked accounts exist | empty | edit/delete unreachable |
-| G-35 bank accounts CRUD | bank accounts exist | empty | edit/delete unreachable |
-| G-44 admin sets FX rate | rate exists for given gateway×currency | inconsistent seed | sometimes editable, sometimes not |
-| G-52 IMAP config CRUD | configs exist | only one default | partial CRUD only |
+| G-10 admin approve tier2 topup | tier2 row pending | only tier1 | scanner thấy không nút Approve → SUSPECTED |
+| G-19 merchant cancels withdraw | merchant pending withdraw | empty wallet | route render empty state → SUSPECTED |
+| G-23 admin reset cooling | merchant cooling | no cooling state | reset button không hiện → SUSPECTED |
+| G-31 transfer group CRUD | existing group | empty list | chỉ create test được → PARTIAL |
+| G-34/35 linked/bank accounts CRUD | accounts exist | empty | edit/delete unreachable |
+| G-44 admin sets FX rate | rate exist gateway×currency | inconsistent seed | sometimes editable |
+| G-52 IMAP CRUD | configs exist | only one default | partial CRUD |
 
-Pattern: **list/queue routes are healthy when empty, but mutation goals (approve/reject/edit/delete/cancel) need the entity to exist first, in the right status, with the right tier/role/state**.
+Pattern: **list/queue route healthy when empty, mutation goals (approve/reject/edit/delete/cancel) cần entity tồn tại trước, đúng status, đúng tier/role/state**.
 
-## What kinds of data does a goal need?
+## 3. Kinds of data goals need
 
-Not all "needs data" cases are equal. From the Phase 3.2 sample:
+1. **Trigger entity** — row action operates on (tier2 row to approve)
+2. **Lifecycle state** — entity ở status cụ thể (cooling, pending withdraw)
+3. **Cross-entity relationship** — A pointing to B (linked account → gateway)
+4. **Time-driven state** — timestamp older than X (7-day deadline)
+5. **Side-effect setup** — entity created by prior side-effect (chargeback freeze)
+6. **Negative-path setup** — entity ở forbidden state (frozen recipient)
 
-1. **Trigger entity** — the row the action operates on (tier2 topup row to approve)
-2. **Lifecycle state** — entity in a specific status (cooling-period merchant, pending withdraw)
-3. **Cross-entity relationship** — entity A pointing to entity B (linked accounts → gateway, transfer between merchants in same group)
-4. **Time-driven state** — entity with timestamp older than X (7-day chargeback deadline, cooling period)
-5. **Side-effect setup** — entity created by a prior side-effect (chargeback webhook fires → wallet frozen → admin sees frozen banner)
-6. **Negative-path setup** — entity in a *forbidden* state to verify the gate (frozen recipient, suspended merchant)
-
-Each needs a different setup mechanism. A "tier2 topup row" might be a single API POST as merchant. A "7-day chargeback timeout" may need time-travel or a fake-clock test mode. A "frozen wallet" needs prior chargeback webhook + freeze logic to have run.
+RFC v9 covers 1, 2, 3, 5, 6. Loại 4 (time-driven) deferred → parallel RFC G.
 
 ---
 
-## Direction chosen (2026-05-02)
+## 4. Direction chosen — 4 strategic decisions
 
-After surveying 6 options (A through F — preserved at the bottom of this doc for context), the chosen path is:
+> **Recipes authored at `/vg:build`, executed before `/vg:review` scanner spawn, reused by `/vg:test` codegen. No inline cleanup — sandbox accumulates; cleanup separate command. Single source-of-truth recipe artifact per mutation goal, public-framework grade.**
 
-> **Recipes authored at `/vg:build` time, executed before `/vg:review` scanner spawn and reused by `/vg:test` Playwright codegen. No inline cleanup — sandbox accumulates data; cleanup is a separate command users run on their own cadence. Single source-of-truth recipe artifact per mutation goal, public-framework grade.**
-
-### Decision 1 — Authoring lives in `/vg:build`
-
-Executor authors fixture recipe alongside the goal it implements, because that's the only point where the API shape is concrete (handler signed, routes registered, schemas final). Blueprint-time authoring would force the planner to predict API details it hasn't designed yet; review-time authoring would force the scanner to know API shapes it shouldn't care about.
-
-Concretely: when `/vg:build` finishes a goal that has `**Mutation evidence:**` declared in TEST-GOALS.md, an additional executor sub-step writes `FIXTURES/{G-XX}.yaml` next to the goal artifacts. Build is not "done" for a mutation goal until its fixture exists. This becomes a new wave-verify gate in `/vg:build`.
-
-Cost: yes, `/vg:build` grows. We accept it because (a) recipes need API knowledge the executor already has, (b) duplicating this knowledge into a separate `/vg:fixture` step would reorder pipeline and add a new artifact dependency, and (c) tests authored at build-time match the implementation they describe — drift is harder.
-
-### Decision 2 — Cleanup is external, not inline
-
-Sandbox is "richer = easier". A sandbox with 200 rows across all states is more useful for review than one with 12 rows that get rejected and disappear. We don't transactional-cleanup after each scanner run.
-
-Implication: scanner runs are NOT idempotent in the sense of "matrix returns to identical state". Re-running `/vg:review --retry-failed` on the same goal will keep creating new tier2 rows. That's fine — they're cheap. The state space we care about is "≥1 tier2 in pending exists at any given moment", not "exactly 1".
-
-Cleanup is a separate command — call it `/vg:fixture-prune` for now — that runs on user's cadence (after a milestone? Weekly via cron? At sandbox-reset?). It reads run logs, finds fixtures created by VGFlow, deletes them. Out of scope for this RFC; tracked as a follow-up.
-
-This decision **massively simplifies recipe schema** — every recipe is one-shot setup, no rollback, no compensating transaction. We lose nothing real because sandbox = disposable seed by env contract.
-
-### Decision 3 — Recipe runtime serves both `/vg:review` and `/vg:test`
-
-One artifact, two consumers:
-
-- **`/vg:review` scanner preflight** — orchestrator runs the recipe before spawning Haiku for that goal's view. Captures created entity IDs into env vars, injects them into Haiku prompt as `EXPECTED_ROW_ID=...` so scanner targets the right row.
-- **`/vg:test` Playwright codegen** — generates `test.beforeEach()` block in the spec file that runs the same recipe (transpiled from YAML to TypeScript at codegen time, OR called via shared HTTP harness — TBD in question 1).
-
-Single recipe = no drift between review's scanner expectations and test's codegen output. If recipe wrong, both fail same way; fix once.
-
-### Decision 4 — Public-framework grade
-
-VGFlow is positioned as a heavy framework other projects will adopt. Implications for this RFC:
-
-- Schema must be portable — no PrintwayV3-isms, no hardcoded auth assumptions
-- Recipe runtime must be language-agnostic at the boundary — YAML in, HTTP/CLI calls out, no project-specific Python imports
-- Failure modes must be load-bearing — a recipe failure must produce an actionable error, not a silent SUSPECTED
-- Every artifact must have a reason to exist — no `FIXTURE.md` doc that just narrates what `FIXTURES.{G-XX}.yaml` already says
-
-This bars option A (extend seed.ts) as the primary mechanism — that's PrintwayV3-specific seed code we can't ship in vgflow. Option F (data_invariants in ENV-CONTRACT.md) survives because it's declarative + portable.
-
-### Final shape: B + F
-
-- **B (per-goal recipes, build-time authored)** is primary
-- **F (data_invariants preflight gate)** is the cheap declarative wrapper — phase declares "≥1 tier2 pending must exist before scanner spawns" in ENV-CONTRACT.md; preflight verifier walks recipes from all goals in the phase, computes whether invariant is met, runs missing recipes
-- A, C, D, E **rejected for v1** — A is project-specific, C is premature abstraction (revisit after 10+ phases), D is non-deterministic, E is orthogonal (separate time-travel RFC later)
+**S1.** Recipe authored at `/vg:build` (executor knows API shape)
+**S2.** No inline cleanup, sandbox = "richer = easier"
+**S3.** Single recipe runtime serves both `/vg:review` preflight và `/vg:test` codegen
+**S4.** Public-framework grade — schema portable, runtime pluggable, no project-isms
 
 ---
 
-## Design decisions (Q1-Q8 resolved 2026-05-02)
+## 5. Design decisions D1-D28
 
-The 8 questions surfaced after Decisions 1-4 are now answered. Each decision below has rationale + immediate implication for implementation.
+### D1 — Architecture: native Python orchestrator
 
-### D1 (was Q3) — Runtime: generic Python runner, declarative auth + escape hatch + Docker
+**Decision:** Vgflow CLI = ~400-500 LOC Python orchestrator + 2 small libs (`requests`, `jsonpath-ng`). Subprocess gọi tools native. **No Docker primary, no MCP wrapper, no Karate/Schemathesis/Zerocode external runtime.**
 
-Vgflow ships `scripts/run-fixture.py` (Python 3.11+) that reads recipe YAML, performs HTTP calls, captures responses. Also ships `Dockerfile` so JS-only / Python-less CI environments can run it as a container — solves "stack pollution" objection.
+**Auth pluggable, 3 layer:**
+- Layer 1 declarative: cookie | bearer | api-key | oauth-client-credentials
+- Layer 2 escape hatch: `auth.kind: command` → invoke `scripts/auth-plugin.sh` (no upstream PR)
+- Layer 3 vendor-deep: project forks runner
 
-**Auth pluggability — three layers, declarative-first:**
+**Token TTL refresh + auth_verify post-login** (closes Codex auth-silent-wrong-role concern).
 
-```yaml
-# Layer 1: declarative (covers ~80% — built into runner)
-auth:
-  kind: cookie | bearer | api-key | oauth-client-credentials
-  login_endpoint: /api/v1/auth/login
-  body_template:
-    email: "{role.email}"
-    password: "{role.password}"
-  capture:
-    cookie: connect.sid
-    # or: token_path: $.token
-  # NEW: token lifecycle (Claude review — solves mid-recipe 401 on JWT expiry)
-  token_ttl_hint_seconds: 900           # optional, runner re-auths when TTL < 10%
-  refresh_endpoint: /api/v1/auth/refresh # optional
+**Split PR-A into A1/A2/A3** per Codex sizing review.
 
-# Layer 2: command escape hatch (covers exotic stacks — SAML/mTLS/HMAC/MFA)
-auth:
-  kind: command
-  run: scripts/auth-plugin.sh           # local plugin, NOT upstream PR
-  expected_output: json                 # must return {"headers": {...}, "cookies": [...]}
-  refresh_run: scripts/auth-plugin.sh --refresh   # optional
+Optional Dockerfile alternative for Python-incompatible CI. Not primary.
 
-# Layer 3: vendor-deep (only if both above don't fit)
-# Project forks runner. Tracked as adoption signal — drives roadmap.
-```
-
-**Rationale (revised after cross-AI review):**
-- Codex flagged 4 declarative kinds insufficient for SAML/mTLS/MFA/HMAC at framework scale → escape hatch added
-- Claude flagged auth escape via upstream PR blocks fast adoption → local plugin path (project's own `scripts/auth-plugin.sh`)
-- Claude flagged JWT mid-recipe expiry silent failure → `token_ttl_hint_seconds` + auto-refresh logic
-- Claude flagged Python-only runner blocks JS shops → Dockerfile shipped from PR-A
-
-**Rejected:**
-- Project-side runner (duplicates code, defeats framework)
-- Python entrypoint plugins (couples language)
-
-### D2 (was Q1) — Recipe schema (cross-AI revisions baked in)
+### D2 — Recipe schema (FIXTURES/{G-XX}.yaml)
 
 ```yaml
-schema_version: "1.0"                    # NEW: mandatory; runner rejects unknown majors
+schema_version: "1.0"                    # mandatory
 goal: G-10
 description: Admin approves tier2 topup — row must exist in pending tier2 state
-fixture_intent:                          # NEW: cross-ref to TEST-GOALS.md mutation_evidence
+fixture_intent:
   declared_in: TEST-GOALS.md#G-10
-  validates: "tier2 topup row visible in admin queue, approve button shown"
+  validates: "tier2 row visible in admin queue"
 
-steps:
-  - id: create_tier2_topup
-    kind: api_call
-    role: merchant-owner                 # lookup into vg.config.credentials[env]
-    method: POST
-    endpoint: /api/v1/wallet/topup-requests
-    body:
-      amount: 0.01                       # NEW: must use sandbox-safe sentinel (D9)
-      currency: USD
-      gateway: sunrate
-      reference: "VG_FIXTURE_{run_id}_{step.id}"   # NEW: standardized prefix (D8)
-    side_effect_risk: money_like         # NEW: gate via D9 sandbox safety
-    capture:
-      request_id:
-        path: $.id                        # JSONPath (RFC 9535)
-        cardinality: scalar               # NEW: scalar | array | optional_scalar
-        on_empty: fail                    # NEW: fail | skip | null
-    validate_after:                       # NEW: read-only assertion (Claude review)
-      kind: api_call
-      method: GET
-      endpoint: /api/v1/admin/topup-requests/{request_id}
-      expect_status: 200
-      assert_jsonpath:
-        - path: $.tier
-          equals: tier2
-        - path: $.status
-          equals: pending
+# D13 concurrency/isolation
+allocation:
+  lease_id: "{run_id}"
+  expires_at: "+30m"
+  owner_session: "{session_id}"
 
-  # NEW: loop step type (Claude review — covers CRUD goals like G-52 IMAP)
-  - id: create_imap_configs
-    kind: loop
-    over: ["primary", "secondary", "fallback"]   # or: count: 3
-    each:
-      kind: api_call
-      role: admin
-      method: POST
-      endpoint: /api/v1/admin/imap-configs
-      body:
-        name: "{loop.value}"
-        host: "test-{loop.index}.fixture.vgflow.test"
-    capture:
-      config_ids:
-        path: $.id
-        from_each: true                   # NEW: collect into array
-
-expects:
-  capture_into:
-    EXPECTED_ROW_ID: "{steps.create_tier2_topup.request_id}"
-```
-
-**Decisions baked in (with cross-AI revisions):**
-- `schema_version` **mandatory** at top. Runner rejects recipes whose major version it doesn't support. Hard error, not silent. Closes Codex+Claude convergent concern about schema evolution.
-- `endpoint`: **relative**, runner resolves `api_base` from `vg.config.environments.{env}.api_base`.
-- `role`: string lookup into `vg.config.credentials[env]`.
-- `capture` cardinality rules (Claude review):
-  - `scalar` — exactly 1 match required (`on_empty: fail` default)
-  - `array` — collect all matches (zero matches OK if `on_empty: skip`)
-  - `optional_scalar` — 0 or 1 match, null if 0
-- `kind: loop` step type (Claude review) — `over: [...]` for explicit values OR `count: N` for indexed; capture supports `from_each: true` to collect array.
-- `body` template variables: `{run_id}`, `{step.id}`, `{steps.<id>.<name>}`, `{role.email}`, `{loop.value}`, `{loop.index}` — minimal interpolation, documented set, no templating engine.
-- `validate_after` block (Claude review) — read-only assertion runs after step. Catches partial-orphan inconsistent state at recipe time, not at scanner time. Optional but recommended for multi-step recipes.
-- `fixture_intent` block (Codex review) — cross-references TEST-GOALS.md `mutation_evidence` declaration. Separate validator can compare blueprint intent vs fixture reality.
-- `side_effect_risk: money_like | volume_change | external_call | none` — gates via D9 sandbox safety. Runner refuses risky steps on non-sandbox envs.
-- `reference` field is **standardized**: `VG_FIXTURE_{run_id}_{step.id}`. Becomes basis for D8 tag-based prune.
-- `run_id` format: **mandatory** `{timestamp_ms}-{random_4hex}` (e.g. `1714683724891-a3f2`). Closes Claude's concurrency concern.
-- `.fixture-cache.json` writes are **atomic** (write tmp + rename) OR per-run files `.fixture-cache-{run_id}.json`. Closes Claude's concurrent-runs race.
-- Auth tokens: handled by runtime per D1 (not in recipe).
-
-**Rejected alternatives:** absolute URLs (breaks portability), typed role enums (premature), jq syntax (tool dep), in-recipe secrets (security smell), unbounded templating engine (Jinja-class — feature creep).
-
-### D3 (was Q2) — Multi-step failure: no rollback, validate-after + orphan log
-
-Step N fails → recipe overall fails → goal marked BLOCKED in matrix with reason `fixture step N/M failed: <error>`. Steps 1..N-1 already executed leave their entities behind (per Decision 2 "no cleanup").
-
-**Cross-AI addition (Claude review):** orphans alone are insufficient. Inconsistent partial state can satisfy invariant queries → false-pass at preflight → scanner finds broken row → unexplained SUSPECTED. Mitigation: `validate_after` block on each step (D2) acts as a checkpoint. If validate_after fails, recipe fails AT that step with a clear "step N produced invalid state" error, not "step N+1 timed out and we don't know why."
-
-**Concrete output on partial failure:**
-- `runs/G-{XX}.fixture-orphans.json`: IDs captured before failure
-- `runs/G-{XX}.fixture-error.json`: error context — which step failed, why, validate_after assertion that triggered if any
-- Goal status: BLOCKED with reason linking to error file
-- Recovery path: `/vg:doctor recovery` shows "fix recipe step N, re-run /vg:review --retry-failed"
-
-**Rationale:** transactional rollback per entity type is engineering cost we don't justify for sandbox-disposable model. validate_after + orphan log + error context cover the diagnostic gap at ~50 lines runner code total.
-
-### D4 (was Q4) — Time-driven goals deferred to parallel RFC (open immediately)
-
-Goals requiring backdated timestamps or fast-forward (cooling period, 7-day chargeback deadline, BullMQ retry-attempt-N) are NOT solved by recipes in v1. They need backend cooperation (test-only headers, sandbox-only env detection) — separate multi-week design.
-
-**Cross-AI revision (Codex):** open the time-travel RFC **immediately as design-only**, not "after first non-3.2 phase blocks." Both reviewers flagged that 8% won't stay constant — billing/fraud/SLA/lifecycle workflows accumulate time-driven goals. After 5 phases possibly 15-20% DEFERRED. Designing in parallel (even if implementation ships later) lets time-travel goal authors know what's coming.
-
-**For now:** affected goals declare `requires_time_travel: true` in TEST-GOALS frontmatter. Matrix classifies as **DEFERRED** with cross-AI revision: also carry `blocked_since_phase: 3.2` field (Claude review) so health checks can surface long-DEFERRED goals as technical debt.
-
-```markdown
-## Goal G-22: Withdraw cooling period blocks new request
-**Surface:** ui
-**Requires time travel:** true
-**Blocked since phase:** 3.2
-**Time travel reason:** Need merchant with last_failed_withdraw_at < 1h ago
-```
-
-**Affected from Phase 3.2 dogfood:** G-22, G-42, G-58 — 3 of 36 (~8%). Expected to grow.
-
-**Follow-up:** open `RFC: time-travel test infrastructure` **as part of this RFC bundle**, design-only, separate document. Implementation tracked as PR-G with no firm date.
-
-### D5 (was Q5) — `data_invariants` schema (REVISED for N-consumer + cycle detection)
-
-**Major revision after both reviewers flagged D7 non-convergence.** Original "≥1 row" semantics fails when N goals each consume one trigger entity. Now: invariants declare per-consumer entity creation, not per-invariant.
-
-```yaml
-# In ENV-CONTRACT.md
-data_invariants:
-  - id: tier2_topup_pending
-    resource: topup_requests
-    where:
-      status: pending
-      tier: tier2
-    consumers:                           # NEW: list of goals that NEED a row
-      - goal: G-10
-        recipe: G-10                     # owning recipe
-        consume_semantics: destructive   # NEW: scanner mutation removes the row
-      - goal: G-11
-        recipe: G-10                     # inherits same recipe template
-        consume_semantics: destructive
-      - goal: G-15                       # hypothetical edit goal
-        recipe: G-10
-        consume_semantics: read_only     # scanner mutates but doesn't remove from query
-    isolation: per_consumer              # NEW: per_consumer | shared_when_read_only
-    # Preflight rule: count consumers with consume_semantics=destructive,
-    # create that many entities. Each entity ID stored separately keyed by goal.
-
-  - id: linked_account_exists
-    resource: linked_accounts
-    where: { status: active }
-    consumers:
-      - goal: G-34
-        recipe: G-34
-        consume_semantics: read_only     # scanner reads but doesn't delete
-    isolation: shared_when_read_only     # 1 entity, all read-only consumers share
-```
-
-**Decisions baked in (CROSS-AI REVISIONS — D7 algorithm fix):**
-- `consumers` block lists every goal that depends on this invariant + each goal's consume semantics
-- `consume_semantics`: `destructive` (scanner mutation removes/transitions entity) | `read_only` (scanner observes only)
-- `isolation`: `per_consumer` (preflight creates N entities, each goal gets unique ID) | `shared_when_read_only` (one entity, multiple read-only consumers share)
-- Preflight algorithm: count `destructive` consumers in matrix, create that many entities, store each in `.fixture-cache.json` keyed by `G-XX` (not by invariant)
-- Inheritance with cycle detection: runner walks `recipe` chain, detects cycles via DFS visited-set, fails build if depth > 5 OR cycle found
-- Diamond inheritance: same-owner = OK (dedup), different-owner = build error
-- `where` is conjunction-only (AND). OR → separate invariants.
-- `count` removed from schema — implicit from `len(consumers)`. Hard-coded counts were the source of the non-convergence bug.
-
-**Rationale:** Both reviewers independently flagged "1 row for N consumers" as a correctness bug. Original D5 had `count: ">=1"` semantics that satisfied invariant query but starved sequential scanners. Now: invariant declares its consumers, preflight creates entities per-consumer, scanner cache is per-goal, ping-pong eliminated by construction.
-
-**Side benefit:** `consume_semantics` annotation makes the matrix self-documenting — anyone reading ENV-CONTRACT.md sees which goals destroy state vs only observe.
-
-### D6 (was Q6) — Codegen emits `runFixture()` runtime call + semantics field
-
-`/vg:test` Playwright codegen emits:
-
-```typescript
-test.beforeEach(async ({ request, page }) => {
-  await runFixture(request, page, 'G-10', { semantics: 'isolated' });
-});
-```
-
-`runFixture` is a TS helper (~30 LOC) shipped with vgflow as `@vgflow/fixture-runtime` (or vendor-copied at PR-E time). Reads YAML, makes HTTP calls, returns capture map.
-
-**Cross-AI revision (Claude review):** review and test have different protocol semantics (review = once-per-phase shared state, test = once-per-test isolated state). Hiding both in one schema makes "no drift" superficially true but structurally fragile. Solution: explicit `semantics` field on `runFixture` call OR top-level `consumer_modes` block in recipe YAML acknowledging both modes.
-
-```yaml
-# Recipe declares which semantics it supports
-consumer_modes:
-  review:
-    semantics: shared
-    cache_key: G-10
-  test:
-    semantics: isolated_per_test
-    cache_key: "{test_uuid}"
-```
-
-**Cross-AI revision (Claude review) — Playwright context:** `runFixture(request, page, ...)` accepts both APIRequestContext (for HTTP calls) AND Page (for cookie sync). Helper auto-syncs cookies between contexts when fixture login sets cookies that test must use. Avoids silent auth-context-mismatch bug.
-
-**Cross-AI revision (Codex+Claude convergent) — schema versioning:**
-- `schema_version: "1.0"` in every YAML (already mandated in D2)
-- `runFixture` rejects YAML whose major version it doesn't support — hard error with clear message
-- Vendor-copied runtime + vgflow schema bump = clear failure, not silent drift
-
-**Rationale:** option (a) transpile-to-inline-TS = drift waiting to happen. Option (b) keeps YAML single source of truth. Trade-off accepted: specs depend on runtime helper + YAML files. Vendor folder OK because schema_version + runtime version both pinned.
-
-### D7 (was Q7) — Preflight runs once, creates entities per-consumer (REVISED)
-
-**Major revision after both reviewers flagged non-convergence ping-pong.** Original "≥1 row" preflight + `--retry-failed` loop was claimed to converge "in 1-2 iterations." Both reviewers proved it doesn't converge when 2+ retry-set goals share a destructive trigger entity (G-10 + G-15 example, A2 in cross-AI synthesis).
-
-Phase 2c-pre adds `verify-data-invariants` step (revised algorithm):
-
-1. Read all `data_invariants` from ENV-CONTRACT.md
-2. For each invariant: count `destructive` consumers from `consumers[]` block (D5)
-3. Query sandbox state for current matching entity count
-4. If `(destructive_consumer_count - matching_count) > 0`: run owning recipe N times, where N = the gap. Each run captures a fresh ID.
-5. Store IDs in `.fixture-cache.json` keyed by **goal_id**, not invariant_id:
-   ```json
-   {
-     "G-10": { "EXPECTED_ROW_ID": "abc123", "created_at": "2026-05-02T..." },
-     "G-11": { "EXPECTED_ROW_ID": "def456", "created_at": "2026-05-02T..." },
-     "G-15": { "EXPECTED_ROW_ID": "ghi789", "created_at": "2026-05-02T..." }
-   }
-   ```
-6. Re-query invariant. If still failed (rare — recipe broken or auth wrong): BLOCK with actionable error.
-
-Each Haiku scanner reads cache for **its own goal's** EXPECTED_ROW_ID. No more "all scanners share one row."
-
-**Concurrent-runs safety (Claude review):** preflight writes cache atomically (tmp file + rename) OR per-run files `.fixture-cache-{run_id}.json`. Either approach prevents last-writer-wins races between two `/vg:review` processes.
-
-**No re-check before each scanner spawn.** Per-consumer entities mean prior scanner mutations don't invalidate later scanners — each has its own. Convergence guaranteed by construction, not by retry loop.
-
-**Rationale:** original D7 was correct in spirit (preflight-once is right architecture) but wrong in algorithm (1 row for N consumers). Per-consumer creation is cost-equivalent (preflight N HTTP calls instead of 1) but algorithmically convergent.
-
-**Order matters:** invariant gap = BLOCK at preflight, not silent SUSPECTED later. This is what prevents the "scanner ran but had nothing to test" failure that started this RFC.
-
-### D8 (was Q8) — `/vg:fixture-prune` spec (REVISED — registry-first, tag-second)
-
-**Major revision after both reviewers flagged "tag-based assumes metadata column."** Many real schemas (ledger rows, immutable audit, join tables, external payment objects) cannot accept arbitrary `vgflow_fixture_run_id` field. Original D8 baked an assumption that breaks adoption.
-
-**Three-layer prune mechanism (in priority order):**
-
-```yaml
-# In vg.config.md
-fixtures:
-  entity_types:
-    topup_requests:
-      tag_strategy: registry_first       # registry → reference_field → time_window
-      reference_field: reference         # field name in this entity type
-      time_window_field: created_at      # for fallback
-
-    ledger_entries:
-      tag_strategy: registry_only        # immutable, can't tag
-      # only deletable via registry lookup; if registry lost, never deletable
-      retention_policy: keep_forever
-
-    transfer_groups:
-      tag_strategy: tag_field_first      # entity supports metadata
-      tag_field: metadata.vgflow_fixture_run_id
-```
-
-**Layer 1 — Registry (primary):** `runs/fixture-registry.jsonl` accumulates one line per fixture-created entity:
-```json
-{"resource":"topup_requests","id":"abc123","run_id":"1714683724891-a3f2","created_at":"...","goal":"G-10"}
-```
-Prune reads registry, deletes entries by `run_id` age + reference pattern match.
-
-**Layer 2 — Reference field (fallback):** if entity has standardized `reference: VG_FIXTURE_{run_id}_{step.id}` (mandated in D2), prune queries `WHERE reference LIKE 'VG_FIXTURE_%' AND created_at > N days ago`. Used when registry lost or for entity types without metadata support.
-
-**Layer 3 — Time window (last resort):** for entity types that have neither metadata nor reference field, prune deletes by time window only. Requires explicit `tag_strategy: time_window_only` opt-in per entity type — high-blast-radius, ops must approve.
-
-**Other contracts (preserved from v3):**
-- Manual trigger v1, no cron
-- Default age threshold 7 days, configurable
-- Scoped role `vgflow-fixture-cleaner` with hard-delete privilege limited to tagged entities only
-- Reads `runs/G-{XX}.fixture-orphans.json` (from D3) for partial-failure cleanup
-
-**Cross-AI addition:** prune dry-run mode (`/vg:fixture-prune --dry-run`) prints what WOULD be deleted before doing it. Mandatory first run on new env, optional after.
-
-**Follow-up:** full `RFC: vg:fixture-prune cleanup command` after D1-D7 ship. v4 RFC commits to the registry-first contract so PR-A doesn't bake wrong tagging assumptions.
-
-### D9 (NEW) — Sandbox safety guardrails (closes "fixture creates real money" risk)
-
-Cross-AI both flagged HIGH: Phase 3.2 is BILLING. Fixture POST creates real wallet balance, gateway webhooks fire externally, reconciliation reports see fixture amounts. RFC v3 had no coverage. v4 commits to:
-
-**Hard environment gate (runner refuses unless ALL pass):**
-1. `vg.config.environments.{env}.kind` must be `sandbox` (not `local|staging|prod`)
-2. Server must respond to health probe with header `X-VGFlow-Sandbox: true` (project adds this to sandbox deploy; absent on prod)
-3. Recipe steps with `side_effect_risk` ∈ `{money_like, external_call}` blocked unless `kind: sandbox` + `X-VGFlow-Sandbox` header confirmed
-
-**Sentinel value requirements (validator at recipe schema time):**
-- Currency-amount fields must use sandbox-safe values: `amount ≤ 0.01` for any field whose name matches `amount|balance|price|fee|cost`
-- Email fields must use domain `@fixture.vgflow.test`
-- `reference` field must start with `VG_FIXTURE_` (already standardized in D2)
-- Names should include `[FIXTURE]` prefix (warn-level, not block)
-
-**Example block in recipe:**
-```yaml
 steps:
   - id: create_tier2_topup
     kind: api_call
     role: merchant-owner
     method: POST
     endpoint: /api/v1/wallet/topup-requests
+    idempotency_key: "VG_FIXTURE_{run_id}_{step.id}"
     body:
-      amount: 0.01                       # sentinel — would be flagged if 100
+      amount: 0.01                       # D9 sandbox sentinel
       currency: USD
       gateway: sunrate
-      reference: "VG_FIXTURE_{run_id}_{step.id}"   # mandatory prefix
-    side_effect_risk: money_like         # gates D9 sandbox check
+      reference: "VG_FIXTURE_{run_id}_{step.id}"
+    side_effect_risk: money_like
+    capture:
+      request_id:
+        path: $.id
+        cardinality: scalar
+        on_empty: fail
+    validate_after:
+      kind: api_call
+      method: GET
+      endpoint: /api/v1/admin/topup-requests/{request_id}
+      assert_jsonpath:
+        - { path: $.tier, equals: tier2 }
+
+  - id: create_imap_configs
+    kind: loop
+    over: ["primary", "secondary", "fallback"]
+    each:
+      kind: api_call
+      role: admin
+      method: POST
+      endpoint: /api/v1/admin/imap-configs
+      idempotency_key: "VG_FIXTURE_{run_id}_imap_{loop.value}"
+      body: { name: "{loop.value}", host: "test-{loop.index}.fixture.vgflow.test" }
+    capture:
+      config_ids: { path: $.id, from_each: true }
+
+# D12 RCRURD lifecycle
+lifecycle:
+  pre_state:
+    role: admin
+    method: GET
+    endpoint: /admin/topup-requests/{request_id}
+    retry: { max_attempts: 3, delay_ms: 200, until_assertion_pass: true }
+    assert_jsonpath:
+      - { path: $.status, equals: pending }
+      - { path: $.tier, equals: tier2 }
+  
+  action:
+    surface: ui_click
+    target: "Approve button on row {request_id}"
+    expected_network:
+      method: POST
+      endpoint: /admin/topup-requests/{request_id}/approve
+      status_range: [200, 299]
+      target_selector_must_include: "{request_id}"
+  
+  post_state:
+    role: admin
+    method: GET
+    endpoint: /admin/topup-requests/{request_id}
+    retry: { max_attempts: 5, delay_ms: 300, until_assertion_pass: true }
+    assert_jsonpath:
+      - { path: $.status, equals: approved }
+      - { path: $.approved_at, not_null: true }
+  
+  side_effects:
+    - role: merchant-owner
+      method: GET
+      endpoint: /wallet/balance
+      retry: { max_attempts: 5, delay_ms: 500, until_assertion_pass: true }
+      assert_jsonpath:
+        - { path: $.balance_usd, increased_by_at_least: 0.01 }
 ```
 
-**Build-time validator** `verify-fixture-sandbox-safety.py`:
-- Walks every `FIXTURES/G-XX.yaml`
-- Reports schema-violations: amount > 0.01 in money fields, email domain != fixture.vgflow.test, missing reference prefix
-- Severity: BLOCK (build wave fails)
+**Schema rules:**
+- `endpoint` relative
+- `role` lookup `vg.config.credentials[env]`
+- `capture` JSONPath RFC 9535
+- Interpolation: `{run_id}`, `{step.id}`, `{steps.<id>.<name>}`, `{role.email}`, `{loop.value}`, `{loop.index}`, `{session_id}`
+- `run_id` mandate format: `{timestamp_ms}-{random_4hex}`
+- `idempotency_key` mandatory cho POST/PUT
+- `retry.until_assertion_pass` cho post_state/side_effects
+- `target_selector_must_include` cho action (scanner click fixture ID)
 
-**Runtime gate** in runner:
-- Refuses execution unless env kind + sandbox header both confirm
-- Refuses any `side_effect_risk: money_like` step on env without confirmed sandbox status
-- Logs every refusal to telemetry (`fixture.refused_unsafe_env`) so user gets clear "I'm not running on prod" feedback
+### D3 — Multi-step failure: validate_after + orphan log
 
-**Rationale:** "richer = easier" was right for sandbox volume but wrong for safety. Hard gates + sentinel values let projects opt into sandbox-only fixtures with confidence the runner won't accidentally pollute prod.
+Step N fail → recipe overall fail → goal BLOCKED.
+- `runs/G-XX.fixture-orphans.json` — orphan IDs for prune
+- `runs/G-XX.fixture-error.json` — error context
+- `validate_after` is primary mitigation against partial-orphan inconsistent state
 
-### D10 (NEW) — Evidence provenance (closes wave-3.2.2 hotfix gap, bundled with this RFC)
+### D4 — Time-travel goals: declare DEFERRED + parallel RFC G
 
-Cross-AI both flagged HIGH: wave-3.2.2 bidirectional sync (currently shipped in PR #79) promotes SUSPECTED → READY when goal_sequence has `submit + 2xx`. Goal_sequence JSON is writable by executor agents, scanner agents, and orchestrator code. Executor can hand-write fake submit + 2xx → auto-promote → trust model has back door.
-
-**Fix bundled into this RFC** (was originally going to be standalone wave-3.2.3):
-
-Add `evidence_source` field to every step in `goal_sequence`:
-```json
-{
-  "do": "click",
-  "target": "Approve button",
-  "evidence_source": "scanner",          // NEW
-  "scanner_run_id": "haiku-G10-1714683724",  // NEW
-  "captured_at": "2026-05-02T...",       // NEW (already partial)
-  "network": [...]
-}
+Affected goals declare:
+```markdown
+**Requires time travel:** true
+**Blocked since phase:** 3.2
+**Time travel reason:** Need merchant với last_failed_withdraw_at < 1h ago
 ```
 
-**Allowed values for `evidence_source`:**
-- `scanner` — Haiku scanner spawned by `/vg:review` Phase 2b-2 wrote this
-- `executor` — `/vg:build` executor wrote this (informational only — never triggers status change)
-- `orchestrator` — orchestrator code path (preflight, recovery, smoke) wrote this
-- `manual` — user/AI hand-edited (explicitly informational, never triggers)
+Matrix classify DEFERRED. Health check surface "blocked since X phases" as technical debt.
 
-**Promotion rule (revised wave-3.2.2 logic):**
-- SUSPECTED → READY ONLY when ALL submit + 2xx steps in goal_sequence have `evidence_source: scanner`
-- Mixed-provenance sequences (some scanner, some executor) → READY downgraded to PARTIAL or stays SUSPECTED
-- Hand-written fake → never promotes, even if structurally valid
+`RFC G: time-travel test infrastructure` open immediately design-only.
 
-**Validator** `verify-evidence-provenance.py`:
-- Walks every goal_sequence
-- Asserts every mutation step has `evidence_source` field
-- Asserts `scanner` claims have matching `scanner_run_id` that exists in events.db
-- BLOCKs review-complete if any submit step has unverified provenance
+### D5 — `data_invariants` per-consumer (no count)
 
-**Migration path:**
-- Existing goal_sequences from PR #79 era lack the field — backfill validator marks them `evidence_source: legacy_pre_provenance`, treats as informational only
-- Dogfood phases (3.2 specifically) re-run scanner for proper attribution
-- New goal_sequences MUST carry `evidence_source` from PR-A onward
+```yaml
+data_invariants:
+  - id: tier2_topup_pending
+    resource: topup_requests
+    where: { status: pending, tier: tier2 }
+    consumers:
+      - { goal: G-10, recipe: G-10, consume_semantics: destructive }
+      - { goal: G-11, recipe: G-10, consume_semantics: destructive }
+      - { goal: G-15, recipe: G-10, consume_semantics: read_only }
+    isolation: per_consumer
+```
 
-**Why bundle into this RFC, not separate hotfix:**
-- PR-A's fixture runtime writes goal_sequence steps with `evidence_source: orchestrator`
-- Without provenance field defined, PR-A's writes would be indistinguishable from scanner output
-- Bundling avoids "PR-A inherits broken trust model, then PR-B fixes it" sequence
+Preflight algorithm: count `destructive` consumers, create N entities, key cache by `goal_id`.
 
-**Implementation:** ships in same PR as RFC v4 schema definitions (PR-pre-A). Lands BEFORE PR-A.
+### D6 — Codegen: runFixture() runtime call
+
+```typescript
+test.beforeEach(async ({ request, page }) => {
+  await runFixture(request, page, 'G-10', { 
+    semantics: 'isolated_per_test',
+    schema_version: '1.0'
+  });
+});
+```
+
+`@vgflow/fixture-runtime` TS helper rejects unknown major schema_version. Cookie sync between APIRequestContext + Page.
+
+### D7 — Preflight: per-consumer + cross-phase resolver + locks
+
+Phase 2c-pre `verify-data-invariants`:
+1. Read invariants from ENV-CONTRACT.md
+2. Per invariant: count `destructive` consumers from matrix
+3. Walk cross-phase dependency graph từ `.vg/API-INDEX.yaml`
+4. Acquire D13 lock (file_lock or Redis advisory)
+5. Query state, run owning recipe N times (with idempotency keys)
+6. Verify entities exist before reuse cache
+7. Store IDs keyed by `goal_id`
+8. Release lock
+9. Re-query. Still failed → BLOCK với actionable error
+
+### D8 — `/vg:fixture-prune` 3-layer registry
+
+```yaml
+fixtures:
+  entity_types:
+    topup_requests: { tag_strategy: registry_first, reference_field: reference }
+    ledger_entries: { tag_strategy: registry_only, retention_policy: keep_forever }
+    transfer_groups: { tag_strategy: tag_field_first, tag_field: metadata.vgflow_fixture_run_id }
+```
+
+Layer 1 registry primary. Layer 2 reference field fallback. Layer 3 time window opt-in.
+
+Manual trigger v1, dry-run mandatory first run, scoped role `vgflow-fixture-cleaner`.
+
+### D9 — Sandbox safety guardrails
+
+**Hard environment gate:**
+1. `vg.config.environments.{env}.kind: sandbox`
+2. Server confirms via `/health` returns `X-VGFlow-Sandbox: true`
+3. Recipe steps with `side_effect_risk` ∈ {money_like, external_call, volume_change} blocked unless above 2 confirmed
+
+**Graceful migration warn-mode:** projects mới chưa có header → warn 30 days, block sau grace period.
+
+**Sentinel value validator:** amount ≤ 0.01, email `@fixture.vgflow.test`, reference `VG_FIXTURE_*`.
+
+### D10 — Evidence provenance (structured)
+
+```yaml
+evidence:
+  source: scanner | executor | orchestrator | diagnostic_l2 | manual
+  artifact_hash: sha256:...
+  scanner_run_id: haiku-G10-1714683724
+  captured_at: 2026-05-02T10:30:00Z
+  schema_version: "1.0"
+  layer2_proposal_id: null
+```
+
+**Promotion rule:** SUSPECTED → READY chỉ khi ALL submit + 2xx steps `evidence.source: scanner`. Other sources informational.
+
+Validator `verify-evidence-provenance.py`: BLOCKs review-complete if mutation step missing structured evidence.
+
+### D11 — Diagnostic Layer 2 (UNIVERSAL across pipeline, hybrid approval)
+
+**Activate cho TẤT CẢ Type B BLOCKs across pipeline** (not just /vg:review):
+
+| BLOCK source | Type | Diagnostic? |
+|---|---|---|
+| /vg:review Haiku scanner fail | B | Yes (existing) |
+| Layer 0 RCRURD lifecycle fail | B | Yes |
+| D27 content depth fail | B | Yes |
+| CrossAI council substance BLOCK | B | Yes |
+| Cross-reference orphan (D23) | B | Yes |
+| Build wave-verify content fail | B | Yes |
+| Stop hook (missing artifact) | A | No, single advisory |
+| Schema validator (field type wrong) | A | No, single advisory |
+| Hash chain broken | A | No, hard error |
+| T8 gate conflicts | C | No, /vg:reapply-patches |
+| Legacy schema (D24) | C | No, single advisory |
+
+**Validator output contract** (universal v9):
+```yaml
+verdict: BLOCK
+block_type: A | B | C
+validator: ...
+artifact: ...
+evidence:
+  field: ...
+  actual: ...
+  expected: ...
+recovery:
+  single_advisory: "..."
+  diagnostic_evidence_context: {...}    # for type B
+  override_flag: "..."                   # for type C
+```
+
+**Hybrid approval flow:**
+- Diagnostic parse evidence_context → articulate hypothesis tiếng người
+- Propose fix với diff
+- Auto-classify complexity:
+  - ≤10 LOC, 1 file, no schema change → 1-click
+  - >10 LOC, multi-file, schema/contract change → full review
+- User: y / n / edit-then-y / skip
+- y → apply, re-verify, commit `evidence.source: diagnostic_l2`
+- Anti-cycle: 2 reject same class → bypass session
+
+**Cost budget:**
+```yaml
+diagnostic_layer2:
+  max_invocations_per_run: 10
+  max_invocations_per_validator: 3
+  max_total_cost_usd: 5.00
+  on_budget_exhausted: skip_remaining
+```
+
+**Granular recovery routing:** `recovery_paths.py` key theo `(validator, evidence_class)`.
+
+### D12 — RCRURD lifecycle Layer 0 automation
+
+Sau Haiku scanner action, orchestrator chạy lifecycle assertion (D2 schema). Tất cả pass → READY automation, KHÔNG user gate.
+
+```
+Layer 0 (D12): RCRURD lifecycle (deterministic Python)
+   ↓ fail
+Layer 1: Auto-recovery (safe paths)
+   ↓ fail
+Layer 2 (D11): Diagnostic + hybrid user gate
+   ↓ decline
+Layer 3: Generic menu
+```
+
+**Eventual consistency handling:** `retry.until_assertion_pass` ở post_state + side_effects.
+
+Build wave-verify validator `verify-fixture-lifecycle-completeness.py`: mutation goal phải có post_state + side_effects non-empty.
+
+### D13 — Concurrency/isolation model
+
+**3 layer:**
+1. **Idempotency key per POST/PUT** (RFC 7240 `Idempotency-Key` header)
+2. **Allocation lease per recipe** (lease_id + expires_at + owner_session)
+3. **Lock backend** (file_lock single-machine, Redis/Postgres advisory team-shared)
+
+**Scanner targets fixture ID** (không "first visible row") — `target_selector_must_include` mandatory.
+
+### D14 — Schema versioning policy
+
+- **Same major required** — runner refuses different major
+- **Minor backward-compatible** — runner v1.2 reads v1.0
+- **N-1 minor support 6 months** grace period
+- **Unknown fields**: strict (default) fail | lenient warn-only
+
+Migration tool `vgflow fixture migrate FIXTURES/G-10.yaml --target=2.0` ship khi major bump.
+
+### D15 — Fixture security threat model
+
+**Recipe content rules** (validator `verify-fixture-security.py` build-time):
+- ❌ No secrets in YAML (regex scan: password|api_key|secret|token|bearer)
+- ❌ No absolute URLs trong endpoint
+- ❌ No external domains (configurable allowlist)
+- ⚠️ Risky verbs (DELETE/DROP/TRUNCATE) require `risk_acknowledged: true`
+
+**Auth log redaction:** Authorization/Cookie/X-API-Key headers redacted, secret regex bodies → `<REDACTED>`.
+
+**Runtime safeguards:** subprocess no shell/eval, safe substitution, file path restricted to `runs/` and `.vg/`.
+
+**Fixture entity ownership** (shared sandbox UI):
+- Sentinel email `@fixture.vgflow.test` filterable
+- Reference prefix `VG_FIXTURE_` excludable từ reports
+- Optional: scoped sandbox tenant `vgflow_test`
+
+### D16 — Multi-developer coordination + run report
+
+**Per-session isolation:** session_id (timestamp + machine + user) interpolated vào reference/email/cache file.
+
+**Lock backend** (D13 layer 3).
+
+**Run report (NEW v7):**
+```text
+=== /vg:review 3.2 run report ===
+Session: 1714683724-a3f2-dev-dzung
+Duration: 4m 23s
+
+Fixtures: Created 14, Reused 3, Failed 0, Orphaned 0
+Cost: $1.40 (Layer 0/1 free; Layer 2: 3 invocations $0.30 + $0.50)
+
+Recipes:
+  G-10..G-52 — all PASS
+  G-46 — Layer 2 fix proposed + 1-click approved
+  G-20 — Layer 2 fix proposed + 1-click approved
+
+Goals: 51 → 65 READY (12 unchanged, 14 newly verified)
+SUSPECTED: 0
+DEFERRED: 3 (G-22, G-42, G-58 — requires_time_travel)
+
+Next: /vg:test 3.2
+```
+
+### D17 — Test Strategy artifact (NEW v8)
+
+`TEST-STRATEGY.md` mới, generated ở blueprint sub-step 3a (trước PLAN/CONTRACTS/GOALS):
+
+```markdown
+# Test Strategy — Phase 3.2
+
+## Test types in scope
+- functional, api_contract, ui_ux, data_integrity, security
+- (out: performance, exploratory deferred to /vg:roam)
+
+## Risk assessment
+- Domain: payment processing → HIGH risk
+- New endpoints: 12 (auth boundary), 8 (mutation), 3 (read)
+- Cross-phase dependency: P1 merchant + P2 wallet
+
+## Coverage targets
+- critical priority: 100% READY required
+- important: ≥80%
+- nice-to-have: ≥50%
+
+## Exit criteria
+- 0 BLOCKED + 0 UNREACHABLE
+- ≤3 DEFERRED (with blocked_since_phase tracked)
+- All defects severity≥major closed or deferred with justification
+
+## Defect severity classification
+- critical: production data loss, security breach
+- major: feature broken, no workaround
+- minor: cosmetic, workaround exists
+- trivial: typo, polish
+```
+
+CrossAI council audit at blueprint complete.
+
+### D18 — Test type classification per goal
+
+TEST-GOALS.md schema:
+```yaml
+## Goal G-10
+**Description:** Admin approves tier2 topup
+**Test type:** functional + api_contract + ui_ux + data_integrity
+**Priority:** critical
+**Surface:** ui
+**Mutation evidence:** POST .../approve trả 200, balance merchant tăng
+**Required data:**                           # D19 merged here
+  categories:
+    - tier2 topup row in pending status
+    - wallet exists for merchant
+    - merchant active (not frozen)
+  edge_cases:
+    - amount = 0.01 (minimum boundary)
+    - amount = 999.99 (large boundary)
+    - merchant với prior failed topup
+  boundaries:
+    - currency mismatch (USD vs EUR)
+    - timezone-sensitive timestamp
+```
+
+**Test types catalog:**
+- `functional` — feature work as specified
+- `api_contract` — request/response shape match contract
+- `ui_ux` — visual + interaction flow
+- `data_integrity` — DB state correct after action
+- `security` — authz/authn boundary
+- `performance` — latency / throughput
+- `exploratory` — free-form discovery
+- `regression` — existing feature unchanged
+
+Validator `verify-test-types-coverage.py`: every mutation goal phải khai ≥1 test_type.
+
+### D19 — Test Data Spec MERGED into TEST-GOALS (per user direction)
+
+Merge as `required_data` field within each goal (above). NOT separate artifact. Reduces artifact count, keeps spec tied to goal context.
+
+### D20 — Skipped (smoke/sanity stage) per user direction
+
+Existing `--mode=full|delta|regression` đủ. No new modes added.
+
+### D21 — Defect Log structured
+
+`DEFECT-LOG.md` mới, persistent across phases:
+
+```yaml
+defects:
+  - id: D-3.2-001
+    severity: critical | major | minor | trivial
+    found_in: phase 3.2 review session 1714683724
+    found_by: scanner | layer2 | crossai | manual_uat
+    title: Approve button shows on tier-1 row but BE rejects 422
+    repro_steps: [...]
+    expected: ...
+    actual: ...
+    related_goals: [G-10, G-11]
+    status: open | in_progress | fixed | wontfix | duplicate
+    fix_commit: 4eb1c0be
+    retest_result: pass | fail | pending
+```
+
+REVIEW-FEEDBACK.md vẫn giữ as raw observation; DEFECT-LOG là processed/triaged.
+
+### D22 — Test Summary Report formal
+
+`TEST-SUMMARY-REPORT.md` template per phase, generate at /vg:test complete + /vg:accept entry. Audit-grade for stakeholders. Includes execution metadata, test type pass rate, defect summary, coverage, recommendations, artifacts trail.
+
+### D23 — Bi-directional traceability
+
+Forward: D-XX → G-XX → TS-XX → defect (existing).
+**Backward (NEW):** TS-XX → G-XX → D-XX, defect → G-XX → D-XX (root cause traceback).
+
+Validator `verify-rtm-bidirectional.py` build matrix automatically từ artifacts. Reports orphans (TS without G, G without D, defect without traceback). BLOCK build/review/test if orphan detected.
+
+### D24 — Legacy phase migration: SINGLE-ADVISORY (NOT menu)
+
+Auto-detect legacy schema at workflow entry of any /vg:* command:
+
+```
+⛔ Phase 3.2 schema pre-v9.
+
+   Chạy:
+     /vg:fixture-backfill 3.2
+
+   Sau đó re-run lệnh này.
+
+   Backfill cost: ~2-4 giờ user review one-time.
+   Backfill enrich TEST-GOALS với test_type + edge_cases,
+   sinh FIXTURES, populate API-INDEX, generate TEST-STRATEGY.
+
+   Override (nếu thực sự muốn skip):
+     /vg:review 3.2 --allow-legacy-skip-with-debt --reason="<text>"
+     (logs OVERRIDE-DEBT, blocks ở /vg:accept)
+```
+
+**No AskUserQuestion 3 options.** Single recommendation, single override path.
+
+`/vg:fixture-backfill <phase>` workflow:
+1. Read TEST-GOALS + API-CONTRACTS + RUNTIME-MAP
+2. Generate DRAFT fixtures (~70% from scanner-evidence, ~50% partial for SUSPECTED)
+3. Dry-run validate (--no-mutate) before promote
+4. Generate TEST-STRATEGY.md từ existing CONTEXT.md
+5. Generate API-INDEX cross-phase resolve
+6. CrossAI council review drafts
+7. User accept/edit interactive
+8. ONLY DRAFT-VALIDATED promotable
+
+### D25 — Research-augmented blueprint (hybrid)
+
+**Static pattern catalog primary** ship vgflow:
+- `.vg/test-patterns/auth-edge-cases.md`
+- `.vg/test-patterns/payment-edge-cases.md`
+- `.vg/test-patterns/crud-edge-cases.md`
+- `.vg/test-patterns/webhook-edge-cases.md`
+- `.vg/test-patterns/{auth-jwt,csrf,idor,sql-injection,...}.md` (OWASP coverage)
+
+**Internet research selective** (3 triggers):
+1. Domain not in catalog (niche industry)
+2. Goal references unfamiliar pattern
+3. CrossAI council flag gap
+
+Cache `.vg/research-cache/{domain-hash}.md` reuse across phases. CrossAI council quarterly audit catalog completeness.
+
+### D26 — Single-recommendation advisory pattern
+
+Khi workflow detect clear right answer, advise straight. Menu of alternatives ONLY hiện khi user explicit request `/vg:doctor recovery --show-alternatives`.
+
+Apply across:
+- D24 legacy migration (already)
+- recovery_paths.py output (BACKPORT to wave-3 PR #79)
+- Layer 2 Diagnostic format (already)
+
+`recovery_paths.py` revised:
+```python
+def render_recovery_block(violation_type, command, phase, evidence_class=None):
+    paths = get_recovery_paths(violation_type, command, phase, evidence_class)
+    if not paths:
+        return generic_fallback()
+    
+    recommended = paths[0]
+    return f"""
+⛔ {violation_type} BLOCK
+
+Recommended:
+  $ {recommended['command']}
+
+Reason: {recommended['rationale']}
+
+See alternatives: /vg:doctor recovery {phase} --show-alternatives
+"""
+```
+
+### D27 — Content depth + quality validators
+
+Force AI engage thật, không skim qua schema-pass-but-thin-content:
+
+**a) Word count + specificity per field**
+```yaml
+description:
+  type: string
+  min_length: 30
+  must_contain_oneof: ["{D-XX}", "{specific entity name}"]
+```
+
+**b) Cross-reference completeness**
+- Every D-XX → ≥1 G-XX cite
+- Every G-XX → ≥1 commit cite
+- Every G-XX với mutation_evidence → ≥1 FIXTURES file
+- Every G-XX → ≥1 TS-XX bind
+- Every defect → trace back D-XX
+
+`verify-cross-reference-completeness.py` orphan-detect.
+
+**c) Edge case substance check**
+- Min 3 entries cho critical priority
+- Each must reference specific value/state (regex or explicit)
+- Generic strings như "edge case 1" → fail
+
+`verify-edge-case-substance.py`.
+
+**d) LLM-as-judge isolated subagent**
+Critical artifacts (TEST-STRATEGY, TEST-GOALS) → spawn separate Haiku judge:
+- Score 1-10 completeness, specificity, domain-relevance
+- < 7 → BLOCK với feedback
+
+Cost: ~$0.30/judge × 2-3 critical artifacts = ~$1/blueprint.
+
+**e) Instruction repetition gate (anti-skim)**
+At blueprint entry: AI must paraphrase 3 most important constraints. Validator regex check non-generic. Generic → re-prompt.
+
+### D28 — Aggregate advisory cho multi-Type-A BLOCKs
+
+Khi multiple Type A BLOCKs cùng common root cause:
+
+```
+⛔ Multiple structural issues:
+  - .vg/phases/3.2/TEST-STRATEGY.md missing
+  - .vg/phases/3.2/FIXTURES/ empty
+  - .vg/API-INDEX.yaml not created
+
+Recommended (single command):
+  /vg:fixture-backfill 3.2
+
+Why: backfill generates all 3 in one run.
+```
+
+Aggregator detect common root cause across multiple structural BLOCKs → suggest unified action thay vì 3 single advisories overlap.
 
 ---
 
-## Out of scope (explicit non-goals)
+## 6. Layer architecture cho /vg:review BLOCK handler
+
+```
+BLOCK detected
+   ↓
+Layer 0 (D12): RCRURD lifecycle automation
+  - Pre-state + action + post-state + side-effects
+  - Deterministic Python, retries với exponential backoff
+  - All pass → READY automation, NO user gate
+  ↓ assertion fail
+Layer 1: Safe auto-recovery (existing wave-3.1)
+  - Override flags
+  - Re-scan với scope khác
+  - Log debt
+  ↓ chưa giải quyết
+Layer 2 (D11 universal): Diagnostic + hybrid user gate
+  - AI parse evidence + articulate hypothesis
+  - Granular recovery_paths theo (validator, evidence_class)
+  - 1-click vs full review per complexity
+  - Cost budget (max invocations + USD cap)
+  - Anti-cycle guard
+  - ACTIVE for ALL Type B BLOCKs across pipeline
+  ↓ user decline hoặc complex
+Layer 3: Generic menu (existing) + D26 single-advisory mode
+```
+
+---
+
+## 7. Migration workflow map (post-backfill)
+
+```
+Legacy phase (pre-v9) — adopt v9 workflow:
+
+Step 1: /vg:fixture-backfill <phase>
+  → Enrich TEST-GOALS, generate FIXTURES + TEST-STRATEGY + API-INDEX
+  → Cost: 2-4h user time (one-time per phase)
+  → Code untouched
+
+Step 2: /vg:review <phase>
+  → Use enriched artifacts
+  → Layer 0/1/2/3 stack
+  → Surface code bugs (if any)
+
+Step 3 (only if Step 2 surface bug): /vg:build <phase> --incremental
+  → Apply Layer 2 proposed fix
+  → Wave-verify
+  → Cost: ~30min - 2h depending on bug
+
+Step 4 (verify): /vg:review <phase> --retry-failed
+
+Step 5: /vg:test <phase> + /vg:accept <phase> (existing)
+
+NOT typically needed:
+- /vg:blueprint <phase> (backfill replaces this for enrichment)
+- /vg:build <phase> full re-build (existing code reused)
+```
+
+`/vg:next` smart routing post-backfill: auto-route tới /vg:review.
+
+---
+
+## 8. Tool inventory final
+
+**Existing (giữ nguyên):**
+- Haiku scanner agent + vg-haiku-scanner skill
+- Playwright MCP (5 slots với lock manager)
+- CrossAI CLIs: codex (gpt-5.5), gemini (gemini-3.1-pro-preview), claude (sonnet)
+
+**New (RFC v9):**
+- ~400-500 LOC Python orchestrator code
+- 2 small Python deps: `requests`, `jsonpath-ng`
+- Optional Dockerfile alternative
+- New schemas: `fixture-recipe.schema.yaml`, `data-invariants.schema.yaml`
+- New artifacts: `FIXTURES/`, `.vg/API-INDEX.yaml`, `.fixture-cache.json`, `TEST-STRATEGY.md`, `DEFECT-LOG.md`, `TEST-SUMMARY-REPORT.md`
+- New validators (15+): provenance, lifecycle, data_invariants, build-fixtures-present, codegen-binding, backend-mutation, sandbox-safety, security, artifact-hash, lock-acquired, test-types-coverage, rtm-bidirectional, cross-reference, edge-case-substance, fixture-lock
+- Pattern catalog `.vg/test-patterns/`
+- Research cache `.vg/research-cache/`
+
+**Borrow techniques (no dependency):**
+- Stagehand DOM chunking → Haiku scanner
+- GUI-ReWalk anti-loop → Haiku skill
+- Schemathesis stateful-link pattern → schema reference
+- OWASP / CVE catalog → pattern files
+
+**Rejected:**
+- ❌ Karate, Schemathesis, Zerocode external runtime
+- ❌ Docker container as primary
+- ❌ MCP wrapper for fixture services
+- ❌ Browser Use / Stagehand / Skyvern as Haiku replacement
+
+---
+
+## 9. Implementation roadmap
+
+### PR-pre-A: Foundation bundle (5-7 days) — STARTS NEXT
+
+- D2 + D5 + D10 schemas
+- D10 structured provenance contract
+- `verify-evidence-provenance.py`
+- Update `verify-matrix-staleness.py` bidirectional sync only on `evidence.source: scanner`
+- Backfill `legacy_pre_provenance` mode
+- Config gate: `provenance.enforcement: warn` initial → `block` next release
+- Tests
+
+### PR-A1: Schema parser + interpolation + JSONPath (3-4 days)
+- Schema validation engine
+- Variable interpolation
+- JSONPath cardinality rules
+- Loop step type
+- Tests: golden + edge cases
+
+### PR-A2: API execution + auth + sandbox safety (3-4 days)
+- 4 declarative auth handlers + `kind: command` escape hatch
+- Token TTL refresh + auth_verify
+- D9 sandbox env gate
+- Sentinel value validator
+
+### PR-A3: Cache + orphans + concurrency (3-4 days)
+- D13 idempotency keys
+- Allocation lease
+- Lock backend (file_lock primary)
+- D15 security validator
+- Atomic cache writes
+
+### PR-A.5: Migration `/vg:fixture-backfill` (5-6 days)
+- Read TEST-GOALS + API-CONTRACTS + RUNTIME-MAP
+- Generate DRAFT fixtures + dry-run validate
+- API-INDEX cross-phase resolve
+- TEST-STRATEGY generate from CONTEXT
+- CrossAI council review hook
+- D24 single-advisory entry detection
+
+### PR-B: `/vg:build` fixture-write step (1 week)
+- Executor sub-step + wave-verify
+- D12 lifecycle completeness check
+- D14 schema_version mandatory
+- Optional `vgflow fixture validate --dry-run --no-mutate`
+
+### PR-C: ENV-CONTRACT data_invariants + preflight (1.5 weeks)
+- N-consumer algorithm
+- Cross-phase dep resolution
+- Cycle detection
+- Lock acquire/release wrapping
+- Granular recovery_paths
+
+### PR-D1: Scanner cache integration (3-4 days)
+- Cache file contract
+- vg-haiku-scanner skill update
+- Scanner targets fixture ID
+
+### PR-D2: Layer 0 RCRURD lifecycle gate (1 week)
+- Deterministic Python check
+- Retry với eventual consistency
+
+### PR-D3: Layer 2 Diagnostic UX universal (1.5 weeks)
+- AI hypothesis parser
+- Hybrid 1-click vs full-review
+- Cost budget enforcement
+- Anti-cycle guard
+- D11 universal across BLOCK types
+- Validator output contract refactor
+
+### PR-E: `/vg:test` codegen integration (1 week)
+- Playwright codegen runFixture()
+- @vgflow/fixture-runtime TS helper
+- Schema-version compat check
+
+### PR-Z (parallel PR-D): Backend mutation evidence validator (5-7 days)
+
+### Pattern catalog seed (5-7 days, parallel anytime)
+- `.vg/test-patterns/` 8-10 domain catalogs
+- OWASP Top 10 + CWE-25 reference
+
+### PR-content-depth: D27 validators (1 week)
+- verify-edge-case-substance
+- verify-cross-reference-completeness
+- LLM-as-judge subagent
+- Instruction repetition gate
+
+### PR-tester-pro: D17/D18/D21/D22/D23 (1.5 weeks)
+- TEST-STRATEGY artifact generation
+- test_type field schema
+- DEFECT-LOG.md structured
+- TEST-SUMMARY-REPORT.md template
+- RTM bi-directional validator
+
+### PR-recovery-D26: Single-advisory backport (2-3 days)
+- BACKPORT to PR #79 wave-3
+- recovery_paths.py render only top recommended
+- /vg:doctor recovery --show-alternatives flag
+
+### PR-block-aggregator: D28 (2-3 days)
+- Aggregate multi-Type-A BLOCKs
+- Common root cause detection
+
+### PR-research-augment: D25 (1.5 weeks)
+- WebSearch/WebFetch integration
+- Cache layer .vg/research-cache/
+- 3 trigger conditions
+- CrossAI catalog audit
+
+### PR-F (followup): `/vg:fixture-prune` (1 week)
+### PR-G (parallel design RFC): Time-travel infrastructure (1 week design only)
+### PR-Y (followup): Recovery-paths-as-code test coverage (5 days)
+
+---
+
+## 10. Total estimate
+
+**~10-13 weeks total** (D1-D28 + tester pro + content depth):
+
+| Phase | Duration |
+|---|---|
+| PR-pre-A foundation | 5-7 days |
+| PR-A1 + A2 + A3 + A.5 | 3 weeks |
+| PR-B | 1 week |
+| PR-C | 1.5 weeks |
+| PR-D1 + D2 + D3 | 2-2.5 weeks |
+| PR-E | 1 week |
+| PR-Z parallel | 5-7 days |
+| PR-content-depth | 1 week |
+| PR-tester-pro | 1.5 weeks |
+| PR-recovery-D26 backport | 2-3 days |
+| PR-block-aggregator | 2-3 days |
+| PR-research-augment | 1.5 weeks |
+| Pattern catalog seed | 5-7 days |
+| **Total** | **~10-13 weeks** |
+
+PR-F + PR-G + PR-Y followups, open-ended.
+
+---
+
+## 11. Risk register (final)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Backfill quality cho no_sequence goals | MEDIUM | DRAFT-NEEDS-HUMAN-REVIEW + dry-run validate |
+| Layer 2 propose wrong fix | MEDIUM | Provenance D10 audit, cost budget, anti-cycle |
+| Time-travel goals stuck DEFERRED | LOW | RFC G open immediately |
+| Cross-phase entity prune destroys data | LOW | Auto-recreate via recipe |
+| Concurrent /vg:review races | **HIGH** | D13 lock backend mandatory + per-session cache |
+| Sandbox vs prod confusion | **HIGH** | D9 hard gate + grace migration |
+| Wave-3.2.2 fake evidence forge | **HIGH** | D10 structured provenance, scanner-only promotion |
+| Recipe YAML contains secrets | **HIGH** | D15 SECURITY validator |
+| Eventual consistency false-fail | MEDIUM | D12 retry config |
+| Schema breaking change orphans fixtures | MEDIUM | D14 versioning policy + migration tool |
+| Auth `kind: command` wrong role | MEDIUM | D1 auth_verify |
+| Fixture pollution shared sandbox | MEDIUM | D15 sentinel values + tenant scope |
+| Multi-dev coordination | HIGH | D16 lock backend + isolation |
+| Layer 2 cost runaway | MEDIUM | D11 cost budget |
+| AI content skim despite passing schema | MEDIUM | D27 depth validators (5 sub-mechanisms) |
+| Workflow loops menu options | HIGH | D26 single-advisory + D11 Diagnostic universal |
+| PR rollback if pre-A bad | MEDIUM | Config gates + warn-mode rollout |
+
+---
+
+## 12. Enforcement model per skill (NEW v9)
+
+19 layer enforcement to minimize AI skim:
+
+### Skill MD frontmatter
+- `runtime_contract`: must_write, must_touch_markers, must_emit_telemetry
+- `argument-hint`: flag whitelist
+- `profile` attribute: which steps required per profile
+
+### Skill body
+- `<step>` blocks ordered, profile-filtered
+- Each step entry: validator preflight gates
+- Each step body: AI work + schema validator + D27 depth check
+- Each step exit: marker + telemetry event
+- Cross-step: CrossAI council at gate, RTM cross-ref
+
+### Pre-commit hook
+- Citation D-XX/API-CONTRACTS required
+- --no-verify forbidden
+
+### Stop hook (vg-verify-claim.py)
+- Verify all must_write artifacts present
+- Verify all markers touched
+- Verify all telemetry emitted
+- Validate hash-chain integrity
+- BLOCK với recovery path nếu gap
+
+### Block type taxonomy (D11 v9)
+- Type A: structural BLOCK → single advisory (D26)
+- Type B: semantic BLOCK → Diagnostic Layer 2 (D11)
+- Type C: process BLOCK → specific recovery + override (D24)
+
+### D27 content depth layers
+1. Word count + specificity per field
+2. Cross-reference completeness
+3. Edge case substance check
+4. LLM-as-judge isolated subagent
+5. Instruction repetition gate
+
+**Honest limit:** ~5-10% AI semantic skim irreducible. Last backstop = human UAT at /vg:accept.
+
+---
+
+## 13. Cost analysis per phase cycle
+
+| Step | Cost |
+|---|---|
+| /vg:blueprint (artifacts + CrossAI council) | $5-6 |
+| /vg:build (implement + FIXTURES) | $7-12 |
+| /vg:review (Haiku scan + Layer 2 + CrossAI) | $5-8 |
+| /vg:test (codegen + run) | $2-3 |
+| /vg:accept | $0.50 |
+| **Total per phase cycle** | **~$20-30** |
+
+So với current (no v9): Phase 3.2 đã loop 2 sessions stuck = ~$10-15 wasted + frustration. v9 spend $20-30 mà converge → value positive.
+
+Migration backfill one-time: ~2-4h user time per legacy phase.
+
+---
+
+## 14. Out of scope
 
 - Production data — never. Sandbox only.
-- Performance testing fixtures (different shape — 100K rows, not 1 row per state).
-- Visual regression baselines (separate concern).
-- Migration test data (handled by schema-verify profile).
-- Time-travel infrastructure (deferred to separate RFC per Q4).
-- Sandbox reset / database snapshot mechanics — outside vgflow's responsibility, project's deploy pipeline handles.
+- Performance/load testing fixtures
+- Visual regression baselines (separate L4 layer wave-3.x)
+- Migration test data (schema-verify profile)
+- Time-travel infrastructure (RFC G separate)
+- Sandbox database snapshot mechanics (project deploy pipeline)
+- Manual tester workflow (vgflow autonomous)
 
 ---
 
-## Implementation plan (revised after cross-AI review)
+## 15. Appendix — Rejected options (final)
 
-D1-D10 resolved. Splits into PRs in dependency order, with PR-pre-A bundle landing first:
-
-### PR-pre-A: Foundation bundle — schema + provenance hotfix + sandbox safety contract
-**Lands before PR-A. Bundles wave-3.2.3 hotfix per user direction "revise RFC trước rồi gộp."**
-
-- `schemas/fixture-recipe.schema.yaml` (JSON-Schema for D2 — full schema spec, no runtime yet)
-- `schemas/data-invariants.schema.yaml` (JSON-Schema for D5)
-- `verify-evidence-provenance.py` validator (D10) — adds `evidence_source` field requirement to goal_sequence steps
-- Update `verify-matrix-staleness.py` (PR #79 wave-3.2.2) — bidirectional sync only triggers on `evidence_source: scanner`
-- Backfill mode: legacy goal_sequences without provenance marked `legacy_pre_provenance`, never auto-promote
-- **No runner code yet** — schema + provenance contract only
-- **Tests:** schema validation + provenance contract + legacy backfill behavior
-
-This closes the wave-3.2.2 trust model hole live in PR #79 BEFORE PR-A's runner inherits it.
-
-### PR-A: Recipe runner + auth + sandbox safety enforcement (D1, D2, D3, D9)
-- `scripts/run-fixture.py` — reads YAML, walks `steps[]`, captures via JSONPath with cardinality rules (scalar/array/optional_scalar)
-- 4 declarative auth-kind handlers: cookie, bearer, api-key, oauth-client-credentials
-- `kind: command` escape hatch handler — invokes local plugin (`scripts/auth-plugin.sh` per project)
-- Token refresh logic: track `token_ttl_hint_seconds`, re-auth when TTL < 10%
-- `kind: loop` step type with `over: [...]` and `count: N` semantics
-- `validate_after` block execution — read-only assertion after each step
-- Orphan logger writes `runs/G-{XX}.fixture-orphans.json` on partial failure
-- **Sandbox safety enforcement:**
-  - Refuses execution unless `vg.config.environments.{env}.kind: sandbox`
-  - Refuses unless server responds with `X-VGFlow-Sandbox: true`
-  - Refuses `side_effect_risk: money_like|external_call` steps on non-sandbox
-  - Sentinel-value validator at schema parse time
-- `Dockerfile` for runner — universal portability layer
-- **Mock consumer (Codex+Claude review):** `test/mock-scanner-consumer.py` reads `.fixture-cache.json` and validates contract that PR-D will rely on. Acts as contract test.
-- **Tests:** unit (schema, JSONPath, interpolation, auth, capture), integration (fake HTTP app), sandbox safety enforcement
-
-### PR-B: `/vg:build` fixture-write step + smoke-execute gate (D2 authoring)
-- Executor sub-step: after implementing goal with `mutation_evidence`, write `FIXTURES/{G-XX}.yaml`
-- Wave-verify validator: `verify-build-fixtures-present.py` — build incomplete if mutation goal lacks fixture YAML
-- **Smoke-execute gate (Claude review):** wave-verify also runs `run-fixture.py` against sandbox at build time. Catches semantic errors (wrong endpoint, wrong payload shape) immediately at build, not 3 PRs later at preflight. Adds ~30s/goal.
-- `requires_time_travel: true` recognition — skip fixture requirement, mark DEFERRED in matrix with `blocked_since_phase`
-
-### PR-C: ENV-CONTRACT.md `data_invariants` + preflight verifier (D5, D7)
-- Schema for `data_invariants` with `consumers[]` block + `consume_semantics` per consumer
-- `verify-data-invariants.py`:
-  - Reads `data_invariants` from ENV-CONTRACT.md
-  - Counts destructive consumers per invariant from matrix
-  - Queries current state, runs owning recipe N times to fill gap
-  - Stores per-goal entries in `.fixture-cache.json` (atomic write or per-run file)
-  - Hooks into `phase2c_pre_dispatch_gates` step
-- Inheritance cycle detection (DFS visited-set) + diamond resolution
-- Recovery paths in `recovery_paths.py` extended with `validator:data-invariants` entries
-
-### PR-D: `/vg:review` scanner integration (D5, D7 consumer side)
-**Split per Codex review — scanner skill changes are non-trivial:**
-- **PR-D.1:** Cache file contract + prompt injection plumbing (orchestrator side)
-- **PR-D.2:** Haiku scanner skill changes — read `.fixture-cache.json`, inject `EXPECTED_ROW_ID` env var into scanner prompt
-- Matrix-staleness validator gets `requires_time_travel` filter
-- Recovery paths extended with fixture-failure entries
-
-### PR-E: `/vg:test` codegen integration (D6)
-- Playwright codegen emits `await runFixture(request, page, 'G-XX', { semantics: 'isolated' })`
-- `@vgflow/fixture-runtime` TS helper (~30 LOC + auth context sync)
-- Schema-version compatibility check at runtime — hard fail on major mismatch
-- Validator: `verify-codegen-fixture-binding.py`
-
-### PR-Z: Backend staleness validator (Codex review — addresses backend goals exempt from D2 scope)
-**Parallel to wave-3.2.1 surface filter. Currently backend goals "trusted" — Codex flagged need parallel validator.**
-- `verify-backend-mutation-evidence.py` — for goals with `surface: api|data|integration|time-driven`
-- Asserts: route handler hit (grep), mutation request observed (server log), 2xx/expected-error status, state changed (DB query)
-- Closes the gap where backend mutations claimed READY without verification
-
-### PR-F (followup, after D1-E ship): `/vg:fixture-prune` (D8)
-- Registry-first + reference-pattern + time-window fallback (3-layer)
-- `vg.config.fixtures.entity_types[]` per-entity-type strategy mapping
-- Dry-run mode mandatory first run
-- Scoped role `vgflow-fixture-cleaner`
-
-### PR-G (parallel design RFC, immediate per Codex): time-travel infrastructure (D4)
-**Open as RFC alongside this one, design-only.** Both reviewers flagged 8% won't stay constant.
-- Backend test-only header contract (`X-Sandbox-Time-Advance`)
-- Sandbox-only env detection enforcement
-- Recipe extension: `kind: time_advance` step type
-- Implementation deferred until first non-Phase-3.2 phase blocks
-
-### PR-Y (separate, recovery-paths-as-code per Codex): recovery command test coverage
-**Codex flagged: recovery commands rot into cargo-cult without tests.**
-- Each entry in `recovery_paths.py` gets a fixture asserting the command actually changes the violation state, OR explicitly marks itself manual-only
-- Runs as part of CI
-
-**Sequencing rationale (revised):**
-- PR-pre-A first — closes live PR #79 hole + ships schemas without runtime, so reviewers see contract intent
-- PR-A is the foundation — runner standalone with mock consumer + Dockerfile + sandbox safety
-- PR-B adds upstream producer (build writes YAML, smoke-executes immediately)
-- PR-C adds downstream consumer (preflight reads YAML, creates per-consumer entities)
-- PR-D wires preflight into review scanner spawn (split D.1 + D.2)
-- PR-E extends to test layer with semantics field
-- PR-Z parallel to PR-D (backend validator)
-- PR-F + PR-G + PR-Y are independent follow-ups
-
-**Revised estimate (Claude review caught optimism):**
-- PR-pre-A: 3-5 days (schemas + provenance hotfix + tests)
-- PR-A: 1.5-2 weeks (full runner + auth + sandbox safety + Docker + tests + mock consumer)
-- PR-B: 1 week (executor sub-step + smoke-execute gate)
-- PR-C: 1 week (preflight verifier + cache file + recovery paths)
-- PR-D.1 + D.2: 1.5 weeks (scanner skill changes are architecture-invasive)
-- PR-E: 1 week (codegen + TS helper + validator)
-- PR-Z: 5-7 days (parallel to PR-D)
-
-**Total: 5-7 weeks for D1-D10 implementation.** PR-F + PR-G + PR-Y open-ended follow-ups.
-
-Honest revision from RFC v3's "2-3 weeks" — that estimate ignored scanner skill modification + sandbox safety + provenance hotfix scope. Claude's "5-7 weeks" projection accepted as realistic.
+- ❌ Build YAML runner from scratch → use Python orchestrator + libs
+- ❌ Karate / Schemathesis / Zerocode external runtime → over-engineered
+- ❌ Docker container as primary → native install simpler
+- ❌ MCP wrapper for fixture services → direct subprocess sufficient
+- ❌ Browser Use / Stagehand / Skyvern as Haiku replacement → pipeline integration deep
+- ❌ Build-time fixture smoke-execute → user vetoed (project may not have sandbox)
+- ❌ Inline fixture cleanup transactional rollback → external /vg:fixture-prune
+- ❌ AskUserQuestion 3-options menu → single advisory + override flag
+- ❌ Test Data Spec separate artifact → MERGE into TEST-GOALS required_data
+- ❌ Smoke / Sanity stage → existing --mode=full|delta|regression sufficient
 
 ---
 
-## Appendix: 6 options surveyed (rejected)
+## End of RFC v9
 
-For context — preserved from initial RFC.
+This is the final consolidated plan. Implementation starts with PR-pre-A (foundation bundle).
 
-### Option A: Data factories baked into seed.ts
-**Rejected** — project-specific, can't ship in vgflow framework.
+Cross-AI iterations: v3 (initial) → v4 (Codex+Claude HIGH findings) → v7 (Codex effort=high) → v8 (tester pro lens) → v9 (Diagnostic universal + content depth + single-advisory).
 
-### Option B: Per-goal `**Required data:**` recipes in TEST-GOALS.md
-**Adopted as primary** (with build-time authoring per Decision 1).
-
-### Option C: Persona-based data wallets
-**Rejected for v1** — premature abstraction. Revisit when 10+ phases share setup patterns.
-
-### Option D: Just-in-time scanner self-help
-**Rejected** — non-deterministic. Scanner inventing API calls = correctness risk.
-
-### Option E: Time-travel + fake-clock test mode
-**Deferred** — orthogonal to recipes. Separate RFC when first goal genuinely blocks (Q4).
-
-### Option F: ENV-CONTRACT.md `data_invariants` + fixture library
-**Adopted as preflight gate wrapper** around B.
+Total decisions: D1-D28 + 4 strategic.
+Total enforcement layers: 19 + D27 5 sub-mechanisms.
+Total estimate: 10-13 weeks.

--- a/docs/discussions/test-data-prerequisites.md
+++ b/docs/discussions/test-data-prerequisites.md
@@ -1,0 +1,232 @@
+# Discussion: Test-data prerequisites for review/test workflow
+
+**Status:** RFC — discussion only, no code yet
+**Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2.x dogfood run
+**Related:** PR #79 (recovery paths + matrix-staleness), PR #74 (anti-performative-review)
+
+## The problem in one paragraph
+
+`/vg:review` and `/vg:test` need realistic application **state** to verify mutation goals. Phase 3.2 G-10 says "Admin approves tier2 topup request"; sandbox seed has 12 tier1 rows and 0 tier2 rows. Scanner navigates to `/billing/topup-queue`, sees only tier1 rows showing "Auto via webhook" placeholder, can't click an Approve button that doesn't exist for tier1, and reports `no_submit_step`. The matrix-staleness validator correctly flags SUSPECTED. But the **root cause is missing data**, not missing UI or missing code. We can re-run scanners forever without ever creating the data they need to exercise.
+
+This is the meta-bug behind ~21 of the 36 mutation goals flagged in the dogfood run: not "scanner missed it" but "nothing to scan because the trigger entity doesn't exist in seed".
+
+## Concrete failure modes observed in Phase 3.2
+
+| Goal | Needs | Sandbox has | Result |
+|---|---|---|---|
+| G-10 admin approve tier2 topup | tier2 topup row in `pending` | only tier1 rows | scanner sees no Approve button → SUSPECTED |
+| G-19 merchant cancels pending withdraw | merchant has pending withdraw | empty wallet, no withdraws | route renders empty state → SUSPECTED |
+| G-20 admin approve withdraw | admin sees withdraw queue with rows | (TypeError on the route, separate bug) | unrelated infra fail |
+| G-23 admin resets cooling period | merchant currently cooling | no cooling-period state | reset button never appears → SUSPECTED |
+| G-31 admin transfer group CRUD | existing transfer group OR new-group flow | empty list, no groups | only "create" path testable, edit/delete dead → partial submit only |
+| G-34 linked accounts CRUD | linked accounts exist | empty | edit/delete unreachable |
+| G-35 bank accounts CRUD | bank accounts exist | empty | edit/delete unreachable |
+| G-44 admin sets FX rate | rate exists for given gateway×currency | inconsistent seed | sometimes editable, sometimes not |
+| G-52 IMAP config CRUD | configs exist | only one default | partial CRUD only |
+
+Pattern: **list/queue routes are healthy when empty, but mutation goals (approve/reject/edit/delete/cancel) need the entity to exist first, in the right status, with the right tier/role/state**.
+
+## What kinds of data does a goal need?
+
+Not all "needs data" cases are equal. From the Phase 3.2 sample:
+
+1. **Trigger entity** — the row the action operates on (tier2 topup row to approve)
+2. **Lifecycle state** — entity in a specific status (cooling-period merchant, pending withdraw)
+3. **Cross-entity relationship** — entity A pointing to entity B (linked accounts → gateway, transfer between merchants in same group)
+4. **Time-driven state** — entity with timestamp older than X (7-day chargeback deadline, cooling period)
+5. **Side-effect setup** — entity created by a prior side-effect (chargeback webhook fires → wallet frozen → admin sees frozen banner)
+6. **Negative-path setup** — entity in a *forbidden* state to verify the gate (frozen recipient, suspended merchant)
+
+Each needs a different setup mechanism. A "tier2 topup row" might be a single API POST as merchant. A "7-day chargeback timeout" may need time-travel or a fake-clock test mode. A "frozen wallet" needs prior chargeback webhook + freeze logic to have run.
+
+## Six options for the discussion
+
+### Option A: Data factories baked into seed.ts
+
+**Idea:** Extend `apps/api/src/modules/auth/seed/sampleUsers.seed.ts` (and add similar for other modules) so the sandbox seed creates ONE of every interesting state combination — 1 tier1 topup row in pending, 1 tier2 in pending, 1 approved, 1 rejected, 1 flagged; 1 merchant in cooling period; 1 frozen wallet; etc.
+
+Pros:
+- Simple, runs once at deploy
+- Deterministic, scanner just reads what's there
+- Easy to debug ("why is row X like this? grep seed.ts")
+
+Cons:
+- Seed file balloons (one row per state × tier × role × edge case → hundreds of records)
+- Time-driven states still hard (a "1 hour ago" row needs the seed to backdate timestamps)
+- Cross-entity relationships fragile (delete one row → cascades break)
+- Test pollution: side-effects from other tests mutate seed; G-11 reject in this dogfood run rejected one of the 12 tier1 rows, leaving 11 — next run sees inconsistent state
+
+Verdict: works for static reference data, fails for dynamic/lifecycle states.
+
+### Option B: Per-goal `**Required data:**` field in TEST-GOALS.md
+
+**Idea:** Each mutation goal declares the data it needs as a setup recipe in TEST-GOALS.md frontmatter or body section:
+
+```markdown
+## Goal G-10: Admin approve tier2 topup request
+
+**Surface:** ui
+**Required data:**
+  - kind: api_call
+    description: Create a pending tier2 topup as merchant
+    role: merchant-owner
+    method: POST
+    endpoint: /api/v1/wallet/topup-requests
+    body: { amount: 100, currency: "USD", gateway: "sunrate", reference: "test-G-10-{run_id}" }
+    capture: { request_id: "$.id" }
+**Cleanup:**
+  - kind: api_call
+    description: Revert via admin reject (so re-runs don't accumulate)
+    role: admin
+    method: POST
+    endpoint: /api/v1/admin/topup-requests/{request_id}/reject
+    body: { reason: "test cleanup", internal_note: "G-10 cleanup" }
+```
+
+Before the Haiku scanner spawns for that goal, orchestrator runs the recipe → captures IDs → injects into Haiku prompt as `EXPECTED_ROW_ID=...`. After scanner completes, cleanup recipe runs.
+
+Pros:
+- Explicit, traceable, version-controlled with the goal
+- Goal-scoped — no global seed bloat
+- Cleanup keeps sandbox clean across runs
+- Recipes can chain (G-23 cooling period needs G-22 first)
+
+Cons:
+- One more authoring burden per goal
+- Recipes need a runtime to execute (curl harness or thin Python lib)
+- Cross-goal dependencies (graph) must be tracked
+- If recipe is wrong, you get "scanner failed" but root cause is in TEST-GOALS
+
+Verdict: most explicit; aligns with how /vg:test will eventually want recipes for codegen anyway.
+
+### Option C: Persona-based data wallets
+
+**Idea:** Define a small set of "personas" with prebuilt complete state — `merchant-cooling`, `merchant-frozen-wallet`, `admin-with-pending-tier2-queue`. Each persona is a seed package. Test goals declare which persona's state they need.
+
+```yaml
+personas:
+  admin-tier2-queue:
+    description: Admin role, sandbox has ≥1 pending tier2 topup, ≥1 approved, ≥1 rejected
+    setup: scripts/personas/admin-tier2-queue.sh
+    used_by: [G-10, G-11, G-12]
+
+  merchant-cooling:
+    description: Merchant currently in cooling period, with prior failed withdraw
+    setup: scripts/personas/merchant-cooling.sh
+    used_by: [G-22, G-23]
+```
+
+Goals reference persona by name; setup runs once per persona per session.
+
+Pros:
+- Reusable across goals
+- Mirrors real user states ("a merchant who is cooling")
+- Lower per-goal authoring burden than B
+- Can be hand-crafted realistic scenarios, not just minimum data
+
+Cons:
+- Personas overlap and conflict (admin-tier2-queue creates rows; merchant-cooling deletes them?)
+- Order matters — running personas in wrong sequence breaks state
+- Not goal-scoped — debugging "which persona broke G-10" indirect
+
+Verdict: good middle ground; closer to how QA teams actually structure test environments.
+
+### Option D: Just-in-time data generation via scanner self-help
+
+**Idea:** Haiku scanner detects "empty state I need to test" (no tier2 rows on /billing/topup-queue), spawns a sub-helper agent that creates the missing row via API as the right role, then continues. No setup recipe declared — scanner figures it out from goal text.
+
+Pros:
+- Zero setup overhead per goal
+- Scanner handles new goals without recipe maintenance
+- Works for unanticipated states
+
+Cons:
+- Scanner needs to know API endpoints — couples scanner to API contract knowledge
+- Non-deterministic: "Haiku decided to call POST /topup with these fields" — hard to reproduce failure
+- No cleanup — sandbox accumulates trash across runs
+- LLM creativity = correctness risk (scanner POSTs wrong fields → 422 → flags fake bug)
+
+Verdict: too clever; loses determinism. Reserve for prototype-only paths.
+
+### Option E: Time-travel + fake-clock test mode
+
+**Idea:** Backend exposes a "test-mode time advance" header (`X-Test-Time: 2026-05-08T00:00:00Z`) only when `NODE_ENV=sandbox` (and never in prod). Scanner sets the header to push virtual clock past 7-day deadlines, cooling periods, etc.
+
+Pros:
+- Solves the time-driven state problem (G-22, G-42, G-58) elegantly
+- No data setup overhead — just rewinds clock
+- Real production code paths exercised
+
+Cons:
+- Backend has to support fake clocks everywhere (cron jobs, scheduled tasks, retry queues)
+- Sandbox-only header risk — if it leaks to prod, time bombs
+- Doesn't help for non-time states (frozen wallet, tier2 queue)
+
+Verdict: orthogonal complement to A/B/C, not a replacement. Probably needed eventually, but separate.
+
+### Option F: ENV-CONTRACT.md declares data invariants
+
+**Idea:** Each phase declares in `ENV-CONTRACT.md` what data invariants the sandbox must maintain:
+
+```yaml
+data_invariants:
+  topup_requests:
+    - status: pending, tier: tier2, count: ">=1"
+    - status: pending, tier: tier1, count: ">=1"
+  withdraws:
+    - status: pending, role: merchant-owner, count: ">=1"
+  merchants:
+    - cooling_period_active: true, count: ">=1"
+```
+
+Before review starts, a verifier checks these invariants against the running sandbox. If any miss → emit a clear error: "Data invariant 'topup pending tier2 ≥1' not met. Run: `pnpm seed:fixture topup-tier2-pending`". A separate `pnpm seed:fixture` script library (one fixture per invariant gap) lets dev or CI fill the gap.
+
+Pros:
+- Pre-flight gate, fails fast with actionable error
+- Decouples "what data must exist" (declared) from "how to create it" (fixture script)
+- Goal authors don't write API recipes; they declare data shape
+- Fixtures composable, reusable across phases
+
+Cons:
+- Two artifacts to maintain (invariants + fixtures) instead of one
+- "Run pnpm seed:fixture X" still manual unless wired into deploy
+
+Verdict: closest to how mature QA frameworks work. Invariants are declarative; fixtures are procedural.
+
+## Recommended direction (pre-discussion strawman)
+
+**Hybrid A + F + opt-in B**, in that order of priority:
+
+1. **Baseline (A)** — extend seed.ts to cover the static reference set per phase: 1 row per status × tier combination at minimum. Solves ~50% of cases for low cost.
+
+2. **Phase-level invariants (F)** — every phase declares `data_invariants` block in ENV-CONTRACT.md. `/vg:review` pre-flight verifies them before spawning Haiku. If invariant miss → BLOCK with "run fixture X" hint, not silent SUSPECTED. This is the gate that prevents the "scanner ran but had nothing to test" failure.
+
+3. **Goal-level recipes (B) for stateful goals only** — opt-in per goal where the static seed cannot represent the state (cooling period, frozen wallet, recently-failed payment). Recipe runs as preflight to that one goal's scanner spawn, with cleanup after.
+
+Time-travel (E) deferred to a separate RFC when we hit a goal that genuinely needs it.
+
+Persona model (C) deferred — not needed yet at our scale; revisit when we have 10+ phases sharing setup.
+
+Just-in-time (D) rejected — too non-deterministic for a verification harness.
+
+## Open questions for discussion
+
+1. **Where does the fixture script library live?** `scripts/fixtures/` per project? Or in vgflow as a generic harness with project-supplied recipes?
+2. **Is "ENV-CONTRACT.md data_invariants" a new section or replaces CRUD-SURFACES.md `state_matrix`?** They overlap.
+3. **Cleanup contract:** if a goal's setup creates a row, is cleanup MUST or SHOULD? What happens when scanner crashes mid-test?
+4. **Idempotency:** if `/vg:review --retry-failed` re-runs a goal whose previous setup row still exists from last run — skip, replace, or fail?
+5. **Who writes recipes?** Goal author at `/vg:blueprint` time, or executor at `/vg:build` time? Different incentives — author knows intent, executor knows implementation.
+6. **Backend test-mode boundary:** if we go (E) time-travel later, what's the contract for sandbox-only test endpoints? `X-Sandbox-*` header pattern? Allow-list of test-only routes?
+7. **Cost concern:** option B/F adds a recipe-runtime per goal scanner spawn. For Phase 3.2's 36 mutation goals × 1 setup + 1 cleanup = 72 extra API calls per `/vg:review` run. Acceptable?
+8. **Scope creep:** does this RFC also cover `/vg:test` codegen (fixture-aware Playwright tests) or just `/vg:review` scanner runs?
+
+## What this RFC does NOT cover
+
+- Production data — never. Sandbox only.
+- Performance testing fixtures (different shape — 100K rows, not 1 row per state).
+- Visual regression baselines (separate concern).
+- Migration test data (handled by schema-verify profile).
+
+## Next step
+
+Discuss the strawman + open questions, pick a direction, then split into implementation PRs (likely 3-4 small ones across vgflow + PrintwayV3).

--- a/docs/discussions/test-data-prerequisites.md
+++ b/docs/discussions/test-data-prerequisites.md
@@ -1,6 +1,6 @@
 # RFC: Test-data prerequisites for review/test workflow
 
-**Status:** Direction chosen 2026-05-02, design questions remain
+**Status:** Direction + design decisions chosen 2026-05-02, ready to split into implementation PRs
 **Surfaced by:** PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2.x dogfood run
 **Related:** PR #79 (recovery paths + matrix-staleness), PR #74 (anti-performative-review)
 
@@ -94,107 +94,160 @@ This bars option A (extend seed.ts) as the primary mechanism — that's Printway
 
 ---
 
-## What still needs design (open questions)
+## Design decisions (Q1-Q8 resolved 2026-05-02)
 
-These are genuine unknowns the chosen direction surfaces. Each blocks some part of implementation.
+The 8 questions surfaced after Decisions 1-4 are now answered. Each decision below has rationale + immediate implication for implementation.
 
-### Q1 — Recipe schema specifics
+### D1 (was Q3) — Runtime architecture: vgflow ships generic runner, pluggable auth via YAML
+
+Vgflow ships `scripts/run-fixture.py` (or equivalent — language TBD at PR-A time but Python likely) that reads recipe YAML, performs HTTP calls, captures responses. Project supplies only YAML content; no project-side runner code.
+
+Auth pluggability is **YAML-declarative**, not Python entrypoints. Project declares in `vg.config.environments.{env}.auth`:
 
 ```yaml
-# Strawman shape, not final
+auth:
+  kind: cookie       # or: bearer, session, api-key
+  login_endpoint: /api/v1/auth/login
+  body_template:
+    email: "{role.email}"
+    password: "{role.password}"
+  capture:
+    cookie: connect.sid          # for kind=cookie
+    # or token_path: $.token     # for kind=bearer
+```
+
+Runner supports 4 auth kinds covering ~90% of stacks (cookie session, bearer JWT, header api-key, OAuth client-credentials). Project with exotic auth → upstream contribution to runner.
+
+**Rationale:** matches "public framework" (Decision 4). Python entrypoints would couple recipes to vgflow's language choice. Sub-shell would be portable but ugly to debug.
+
+**Rejected alternatives:**
+- (b) project-side runner — duplicates HTTP+auth+capture code per project; defeats framework adoption
+- Python entrypoints — coupling vgflow language to recipe consumers
+
+### D2 (was Q1) — Recipe schema
+
+```yaml
 goal: G-10
-description: Admin approves tier2 topup → row must exist in pending tier2 state
-setup:
-  - kind: api_call
-    role: merchant-owner
+description: Admin approves tier2 topup — row must exist in pending tier2 state
+steps:
+  - id: create_tier2_topup
+    kind: api_call
+    role: merchant-owner                 # lookup into vg.config.credentials[env]
     method: POST
-    endpoint: /api/v1/wallet/topup-requests
+    endpoint: /api/v1/wallet/topup-requests   # relative; runner resolves base from config
     body:
       amount: 100
       currency: USD
       gateway: sunrate
-      reference: "vgflow-fixture-G10-{run_id}"
+      reference: "vgflow-fixture-{run_id}-{step.id}"
     capture:
-      request_id: $.id
+      request_id: $.id                   # JSONPath syntax (RFC 9535)
 expects:
-  invariant: "topup_requests.where(status=pending, tier=tier2).count >= 1"
   capture_into:
-    EXPECTED_ROW_ID: $request_id
+    EXPECTED_ROW_ID: "{steps.create_tier2_topup.request_id}"
 ```
 
-Open: should `endpoint` be relative (vgflow resolves base URL from env) or absolute? Should `role` be a string lookup into `vg.config.credentials[env]` (current pattern) or a typed enum? How are auth tokens captured/refreshed inside multi-step recipes? Does `capture` use JSONPath, jq syntax, or YAML-native? Each impacts portability.
+**Decisions baked in:**
+- `endpoint`: **relative**, runner resolves `api_base` from `vg.config.environments.{env}.api_base`. Portable across local/sandbox/staging.
+- `role`: **string lookup** into existing `vg.config.credentials[env]` array. No new typed enum — reuses established pattern.
+- `capture`: **JSONPath** (RFC 9535 standard). Not jq — that's a project-side tool dependency we won't ship.
+- `body` template variables: `{run_id}`, `{step.id}`, `{steps.<step_id>.<capture_name>}`, `{role.email}` — minimal interpolation, no full templating engine.
+- Auth tokens: **handled by runtime, not in recipe**. Recipe declares `role: merchant-owner`; runner logs in once per role per session, attaches creds to subsequent calls.
+- Multi-step: `steps: [...]` array, each step has `id`, later steps reference prior captures via `{steps.<id>.<name>}`.
 
-### Q2 — Multi-step recipe support
+**Rejected alternatives:** absolute URLs (breaks portability), typed role enums (premature abstraction), jq syntax (tool dep), in-recipe secrets (security smell).
 
-Some goals need 2+ steps to set up state — G-23 admin reset cooling period needs (a) merchant exists, (b) merchant performed N failed withdraws, (c) cooling-period flag was raised. Three sequential API calls, each capturing IDs the next uses. Recipe schema must support `steps: [...]` not just one `setup:`.
+### D3 (was Q2) — Multi-step failure: no rollback, log orphans
 
-But chained recipes have failure modes — if step 2 fails, what happens to step 1's created entity? With "no cleanup" rule (Decision 2), nothing — leave the orphan. Is that acceptable, or do we need at least best-effort cleanup on partial recipe failure?
+Step N fails → recipe overall fails → goal marked BLOCKED in matrix with reason `fixture step N/M failed: <error>`. Steps 1..N-1 already executed leave their entities behind (per Decision 2 "no cleanup").
 
-### Q3 — Recipe runtime — vgflow-side or project-side?
+One concession to debugging: orphan IDs captured before failure get logged to `runs/G-{XX}.fixture-orphans.json`. `/vg:fixture-prune` (D8) reads this when cleaning up.
 
-Two architectures:
+**Rationale:** transactional rollback would require compensating-call infrastructure per entity type — engineering cost too high for sandbox-disposable model. Logging orphans is ~10 lines, gives prune the data it needs.
 
-**(a) vgflow ships a generic recipe runner** (`scripts/run-fixture.py`) that reads YAML, makes HTTP calls, captures IDs. Project provides only the YAML content. Most portable — projects don't write code.
+### D4 (was Q4) — Time-driven goals deferred to separate RFC
 
-**(b) vgflow ships only the schema; projects provide their own runner** in their `scripts/fixtures/` dir. Projects can use whatever language/HTTP lib fits their stack.
+Goals requiring backdated timestamps or fast-forward (cooling period, 7-day chargeback deadline, BullMQ retry-attempt-N) are NOT solved by recipes in v1. They need backend cooperation (test-only headers, sandbox-only env detection) — a separate multi-week design.
 
-Option (a) means vgflow has to handle every project's auth pattern (cookie? JWT header? SSO? OAuth? mTLS?). Option (b) duplicates runner code across projects but keeps vgflow language-agnostic.
+**For now:** affected goals declare `requires_time_travel: true` in TEST-GOALS frontmatter. Surface filter in `/vg:review` classifies them as **DEFERRED** (not SUSPECTED, not BLOCKED) with reason "needs time-travel infra (separate RFC)". Matrix verdict treats DEFERRED as a valid endpoint per existing v1.14.0+ scope-tag model.
 
-Probably (a) with a pluggable auth strategy. But pluggable how — Python entrypoints? Sub-shell scripts? YAML-declarative auth blocks?
+**Affected from Phase 3.2 dogfood:** G-22 (withdraw cooling period), G-42 (chargeback 7d auto-suspend), G-58 (BullMQ retry + DLQ). 3 of 36, ~8%.
 
-### Q4 — Time-driven state (option E re-entry)
+**Follow-up:** open `RFC: time-travel test infrastructure` once first non-Phase-3.2 phase blocks on this class.
 
-Decision rejected E (time-travel) for v1, but Phase 3.2 has goals like G-22 (cooling period blocks new withdraw — needs merchant with `last_failed_withdraw_at < 1h ago`), G-42 (7-day chargeback deadline), G-58 (BullMQ retry — needs job at retry attempt N).
-
-These cannot be solved by API calls alone. Either:
-- Backend exposes a `X-Sandbox-Time-Advance: 8d` header that fast-forwards
-- Recipe creates entity with backdated timestamp directly via raw DB write (bypasses domain logic)
-- Defer those goals — mark them "needs time-travel infrastructure", separate RFC, accept SUSPECTED for now
-
-Which path? If we defer, ~5 of 36 dogfood goals stay SUSPECTED indefinitely.
-
-### Q5 — `data_invariants` schema in ENV-CONTRACT.md
-
-Decision 3 says invariants live there. But the schema isn't designed yet. Strawman:
+### D5 (was Q5) — `data_invariants` schema with explicit owner
 
 ```yaml
+# In ENV-CONTRACT.md
 data_invariants:
-  - resource: topup_requests
-    where: { status: pending, tier: tier2 }
+  - id: tier2_topup_pending
+    resource: topup_requests
+    where:
+      status: pending
+      tier: tier2
     count: ">=1"
-    setup_recipe: G-10  # which goal's recipe creates this
+    setup_recipe: G-10                   # 1:1 case — single goal owns
+
+  - id: linked_account_exists
+    resource: linked_accounts
+    where: { status: active }
+    count: ">=1"
+    setup_recipe: [G-34]                 # list form — same syntax as multi-owner
+    # When multiple goals share: setup_recipe: [G-34, G-36]
+    # First entry = owner, rest declare `inherits: G-34` in their own FIXTURES/{G-XX}.yaml
 ```
 
-Multiple goals may share an invariant (G-10 and G-12 both need tier2 pending). Whose recipe is "owner"? First in alphabetical order? First declared in TEST-GOALS? Manual `owner: G-10` field?
+**Decisions baked in:**
+- Owner is **explicit**, not auto-derived. First entry in `setup_recipe` list owns the recipe; others reference via `inherits` field in their own fixture YAML.
+- `where` is conjunction-only (AND semantics across keys). Disjunction (OR) → multiple invariant entries. Keeps query simple.
+- `count` accepts `>=N`, `==N`, `>N` (string syntax — runner parses).
 
-### Q6 — `/vg:test` codegen consumption format
+**Rationale:** auto-derived ownership (alphabetical, declaration order, etc.) creates surprise when goals are reordered. Explicit field = grep-able, refactor-safe.
 
-Recipe is YAML. Playwright spec is TypeScript. Two paths:
+### D6 (was Q6) — Codegen emits `runFixture()` runtime call (option b)
 
-**(a) Codegen transpiles YAML → TS at codegen time** — every recipe becomes inline TS in the `.spec.ts` file. Spec is self-contained.
+`/vg:test` Playwright codegen emits:
 
-**(b) Codegen emits import + call** — `await runFixture('G-10')` in the spec, the runtime imports a TS helper that reads YAML at test-run time. Spec depends on runtime + YAML files at runtime.
+```typescript
+test.beforeEach(async ({ request }) => {
+  await runFixture(request, 'G-10');     // resolves to FIXTURES/G-10.yaml at test-run time
+});
+```
 
-Option (a) is simpler for users running the spec standalone. Option (b) is DRY — change YAML once, both review and test see new behavior. Probably (b) but adds runtime dependency.
+`runFixture` is a TS helper (~30 LOC) shipped with vgflow as `@vgflow/fixture-runtime` (or vendor-copied — packaging TBD at PR-E time). Reads YAML, makes HTTP calls via Playwright's `request` fixture, returns capture map.
 
-### Q7 — Preflight verifier architecture
+**Rationale:** option (a) transpile-to-inline-TS means changing YAML doesn't update emitted specs until codegen re-runs — drift waiting to happen. Option (b) keeps YAML as single source of truth; tests pick up changes on next run automatically.
 
-Phase 2c-pre already runs `verify-env-contract.py` (preflight checks for app reachable + login works). The new `data_invariants` check fits naturally there as a third check. But:
+**Trade-off accepted:** specs depend on a runtime helper + YAML files. For projects checking specs into a vendor folder, the helper vendors with them — minimal friction.
 
-- Current verifier is "smoke a thing, fail or pass" — invariant check is "query state, run recipe if missing, re-query, fail if still missing". Different shape.
-- If invariant fails AND its setup recipe also fails, what's the user-facing error? "Fixture for G-10 failed — see runs/G-10.fixture-error.json"?
-- Preflight runs once before all scanners. Should each scanner also run its own goal's recipe just-before-spawn (in case prior scanners' actions invalidated the invariant — e.g., G-11 reject removed the row G-10 needs)?
+### D7 (was Q7) — Preflight runs once, scanner reads cache
 
-### Q8 — `/vg:fixture-prune` cleanup command spec
+Phase 2c-pre adds `verify-data-invariants` step:
+1. Walk all `data_invariants` declared in ENV-CONTRACT.md
+2. Query sandbox state via API for each (read-only).
+3. For each invariant violated: lookup `setup_recipe` (the owning goal), run that goal's `FIXTURES/{G-XX}.yaml`, capture IDs into `${PHASE_DIR}/.fixture-cache.json`.
+4. Re-query each violated invariant. Still violated → BLOCK with actionable error referencing recipe path.
 
-Decision 2 puts cleanup in a separate command. Spec needed:
+Each Haiku scanner reads `${PHASE_DIR}/.fixture-cache.json` for its goal's `EXPECTED_ROW_ID` and other captures. Injects into prompt as env vars.
 
-- What does prune delete? Only entities tagged with `vgflow-fixture-{run_id}` reference? Anything older than N days? Anything matching naming convention?
-- When does user run it? Manual after each `/vg:accept`? Scheduled? Tied to sandbox-reset?
-- How does it know which entities are fixture-created vs real test data the user wants to keep?
-- Auth: which role runs the prune? Admin with hard-delete? Or a dedicated `fixture-cleanup` role to limit blast radius?
+**No re-check before each scanner spawn.** If prior scanner's mutation invalidated a later goal's invariant (e.g., G-11 rejects the only tier2 row that G-10 needed), G-10's scanner fails with clear error → matrix BLOCKED → next `/vg:review --retry-failed` re-runs preflight which re-creates the missing entity.
 
-This is its own mini-RFC. For now, accept that it's TBD.
+**Rationale:** N scanners × M invariants × API roundtrip = excessive cost for marginal correctness. Once-per-run preflight + retry-failed loop converges in 1-2 iterations for hostile cases.
+
+**Order matters:** the preflight check is a first-class verifier, not a soft-warn — invariant gap = BLOCK. This is what prevents the "scanner ran but had nothing to test" failure that started this RFC.
+
+### D8 (was Q8) — `/vg:fixture-prune` spec (own mini-RFC, contracts only)
+
+Full spec deferred to its own RFC, but commits to these contracts:
+
+- **Tag-based delete only.** Every fixture-created entity carries `vgflow_fixture_run_id` field (or analogous metadata per entity type). Prune matches by tag pattern, never deletes untagged entities.
+- **Manual trigger for v1** — user runs `/vg:fixture-prune` on their cadence. No cron. Default age threshold: 7 days (configurable).
+- **Scoped role** — dedicated `vgflow-fixture-cleaner` credential with hard-delete privilege scoped to fixture-tagged entities only. NOT admin role — limits blast radius if cleaner script bugs out.
+- **Includes orphan list** — reads `runs/G-{XX}.fixture-orphans.json` (from D3) to clean partial-recipe-failure leftovers.
+
+These contracts unblock D2, D3, D5 — they don't have to predict prune behavior.
+
+**Follow-up:** `RFC: vg:fixture-prune cleanup command` after D1-D7 ship.
 
 ---
 
@@ -209,19 +262,60 @@ This is its own mini-RFC. For now, accept that it's TBD.
 
 ---
 
-## Implementation plan (after questions resolved)
+## Implementation plan
 
-Once Q1-Q8 are answered, split into PRs:
+D1-D8 resolved. Split into PRs in dependency order:
 
-1. **PR-A: Recipe schema + JSON-Schema validator** — write the canonical YAML schema, ship as `schemas/fixture-recipe.schema.yaml`, add validator script. No runtime yet.
-2. **PR-B: `/vg:build` fixture-write step** — executor writes `FIXTURES/{G-XX}.yaml` for every goal with `mutation_evidence`. New wave-verify validator: build incomplete if mutation goal lacks fixture.
-3. **PR-C: ENV-CONTRACT.md `data_invariants` block + preflight verifier** — declarative invariant schema, runner that reads recipes + queries state + reports gaps.
-4. **PR-D: `/vg:review` scanner preflight integration** — orchestrator runs invariant check, runs missing recipes, captures IDs, injects into Haiku prompt.
-5. **PR-E: `/vg:test` codegen integration** — Playwright spec emits `runFixture(G-XX)` calls in `beforeEach`, runtime helper reads YAML.
-6. **PR-F (separate)** — `/vg:fixture-prune` cleanup command (Q8).
-7. **PR-G (separate, future)** — time-travel test-mode infrastructure (Q4).
+1. **PR-A: Recipe schema + auth-pluggable runner skeleton** (D1, D2, D3)
+   - `schemas/fixture-recipe.schema.yaml` (JSON-Schema for validation)
+   - `scripts/run-fixture.py` skeleton — reads YAML, walks `steps[]`, captures via JSONPath, no-op when API base unreachable
+   - 4 auth-kind handlers: cookie, bearer, api-key, oauth-client-creds
+   - Unit tests on schema validation + JSONPath capture + multi-step variable resolution
+   - Orphan logger writes `runs/G-{XX}.fixture-orphans.json` on partial failure
+   - **No vgflow consumer yet** — runner runs standalone via `python3 run-fixture.py FIXTURES/G-10.yaml`. Validates the engine before wiring anything.
 
-Estimated 5-7 small PRs over 2-3 weeks once Q1-Q8 land.
+2. **PR-B: `/vg:build` fixture-write step** (D2 authoring side)
+   - New executor sub-step: after implementing a goal with `mutation_evidence`, write `FIXTURES/{G-XX}.yaml`
+   - New wave-verify validator: `verify-build-fixtures-present.py` — build wave not done if mutation goal lacks fixture YAML matching schema
+   - `requires_time_travel: true` recognition — skip fixture requirement, mark goal DEFERRED in matrix instead (D4)
+   - Build can no-op gracefully on phases with no mutation goals (backward compat)
+
+3. **PR-C: ENV-CONTRACT.md `data_invariants` + preflight verifier** (D5, D7)
+   - Schema for `data_invariants` block in ENV-CONTRACT.md
+   - `verify-data-invariants.py` — queries sandbox per invariant, runs `setup_recipe` if violated, re-queries, BLOCKs if still violated
+   - Hooks into `phase2c_pre_dispatch_gates` step in `/vg:review`
+   - Writes `${PHASE_DIR}/.fixture-cache.json` for downstream scanners
+
+4. **PR-D: `/vg:review` scanner preflight integration**
+   - Haiku scanner prompt extended: reads `.fixture-cache.json`, injects `EXPECTED_ROW_ID` etc. as env vars for scanner agent
+   - Matrix-staleness validator gets new `requires_time_travel` filter — those goals never flagged SUSPECTED, classified DEFERRED instead
+   - Recovery paths in `recovery_paths.py` extended with `validator:data-invariants` entries
+
+5. **PR-E: `/vg:test` codegen integration** (D6)
+   - Playwright codegen emits `await runFixture(request, 'G-XX')` in generated specs
+   - `@vgflow/fixture-runtime` package (or vendor copy) — TS helper that reads YAML at test-run time
+   - Validator: `verify-codegen-fixture-binding.py` — every codegen test for a mutation goal must include `runFixture()` call
+
+6. **PR-F (separate, after D1-E land)** — `RFC + impl: /vg:fixture-prune` cleanup command (D8)
+   - Tag-based scan + delete with `vgflow-fixture-cleaner` role
+   - Reads orphan logs from PR-A
+   - User-triggered, default 7-day age threshold
+
+7. **PR-G (separate, future)** — `RFC: time-travel test infrastructure` (D4)
+   - Backend `X-Sandbox-Time-*` headers contract
+   - Sandbox-only env detection
+   - Recipe extension: `time_advance:` step kind
+   - Lifts ~8% of dogfood goals from DEFERRED to testable
+
+**Sequencing rationale:**
+- PR-A is the foundation — runner works standalone, can be tested without other components
+- PR-B adds the upstream producer (build writes YAML)
+- PR-C adds the downstream consumer (preflight reads YAML)
+- PR-D wires preflight into review scanner spawn
+- PR-E extends to test layer
+- PR-F + PR-G are independent follow-ups
+
+**Estimate:** PR-A through PR-E in 2-3 weeks if no surprises. PR-F + PR-G open-ended.
 
 ---
 


### PR DESCRIPTION
## Why this PR exists

PrintwayV3 Phase 3.2 dogfood (2026-05-01) on wave-3.2 matrix-staleness validator surfaced a meta-bug that no amount of validator + scanner improvement can fix:

> /vg:review needs realistic application **state** to verify mutation goals. Phase 3.2 G-10 says "Admin approves tier2 topup request"; sandbox seed has 12 tier1 rows and 0 tier2 rows. Scanner navigates → sees nothing to approve → reports `no_submit_step`. The matrix-staleness validator correctly flags SUSPECTED. But the **root cause is missing data**, not missing UI or missing code.

21 of 36 mutation goals flagged in the dogfood had this shape: not "scanner missed it" but "nothing to scan because the trigger entity doesn't exist".

## What's in the PR

A single discussion document — `docs/discussions/test-data-prerequisites.md` — that:

- Lists 9 concrete failure modes from Phase 3.2 (G-10, G-19, G-20, G-23, G-31, G-34, G-35, G-44, G-52)
- Categorizes 6 kinds of state a goal might need (trigger entity, lifecycle state, cross-entity, time-driven, side-effect, negative-path)
- Surveys 6 design options (A: extend seed.ts, B: per-goal recipes, C: personas, D: just-in-time, E: time-travel, F: declarative invariants + fixtures)
- Pre-commits to a strawman: **hybrid A + F + opt-in B**
- Lists 8 open questions to drive discussion

## What's NOT in the PR

- No code changes. No CONTEXT.md or schema mutations. No new fields in TEST-GOALS.md or ENV-CONTRACT.md.
- This is a thinking artifact. Once we pick a direction, implementation will split into 3-4 small PRs.

## Discussion thread starts here

Read `docs/discussions/test-data-prerequisites.md`, then use this PR's review thread for back-and-forth. Particularly want pushback on:

1. Is the **strawman direction** (A + F + opt-in B) right, or should we go full B (recipes everywhere)?
2. Open question #5 — **who writes recipes**: blueprint-time author or build-time executor?
3. Open question #7 — **cost**: 72 extra API calls per /vg:review run for 36 mutation goals. Threshold concern?
4. Should this RFC be coupled with `/vg:test` codegen, or left for a follow-up RFC?

🤖 Generated with [Claude Code](https://claude.com/claude-code)