### PR TITLE
feat(rfc-v9 ALL): full implementation (PR-pre-A through PR-F + skill wiring)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install test dependencies
-        run: pip install jsonschema pyyaml pytest
+      - name: Install all dependencies (RFC v9 needs requests + jsonpath-ng)
+        run: pip install -r requirements.txt
 
       - name: Validate JSON schemas
         run: |
@@ -65,6 +65,30 @@ jobs:
           else
             echo "(no negative tests yet)"
           fi
+
+      - name: RFC v9 runtime + validator suite (full)
+        run: |
+          # Run the entire pytest tree under tests/ — covers recipe runtime,
+          # fixture cache, preflight, RCRURD gate, content depth, pattern
+          # catalog, diagnostic L2, tester pro, schema golden tests, and the
+          # standalone runner subprocess tests.
+          python -m pytest tests/ -q --tb=short
+
+      - name: Shell test suite (block-resolver harness)
+        run: |
+          for t in tests/test_block_resolver_*.sh; do
+            [ -f "$t" ] || continue
+            echo "▸ $t"
+            bash "$t"
+          done
+
+      - name: Verify request-based tests did NOT skip (regression guard)
+        run: |
+          # Catch the silent-skip regression Codex flagged: if `requests` or
+          # `jsonpath-ng` go missing from requirements, every executor/auth/
+          # api_index test would skip via importorskip and CI would still
+          # be green. This step asserts those deps are importable.
+          python -c "import requests, jsonpath_ng, jsonschema; print('all RFC v9 deps importable')"
 
       - name: Stack health (if present)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 *.bak
 # Graphify knowledge graph (regenerable)
 graphify-out/
+# vgflow-bugfix is the workflow repo, not a phase-managed project — .vg/
+# only ever appears here as test-run telemetry/artifacts.
+.vg/

--- a/catalog/edge-cases/auth-session-fixation.md
+++ b/catalog/edge-cases/auth-session-fixation.md
@@ -1,0 +1,27 @@
+---
+id: auth-session-fixation
+surface: api
+tags: [auth, security, session]
+severity: critical
+---
+
+**Pattern:** Login does not rotate session cookie. Attacker pre-plants
+an empty cookie, victim logs in, attacker reuses the now-authenticated
+cookie.
+
+**Failure mode:**
+- Attacker visits site, gets `sess_id=ATK`.
+- Lures victim to a URL that drops `sess_id=ATK` cookie (e.g., open
+  redirect, subdomain XSS, stored cookie injection via header reflection).
+- Victim logs in; backend marks `sess_id=ATK` as authenticated.
+- Attacker hits app with same cookie → full account access.
+
+**Edge cases test must cover:**
+- POST /login response MUST contain `Set-Cookie: sess_id=NEW; ...`
+  with a different value than any cookie sent in the request.
+- Logout MUST invalidate the cookie server-side (cookie list table or
+  signed token revocation).
+- Cookie attributes: `HttpOnly; Secure; SameSite=Strict|Lax`.
+- Session ID entropy ≥ 128 bits.
+
+**OWASP reference:** A07:2021 — Identification and Authentication Failures.

--- a/catalog/edge-cases/concurrent-mutation-race.md
+++ b/catalog/edge-cases/concurrent-mutation-race.md
@@ -1,0 +1,26 @@
+---
+id: concurrent-mutation-race
+surface: api
+tags: [race, concurrency, integrity]
+severity: high
+---
+
+**Pattern:** Two clients update the same resource concurrently; the
+second write overwrites the first without either party noticing.
+
+**Failure mode:**
+- Client A: GET resource (v=1, balance=100). Client B: GET (v=1, 100).
+- Client A: PUT balance=150 (forgot to apply +50 from a prior tx).
+- Client B: PUT balance=180.
+- Final balance = 180; A's intent lost ("lost-update").
+
+**Edge cases test must cover:**
+- Optimistic concurrency: send `If-Match: <etag>` on PUT; server
+  returns 412 Precondition Failed when version mismatches.
+- Test with deliberately stale ETag → must get 412.
+- Server-side row-level lock for critical mutations (DB SELECT FOR UPDATE).
+- Distributed lock (Redis SETNX, etcd, Postgres advisory lock) for
+  mutations that span multiple rows.
+- Idempotency-Key on PUT/PATCH (RFC 7240).
+
+**Reference:** Lost-update problem — Atkinson & Buneman, 1987.

--- a/catalog/edge-cases/payments-idempotency-collision.md
+++ b/catalog/edge-cases/payments-idempotency-collision.md
@@ -1,0 +1,25 @@
+---
+id: payments-idempotency-collision
+surface: api
+tags: [payments, idempotency, retry, money_like]
+severity: high
+---
+
+**Pattern:** Same `Idempotency-Key` with different body returns cached
+response, not a 4xx. Silent data corruption when caller retries with
+drift.
+
+**Failure mode:**
+- Caller A POST `{amt: 100, key: K}` → 201 receipt R.
+- Caller B POST `{amt: 200, key: K}` → 200 returns R (cached).
+- B never billed; reconciliation diverges between client and server.
+
+**Edge cases test must cover:**
+- Same key, identical body → second response = first (expected).
+- Same key, different body → MUST return 422 or 409, NOT a stale 200.
+- Same key, partial body change (e.g., metadata) → policy decision
+  must be documented and tested.
+- Key collision across users (multi-tenant) → MUST scope to
+  user/tenant; cross-tenant key reuse is a data leak risk.
+
+**RFC reference:** RFC 7240 §4.3 (Idempotency-Key header).

--- a/catalog/edge-cases/ui-double-submit.md
+++ b/catalog/edge-cases/ui-double-submit.md
@@ -1,0 +1,25 @@
+---
+id: ui-double-submit
+surface: ui
+tags: [ui, idempotency, race]
+severity: medium
+---
+
+**Pattern:** User clicks Submit twice (impatient, slow network, double-tap
+on mobile). Without front-end disable + back-end idempotency, two POSTs
+fire — money double-charged or two records created.
+
+**Failure mode:**
+- Click 1: POST /api/topup, button stays clickable while in-flight.
+- Click 2 (200ms later): second POST.
+- Server processes both → 2 receipts.
+
+**Edge cases test must cover:**
+- Submit button MUST disable on click; re-enable on response.
+- Loading spinner shown during in-flight request.
+- Server idempotency: same Idempotency-Key returns cached response
+  (see `payments-idempotency-collision`).
+- Optimistic UI: temporarily show "submitting..." with rollback on error.
+- Mobile: double-tap zoom disabled on the button to avoid 2 events.
+
+**Reference:** Cause of P3.D-12 dogfood incident (PrintwayV3 v3.2 topup).

--- a/catalog/edge-cases/upload-mime-spoof.md
+++ b/catalog/edge-cases/upload-mime-spoof.md
@@ -1,0 +1,27 @@
+---
+id: upload-mime-spoof
+surface: api
+tags: [upload, security, validation]
+severity: high
+---
+
+**Pattern:** Server trusts client-supplied `Content-Type` header on
+file upload; attacker uploads `evil.html` declared as `image/png`.
+Server stores under image dir; victim opens URL → XSS in same origin.
+
+**Failure mode:**
+- POST `/api/upload` with `Content-Type: image/png` header but body is
+  `<script>fetch('/api/me').then(...).then(send_to_attacker)</script>`.
+- Backend writes to `/uploads/123.png`.
+- Browser fetches; if MIME sniffing or `Content-Type: text/html` is
+  served back, script runs in the app's origin.
+
+**Edge cases test must cover:**
+- Magic-byte detection (libmagic / file's first 16 bytes), not header.
+- Reject upload if magic-byte mismatch with declared type.
+- Strip EXIF / metadata from images server-side (steganography).
+- Serve uploads with `Content-Disposition: attachment` OR from a
+  separate cookie-less subdomain (`*.usercontent.tld`).
+- Filename sanitization — reject path traversal (`..`, `/`).
+
+**Reference:** OWASP File Upload Cheat Sheet.

--- a/commands/vg/_shared/config-loader.md
+++ b/commands/vg/_shared/config-loader.md
@@ -165,6 +165,7 @@ declare -A CONFIG_V1_9_SECTIONS=(
   ["scope"]="Scope adversarial check (v1.9.1 R3) — adversarial_check, adversarial_model"
   ["models.review_fix_inline"]="Review fix inline model (v1.9.1 R2) — main tier for small MINOR fixes"
   ["models.review_fix_spawn"]="Review fix spawn model (v1.9.1 R2) — cheaper tier for MODERATE/large fixes"
+  ["review.provenance"]="Evidence provenance enforcement (v2.46-wave3.2.3 RFC v9 D10) — warn|block; warn during migration, block once /vg:fixture-backfill has run"
 )
 
 DRIFT_COUNT=0

--- a/commands/vg/_shared/lib/block-resolver.sh
+++ b/commands/vg/_shared/lib/block-resolver.sh
@@ -230,10 +230,25 @@ _block_resolve_l2_architect() {
   local spawn_script="${REPO_ROOT:-.}/scripts/spawn-diagnostic-l2.py"
   if [ -f "$spawn_script" ] && [ -n "$phase_dir" ] && [ -d "$phase_dir" ] && \
      [ "${VG_DIAGNOSTIC_L2_DISABLE:-0}" != "1" ]; then
+    # Codex MEDIUM fix: block_family is the validator domain (provenance,
+    # traceability, content-depth, ...), NOT the gate_id prefix. Map known
+    # gate_id stems to families; default to "uncategorized" for unknown
+    # gates (architect still gets full context via evidence_json).
+    local block_family
+    case "$gate_id" in
+      *evidence*|*provenance*|*scanner*|*replay*) block_family="provenance" ;;
+      *trace*|*orphan*|*coverage*|*matrix*) block_family="traceability" ;;
+      *content*|*depth*|*skim*|*tbd*) block_family="content-depth" ;;
+      *fixture*|*recipe*|*invariant*) block_family="fixtures" ;;
+      *security*|*auth*|*secret*) block_family="security" ;;
+      *contract*|*api-index*|*envelope*) block_family="contract" ;;
+      *artifact*|*missing*|*prereq*) block_family="artifacts" ;;
+      *) block_family="uncategorized" ;;
+    esac
     local spawn_out
     spawn_out=$("${PYTHON_BIN:-python3}" "$spawn_script" \
       --gate-id "$gate_id" \
-      --block-family "${gate_id%%-*}" \
+      --block-family "$block_family" \
       --phase-dir "$phase_dir" \
       --gate-context "$gate_context" \
       --evidence-json "$evidence_json" \

--- a/commands/vg/_shared/lib/block-resolver.sh
+++ b/commands/vg/_shared/lib/block-resolver.sh
@@ -481,6 +481,90 @@ JSON
 }
 
 # ═══════════════════════════════════════════════════════════════════════
+# block_resolve_l3_single_advisory — D26 single-advisory variant (RFC v9 PR-D3)
+# ═══════════════════════════════════════════════════════════════════════
+# When the architect's proposal has high confidence (typically ≥ 0.8) and
+# the right answer is clear, do NOT fabricate a 3-option menu. Lead with
+# the recommendation, ask Y/n. Override + abort remain reachable via [d]etails.
+#
+# RFC v9 D26 rule (user-stated): "khi có 1 đường đúng, đừng tạo menu giả định
+# người dùng có lựa chọn" — when there's a clear right path, advise straight.
+#
+# Args:
+#   $1 — gate_id (e.g., "missing-evidence")
+#   $2 — phase_dir (defaults to $PHASE_DIR)
+#   $3 — confidence (0.0 .. 1.0; default 0.8)
+#
+# Behavior:
+#   - confidence >= threshold (config.review.l3_single_advisory_min_confidence,
+#     default 0.7): emit single-advisory JSON (one primary action + [d]etails)
+#   - confidence < threshold: fall through to block_resolve_l3_present (3-option)
+#
+# Use when:
+#   - L2 architect surfaces high-confidence fix.
+#   - Recovery paths in vg:review/test/build where the alternative is just
+#     "do nothing" or "investigate manually" (not a real divergent decision).
+block_resolve_l3_single_advisory() {
+  local gate_id="$1"
+  local phase_dir="${2:-${PHASE_DIR:-.}}"
+  local confidence="${3:-0.8}"
+  local brief="${phase_dir}/.block-resolver-l2-brief.md"
+  local threshold="${CONFIG_REVIEW_L3_SINGLE_ADVISORY_MIN_CONFIDENCE:-0.7}"
+
+  if [ ! -f "$brief" ]; then
+    echo "⛔ block_resolve_l3_single_advisory: brief missing at ${brief}" >&2
+    return 1
+  fi
+
+  # Compare confidence vs threshold (POSIX bash arithmetic via awk for floats)
+  local should_advise
+  should_advise=$(awk "BEGIN { print ($confidence >= $threshold) ? 1 : 0 }")
+  if [ "$should_advise" != "1" ]; then
+    # Low confidence — fall back to 3-option menu (preserve audit trail)
+    echo "▸ confidence=$confidence < threshold=$threshold → falling back to multi-option L3" >&2
+    block_resolve_l3_present "$gate_id" "$phase_dir"
+    return $?
+  fi
+
+  local p_type=$(grep -E "^\- \*\*Type:\*\*" "$brief" | head -1 | sed 's/.*Type:\*\*\s*//')
+  local p_summary=$(grep -E "^\- \*\*Summary:\*\*" "$brief" | head -1 | sed 's/.*Summary:\*\*\s*//')
+  local p_rationale=$(grep -E "^\- \*\*Rationale:\*\*" "$brief" | head -1 | sed 's/.*Rationale:\*\*\s*//')
+
+  cat <<JSON
+{
+  "marker": "BLOCK_RESOLVER_L3_PROMPT_SINGLE_ADVISORY",
+  "gate_id": "${gate_id}",
+  "brief_path": "${brief}",
+  "confidence": ${confidence},
+  "ask_user_question_template": {
+    "question": "Áp dụng đề xuất sửa cho '${gate_id}'? ${p_summary}",
+    "header": "L3 single-advisory (confidence=${confidence})",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "Yes — apply now",
+        "description": "${p_rationale}"
+      },
+      {
+        "label": "No — show details",
+        "description": "Reveal full L2 brief at ${brief}; choose override/abort then"
+      }
+    ]
+  }
+}
+JSON
+
+  echo "▸ Orchestrator: invoke AskUserQuestion with the template above, then call block_resolve_l3_apply '${gate_id}' '<chosen_option>'" >&2
+
+  if type -t emit_telemetry_v2 >/dev/null 2>&1; then
+    emit_telemetry_v2 "block_l3_single_advisory_emitted" "${VG_CURRENT_PHASE:-unknown}" "${VG_CURRENT_STEP:-unknown}" "$gate_id" "L3_SINGLE_ADVISORY" \
+      "{\"confidence\":${confidence},\"proposal_type\":\"${p_type//\"/\\\"}\"}"
+  fi
+
+  return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════════
 # block_resolve_l3_apply — telemetry helper when user accepts proposal
 # ═══════════════════════════════════════════════════════════════════════
 block_resolve_l3_apply() {

--- a/commands/vg/_shared/lib/block-resolver.sh
+++ b/commands/vg/_shared/lib/block-resolver.sh
@@ -224,9 +224,54 @@ _block_resolve_l2_architect() {
   echo "$prompt_path" >&3 2>/dev/null || true
   echo "block-architect-prompt: $prompt_path (model=${architect_model})" >&2
 
-  # Fallback return when Task dispatch isn't hooked up in raw shell:
-  # emit a placeholder proposal so caller can decide L3/L4.
-  printf '{"type":"config-change","summary":"architect_unavailable — Task dispatch required","file_structure":"N/A","framework_choice":"N/A","decision_questions":[{"q":"Architect subagent could not be dispatched in this context. Proceed with manual direction?","recommendation":"Re-run command from Claude harness (Task tool available) or provide manual fix.","rationale":"Raw shell has no Task capability; orchestrator must substitute live Haiku call."}],"confidence":0.1}\n'
+  # RFC v9 PR-D3 stub-3 fix: try scripts/spawn-diagnostic-l2.py for live
+  # Haiku invocation. Falls back to placeholder if script unavailable, CLI
+  # not in PATH, or subagent fails.
+  local spawn_script="${REPO_ROOT:-.}/scripts/spawn-diagnostic-l2.py"
+  if [ -f "$spawn_script" ] && [ -n "$phase_dir" ] && [ -d "$phase_dir" ] && \
+     [ "${VG_DIAGNOSTIC_L2_DISABLE:-0}" != "1" ]; then
+    local spawn_out
+    spawn_out=$("${PYTHON_BIN:-python3}" "$spawn_script" \
+      --gate-id "$gate_id" \
+      --block-family "${gate_id%%-*}" \
+      --phase-dir "$phase_dir" \
+      --gate-context "$gate_context" \
+      --evidence-json "$evidence_json" \
+      ${VG_DIAGNOSTIC_L2_DRY_RUN:+--dry-run} \
+      2>/dev/null)
+    local spawn_rc=$?
+    if [ "$spawn_rc" -eq 0 ]; then
+      # Translate spawn-diagnostic-l2 output → architect proposal shape
+      ${PYTHON_BIN:-python3} -c "
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+    out = {
+        'type': 'diagnostic-l2',
+        'summary': d.get('diagnosis', '')[:200],
+        'file_structure': 'N/A — proposal stored at .l2-proposals/{}.json'.format(d.get('proposal_id','')),
+        'framework_choice': 'diagnostic_l2 subagent',
+        'decision_questions': [{
+            'q': 'Apply proposed fix?',
+            'recommendation': d.get('proposed_fix', '')[:300],
+            'rationale': f'L2 audit trail: {d.get(\"proposal_id\",\"?\")}; confidence {d.get(\"confidence\",0):.2f}',
+        }],
+        'confidence': float(d.get('confidence', 0.0)),
+        'proposal_id': d.get('proposal_id'),
+    }
+    print(json.dumps(out))
+except Exception as e:
+    print(json.dumps({'type':'parse-error','summary':str(e),'file_structure':'','framework_choice':'','decision_questions':[],'confidence':0.0}))
+" "$spawn_out"
+      return 0
+    else
+      echo "  spawn-diagnostic-l2 exited rc=${spawn_rc} — falling back to placeholder" >&2
+    fi
+  fi
+
+  # Fallback return when spawn unavailable: emit placeholder proposal so
+  # caller (orchestrator/Claude harness) can decide L3/L4 manually.
+  printf '{"type":"config-change","summary":"architect_unavailable — Task dispatch required","file_structure":"N/A","framework_choice":"N/A","decision_questions":[{"q":"Architect subagent could not be dispatched in this context. Proceed with manual direction?","recommendation":"Re-run command from Claude harness (Task tool available) or provide manual fix.","rationale":"Raw shell has no Task capability; orchestrator must substitute live Haiku call. Set VG_DIAGNOSTIC_L2_DRY_RUN=1 to test plumbing without invoking CLI."}],"confidence":0.1}\n'
 }
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/commands/vg/_shared/lib/block-resolver.sh
+++ b/commands/vg/_shared/lib/block-resolver.sh
@@ -413,12 +413,43 @@ block_resolve_l2_handoff() {
   local phase_dir="${3:-${PHASE_DIR:-.}}"
   local brief="${phase_dir}/.block-resolver-l2-brief.md"
 
-  # Extract proposal fields from JSON result
-  local p_type=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "import json,sys; d=json.loads(sys.stdin.read()); p=d.get('proposal',{}); print(p.get('type','?'))" 2>/dev/null)
-  local p_summary=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "import json,sys; d=json.loads(sys.stdin.read()); p=d.get('proposal',{}); print(p.get('summary',''))" 2>/dev/null)
-  local p_confidence=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "import json,sys; d=json.loads(sys.stdin.read()); p=d.get('proposal',{}); print(p.get('confidence',0))" 2>/dev/null)
-  local p_rationale=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "import json,sys; d=json.loads(sys.stdin.read()); p=d.get('proposal',{}); print(p.get('rationale',''))" 2>/dev/null)
-  local p_actions=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "import json,sys; d=json.loads(sys.stdin.read()); p=d.get('proposal',{}); print('\n'.join('- ' + a for a in p.get('suggested_actions',[])))" 2>/dev/null)
+  # Codex-R7 fix: previously extracted only legacy `proposal.rationale` and
+  # `proposal.suggested_actions`. The diagnostic-L2 shape (built at line ~269)
+  # puts the actionable fix under `decision_questions[0].recommendation` and
+  # `decision_questions[0].rationale`. Extract from BOTH shapes so the brief
+  # always shows the architect's recommendation to L3.
+  local extract_py='
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    p = d.get("proposal") or {}
+    out = {
+        "type": p.get("type", "?"),
+        "summary": p.get("summary", ""),
+        "confidence": p.get("confidence", 0),
+        # Legacy shape paths
+        "rationale": p.get("rationale", ""),
+        "actions": p.get("suggested_actions") or [],
+    }
+    # Diagnostic-L2 shape — decision_questions array carries fix
+    dqs = p.get("decision_questions") or []
+    if dqs and isinstance(dqs[0], dict):
+        dq0 = dqs[0]
+        if not out["rationale"]:
+            out["rationale"] = dq0.get("rationale", "")
+        rec = dq0.get("recommendation", "")
+        if rec and rec not in out["actions"]:
+            out["actions"] = [rec] + list(out["actions"])
+    print(json.dumps(out))
+except Exception:
+    print("{}")
+'
+  local extracted=$(echo "$br_result" | ${PYTHON_BIN:-python3} -c "$extract_py" 2>/dev/null)
+  local p_type=$(echo "$extracted" | ${PYTHON_BIN:-python3} -c "import json,sys; print(json.loads(sys.stdin.read()).get('type','?'))" 2>/dev/null)
+  local p_summary=$(echo "$extracted" | ${PYTHON_BIN:-python3} -c "import json,sys; print(json.loads(sys.stdin.read()).get('summary',''))" 2>/dev/null)
+  local p_confidence=$(echo "$extracted" | ${PYTHON_BIN:-python3} -c "import json,sys; print(json.loads(sys.stdin.read()).get('confidence',0))" 2>/dev/null)
+  local p_rationale=$(echo "$extracted" | ${PYTHON_BIN:-python3} -c "import json,sys; print(json.loads(sys.stdin.read()).get('rationale',''))" 2>/dev/null)
+  local p_actions=$(echo "$extracted" | ${PYTHON_BIN:-python3} -c "import json,sys; print('\n'.join('- ' + str(a) for a in json.loads(sys.stdin.read()).get('actions',[])))" 2>/dev/null)
 
   # Write brief file for orchestrator Task tool
   cat > "$brief" <<EOF

--- a/commands/vg/build.md
+++ b/commands/vg/build.md
@@ -2770,6 +2770,59 @@ except Exception:
   else
     echo "  ✓ wave-verify PASS — executor claims match subprocess reality"
   fi
+
+  # RFC v9 PR-B: fixture wave-verify — every mutation goal touched by this
+  # wave must have FIXTURES/{G-XX}.yaml. Fixture parses against
+  # fixture-recipe.v1.json. Failure → BLOCK with /vg:fixture-backfill hint.
+  if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/TEST-GOALS.md" ]; then
+    "${PYTHON_BIN:-python3}" - <<'FIX_VERIFY' || echo "  ⚠ fixture wave-verify failed (non-blocking; queue for D14 strict-mode)"
+import os, re, sys
+from pathlib import Path
+sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts"))
+phase_dir = Path(os.environ["PHASE_DIR"])
+test_goals = phase_dir / "TEST-GOALS.md"
+fixtures_dir = phase_dir / "FIXTURES"
+text = test_goals.read_text(encoding="utf-8")
+
+# Find mutation goals (have non-empty Mutation evidence)
+goals = []
+for m in re.finditer(
+    r"^##\s+Goal\s+(G-[\w.-]+):?\s*(.*?)$"
+    r"(?P<body>(?:(?!^##\s+Goal\s+).)*)",
+    text, re.MULTILINE | re.DOTALL,
+):
+    body = m.group("body") or ""
+    me = re.search(r"\*\*Mutation evidence:\*\*\s*(.+?)(?=\*\*|\n##|\Z)",
+                    body, re.DOTALL)
+    if me and me.group(1).strip():
+        goals.append(m.group(1))
+
+missing = []
+parse_errors = []
+for gid in goals:
+    yaml_path = fixtures_dir / f"{gid}.yaml"
+    if not yaml_path.exists():
+        missing.append(gid)
+        continue
+    try:
+        from runtime.recipe_loader import load_recipe
+        load_recipe(yaml_path)
+    except Exception as e:
+        parse_errors.append((gid, str(e)[:100]))
+
+if missing or parse_errors:
+    print(f"  ⚠ fixture wave-verify: {len(missing)} missing, {len(parse_errors)} parse-error")
+    for gid in missing[:5]:
+        print(f"    missing: FIXTURES/{gid}.yaml")
+    for gid, err in parse_errors[:3]:
+        print(f"    parse-error: {gid}: {err}")
+    if missing:
+        print(f"  Hint: scripts/fixture-backfill.py --phase {os.environ['PHASE_NUMBER']} --apply")
+else:
+    if goals:
+        print(f"  ✓ fixture wave-verify: {len(goals)}/{len(goals)} mutation recipes present + valid")
+FIX_VERIFY
+  fi
 fi
 ```
 

--- a/commands/vg/build.md
+++ b/commands/vg/build.md
@@ -2773,10 +2773,12 @@ except Exception:
 
   # RFC v9 PR-B: fixture wave-verify — every mutation goal touched by this
   # wave must have FIXTURES/{G-XX}.yaml. Fixture parses against
-  # fixture-recipe.v1.json. Failure → BLOCK with /vg:fixture-backfill hint.
+  # fixture-recipe.v1.json. Codex-HIGH-2 fix: BLOCKS on missing/parse-error
+  # (was non-blocking with `|| echo`). Override via --allow-missing-fixtures
+  # logs override-debt.
   if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/TEST-GOALS.md" ]; then
-    "${PYTHON_BIN:-python3}" - <<'FIX_VERIFY' || echo "  ⚠ fixture wave-verify failed (non-blocking; queue for D14 strict-mode)"
-import os, re, sys
+    FIX_VERIFY_OUT=$("${PYTHON_BIN:-python3}" - 2>&1 <<'FIX_VERIFY'
+import json, os, re, sys
 from pathlib import Path
 sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts"))
 phase_dir = Path(os.environ["PHASE_DIR"])
@@ -2784,7 +2786,6 @@ test_goals = phase_dir / "TEST-GOALS.md"
 fixtures_dir = phase_dir / "FIXTURES"
 text = test_goals.read_text(encoding="utf-8")
 
-# Find mutation goals (have non-empty Mutation evidence)
 goals = []
 for m in re.finditer(
     r"^##\s+Goal\s+(G-[\w.-]+):?\s*(.*?)$"
@@ -2808,20 +2809,52 @@ for gid in goals:
         from runtime.recipe_loader import load_recipe
         load_recipe(yaml_path)
     except Exception as e:
-        parse_errors.append((gid, str(e)[:100]))
+        parse_errors.append((gid, str(e)[:120]))
 
-if missing or parse_errors:
-    print(f"  ⚠ fixture wave-verify: {len(missing)} missing, {len(parse_errors)} parse-error")
-    for gid in missing[:5]:
-        print(f"    missing: FIXTURES/{gid}.yaml")
-    for gid, err in parse_errors[:3]:
-        print(f"    parse-error: {gid}: {err}")
-    if missing:
-        print(f"  Hint: scripts/fixture-backfill.py --phase {os.environ['PHASE_NUMBER']} --apply")
-else:
-    if goals:
-        print(f"  ✓ fixture wave-verify: {len(goals)}/{len(goals)} mutation recipes present + valid")
+print(json.dumps({
+    "total": len(goals),
+    "missing": missing,
+    "parse_errors": [{"gid": g, "err": e} for g, e in parse_errors],
+}))
 FIX_VERIFY
+)
+    FIX_TOTAL=$(echo "$FIX_VERIFY_OUT" | "${PYTHON_BIN:-python3}" -c "import json,sys; print(json.loads(sys.stdin.read()).get('total',0))" 2>/dev/null || echo 0)
+    FIX_MISSING=$(echo "$FIX_VERIFY_OUT" | "${PYTHON_BIN:-python3}" -c "import json,sys; print(len(json.loads(sys.stdin.read()).get('missing',[])))" 2>/dev/null || echo 0)
+    FIX_PARSE_ERR=$(echo "$FIX_VERIFY_OUT" | "${PYTHON_BIN:-python3}" -c "import json,sys; print(len(json.loads(sys.stdin.read()).get('parse_errors',[])))" 2>/dev/null || echo 0)
+
+    if [ "$FIX_MISSING" -gt 0 ] || [ "$FIX_PARSE_ERR" -gt 0 ]; then
+      echo "  ⛔ fixture wave-verify: ${FIX_MISSING} missing, ${FIX_PARSE_ERR} parse-error"
+      echo "$FIX_VERIFY_OUT" | "${PYTHON_BIN:-python3}" -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+for gid in d.get('missing', [])[:5]:
+    print(f'    missing: FIXTURES/{gid}.yaml')
+for e in d.get('parse_errors', [])[:3]:
+    print(f'    parse-error: {e[\"gid\"]}: {e[\"err\"]}')"
+      echo "  Fix path:"
+      echo "    1. scripts/fixture-backfill.py --phase ${PHASE_NUMBER} --apply"
+      echo "    2. Review/edit FIXTURES/{G-XX}.yaml drafts"
+      echo "    3. Re-run /vg:build ${PHASE_NUMBER}"
+      echo "    4. Override (creates debt): /vg:build ${PHASE_NUMBER} --allow-missing-fixtures"
+
+      if [[ ! "$ARGUMENTS" =~ --allow-missing-fixtures ]]; then
+        type -t emit_telemetry_v2 >/dev/null 2>&1 && emit_telemetry_v2 \
+          "build_fixture_wave_verify_blocked" "$PHASE_NUMBER" "build.wave-${N}.fixture-verify" \
+          "fixture-wave-verify" "BLOCK" \
+          "{\"missing\":${FIX_MISSING},\"parse_errors\":${FIX_PARSE_ERR}}"
+        FAILED_GATE="fixture-wave-verify"
+        echo "wave-${N}: FAILED (fixture-wave-verify, retries: ${RETRY_COUNT})" \
+          >> "${PHASE_DIR}/build-state.log"
+      else
+        type -t log_override_debt >/dev/null 2>&1 && log_override_debt \
+          "--allow-missing-fixtures" "$PHASE_NUMBER" "build.wave-${N}.fixture-verify" \
+          "missing/parse-error fixtures accepted by user" \
+          "build-wave-${N}-fixture-verify"
+        echo "  ⚠ override accepted via --allow-missing-fixtures"
+      fi
+    elif [ "$FIX_TOTAL" -gt 0 ]; then
+      echo "  ✓ fixture wave-verify: ${FIX_TOTAL}/${FIX_TOTAL} mutation recipes present + valid"
+    fi
   fi
 fi
 ```

--- a/commands/vg/build.md
+++ b/commands/vg/build.md
@@ -2845,6 +2845,13 @@ for e in d.get('parse_errors', [])[:3]:
         FAILED_GATE="fixture-wave-verify"
         echo "wave-${N}: FAILED (fixture-wave-verify, retries: ${RETRY_COUNT})" \
           >> "${PHASE_DIR}/build-state.log"
+        # Codex-HIGH-2-bis fix: hard exit immediately. The retry/exit
+        # handler at line ~2611 already ran by the time we reach here, so
+        # setting FAILED_GATE alone wouldn't trigger debugger retry. The
+        # only correct behavior is fail-fast: missing fixtures = build broken.
+        echo "⛔ Build cannot proceed — fixture wave-verify failed and no override."
+        echo "   Re-run with --allow-missing-fixtures only after explicit review."
+        exit 1
       else
         type -t log_override_debt >/dev/null 2>&1 && log_override_debt \
           "--allow-missing-fixtures" "$PHASE_NUMBER" "build.wave-${N}.fixture-verify" \

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1622,22 +1622,36 @@ scanner so we fail fast on broken sandbox state instead of burning Haiku
 tokens on a doomed scan.
 
 ```bash
-# RFC v9 preflight — best-effort, skip silently if scripts/runtime missing
+# RFC v9 preflight — Codex-HIGH-5-ter fix: outer guard checks scripts/runtime
+# only. The inner gates check their own artifacts (ENV-CONTRACT.md for
+# invariants, FIXTURES/ for RCRURD). Previously the outer guard required
+# BOTH scripts/runtime AND ENV-CONTRACT, so a phase with FIXTURES+lifecycle
+# but no ENV-CONTRACT skipped RCRURD entirely.
 PRE_OK=1
-if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ]; then
-  echo ""
-  echo "━━━ Phase 0.5 — RFC v9 preflight ━━━"
+if [ -d "${REPO_ROOT}/scripts/runtime" ]; then
+  RFC_V9_GATE_RAN=0
+  # Only echo the banner once when at least one gate has work to do
+  HAS_INVARIANTS_FILE=0
+  HAS_FIXTURES_DIR=0
+  [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ] && HAS_INVARIANTS_FILE=1
+  [ -d "${PHASE_DIR}/FIXTURES" ] && HAS_FIXTURES_DIR=1
+  if [ "$HAS_INVARIANTS_FILE" = "1" ] || [ "$HAS_FIXTURES_DIR" = "1" ]; then
+    echo ""
+    echo "━━━ Phase 0.5 — RFC v9 preflight ━━━"
 
-  # 1. Reap expired leases + orphans (PR-F)
-  if [ -f "${REPO_ROOT}/scripts/fixture-prune.py" ]; then
-    "${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/fixture-prune.py" \
-      --phase "$PHASE_NUMBER" --apply --skip-orphans 2>&1 | sed 's/^/  prune: /'
-  fi
+    # 1. Reap expired leases + orphans (PR-F) — only if FIXTURES exist
+    if [ "$HAS_FIXTURES_DIR" = "1" ] && [ -f "${REPO_ROOT}/scripts/fixture-prune.py" ]; then
+      "${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/fixture-prune.py" \
+        --phase "$PHASE_NUMBER" --apply --skip-orphans 2>&1 | sed 's/^/  prune: /'
+    fi
+
+    # Codex-HIGH-1-ter fix: delete stale snapshot at entry. Otherwise post
+    # mode at run-complete may load a snapshot from a PRIOR run.
+    rm -f "${PHASE_DIR}/.rcrurd-pre-snapshot.json" 2>/dev/null || true
+  fi  # end OR guard (banner + prune + snapshot reset)
 
   # 2. data_invariants N-consumer check (PR-C, live HTTP wiring stub-1 fix)
-  # Calls scripts/preflight-invariants.py which authenticates per credentials_map
-  # and counts entities via api_index. BLOCK exits the skill so we don't burn
-  # Haiku tokens on a doomed scan.
+  # Codex-HIGH-5-ter: guarded by ENV-CONTRACT.md only — independent of FIXTURES.
   if [ -f "${REPO_ROOT}/scripts/preflight-invariants.py" ] && \
      [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ]; then
     # Resolve base_url from config (sandbox env section)
@@ -1721,9 +1735,14 @@ for g in d.get("gaps", []):
      [ -d "${PHASE_DIR}/FIXTURES" ]; then
     PRE_BASE_RC="${PRE_BASE:-${VG_BASE_URL:-}}"
     if [ -n "$PRE_BASE_RC" ]; then
+      # Codex-HIGH-1-ter fix: capture snapshot in the SAME pre-mode call
+      # (not a follow-up). The snapshot is read by post-mode at run-complete
+      # to compute increased_by_at_least deltas against real pre-action state.
+      RCRURD_SNAP="${PHASE_DIR}/.rcrurd-pre-snapshot.json"
       RCRURD_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
         --phase "$PHASE_NUMBER" --base-url "$PRE_BASE_RC" \
-        --severity "${VG_RCRURD_SEVERITY:-block}" 2>&1)
+        --severity "${VG_RCRURD_SEVERITY:-block}" \
+        --capture-snapshot "$RCRURD_SNAP" 2>&1)
       RCRURD_RC=$?
       echo "  RCRURD pre_state: $(echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys
@@ -1771,18 +1790,22 @@ for r in d.get("results", []):
         exit 1
       fi
 
-      # Codex-HIGH-1-bis fix: persist pre_state snapshot so post mode
-      # (final gate after Phase 4) can compute increased_by_at_least
-      # deltas correctly. Without this, post mode samples pre AFTER
-      # action ran → both reads are post-action → delta=0 false-fail.
-      if [ "$RCRURD_RC" -eq 0 ]; then
-        # Re-fetch pre_state payload and stash to .rcrurd-pre-snapshot.json
-        # for post-mode reuse. Best-effort; missing snapshot just means
-        # post mode will skip increased_by_at_least assertions.
-        "${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
-          --phase "$PHASE_NUMBER" --base-url "$PRE_BASE_RC" \
-          --severity warn --capture-snapshot "${PHASE_DIR}/.rcrurd-pre-snapshot.json" \
-          >/dev/null 2>&1 || true
+      # Codex-HIGH-1-ter fix: validate snapshot was captured. If pre-mode
+      # passed assertions but snapshot file missing, post-mode delta
+      # assertions will be wrong. Block if any fixture declares an
+      # increased_by_at_least assertion (those NEED snapshot).
+      if [ "$RCRURD_RC" -eq 0 ] && [ -d "${PHASE_DIR}/FIXTURES" ]; then
+        NEEDS_SNAPSHOT=$(grep -lE 'increased_by_at_least|decreased_by_at_least' \
+          "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$NEEDS_SNAPSHOT" -gt 0 ] && [ ! -f "$RCRURD_SNAP" ]; then
+          echo "⛔ Phase 0.5 RCRURD setup error — pre-state snapshot not"
+          echo "   captured but ${NEEDS_SNAPSHOT} fixture(s) declare delta"
+          echo "   assertions (increased_by_at_least / decreased_by_at_least)."
+          echo "   Without snapshot, post-mode would compare post-action to"
+          echo "   post-action → delta=0 false-fail."
+          "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_snapshot_missing" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+          exit 1
+        fi
       fi
     else
       # Codex-HIGH-5-bis: missing base_url + FIXTURES with lifecycle = setup error
@@ -6174,6 +6197,17 @@ if [ "$HAS_POST_LIFECYCLE" -gt 0 ] && [ -z "$POST_BASE_RC" ] && \
 fi
 if [ -f "${REPO_ROOT}/scripts/rcrurd-preflight.py" ] && \
    [ -d "${PHASE_DIR}/FIXTURES" ] && [ -n "$POST_BASE_RC" ]; then
+  # Codex-HIGH-1-ter fix: snapshot must exist when delta assertions present
+  POST_NEEDS_SNAP=$(grep -lE 'increased_by_at_least|decreased_by_at_least' \
+    "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$POST_NEEDS_SNAP" -gt 0 ] && [ ! -f "${PHASE_DIR}/.rcrurd-pre-snapshot.json" ] && \
+     [ "${VG_RCRURD_POST_SEVERITY:-block}" = "block" ]; then
+    echo "⛔ RCRURD post_state — pre-snapshot missing but ${POST_NEEDS_SNAP}"
+    echo "   fixture(s) declare delta assertions. Pre-mode at Phase 0.5"
+    echo "   should have captured it. Re-run /vg:review from scratch."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_post_snapshot_missing" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
   POST_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
     --phase "$PHASE_NUMBER" --base-url "$POST_BASE_RC" \
     --mode post --severity "${VG_RCRURD_POST_SEVERITY:-block}" \

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1615,6 +1615,58 @@ fi
 </step>
 
 <step name="phase1_code_scan">
+## Phase 0.5: RFC v9 preflight (data invariants + RCRURD + cache hygiene)
+
+**RFC v9 PR-D1/D2/F integration.** Runs deterministic gates BEFORE the
+scanner so we fail fast on broken sandbox state instead of burning Haiku
+tokens on a doomed scan.
+
+```bash
+# RFC v9 preflight — best-effort, skip silently if scripts/runtime missing
+PRE_OK=1
+if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ]; then
+  echo ""
+  echo "━━━ Phase 0.5 — RFC v9 preflight ━━━"
+
+  # 1. Reap expired leases + orphans (PR-F)
+  if [ -f "${REPO_ROOT}/scripts/fixture-prune.py" ]; then
+    "${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/fixture-prune.py" \
+      --phase "$PHASE_NUMBER" --apply --skip-orphans 2>&1 | sed 's/^/  prune: /'
+  fi
+
+  # 2. data_invariants N-consumer check (PR-C)
+  # Stub count_fn returns 0 — real implementation wires recipe_executor;
+  # for now we surface gaps so user can populate FIXTURES manually.
+  PRE_INVARIANT=$("${PYTHON_BIN:-python3}" - <<'PY'
+import json, os, sys
+from pathlib import Path
+sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts"))
+try:
+    from runtime.preflight import parse_env_contract, verify_invariants
+    invs = parse_env_contract(Path(os.environ["PHASE_DIR"]) / "ENV-CONTRACT.md")
+    if invs:
+        # Stub count_fn: returns 0 until recipe_executor wiring lands
+        def count_fn(resource, where): return 0
+        gaps = verify_invariants(invs, count_fn)
+        print(json.dumps({"invariants": len(invs), "gaps": len(gaps)}))
+    else:
+        print(json.dumps({"invariants": 0, "gaps": 0}))
+except Exception as e:
+    print(json.dumps({"error": str(e)[:200]}))
+PY
+)
+  echo "  preflight invariants: $PRE_INVARIANT"
+
+  # 3. RCRURD pre_state gate (PR-D2) — informational; full wiring requires
+  # recipe_executor session + lifecycle parsing from FIXTURES/{G-XX}.yaml.
+  # For now we count how many mutation goals declare lifecycle blocks.
+  if [ -d "${PHASE_DIR}/FIXTURES" ]; then
+    LIFECYCLE_N=$(grep -lE "^lifecycle:" "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+    echo "  lifecycle declarations: ${LIFECYCLE_N} fixtures (PR-D2 wiring queued)"
+  fi
+fi
+```
+
 ## Phase 1: CODE SCAN (automated, <10 sec)
 
 **If --skip-scan, skip this phase.**

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -6001,6 +6001,43 @@ except: print('?')
   fi
 fi
 
+# v2.46-wave3.2.3 (RFC v9 D10) — evidence provenance gate. Mutation steps
+# claiming success (action + 2xx network) MUST carry structured evidence:
+# {source, artifact_hash, captured_at, schema_version, scanner_run_id |
+# layer2_proposal_id}. Closes the trust hole where executor agents could
+# fabricate evidence to flip matrix-staleness bidirectional sync.
+#
+# Migration grace: provenance.enforcement=warn (default) emits findings
+# without blocking. Set provenance.enforcement=block in vg.config.md once
+# all phases have been migrated via /vg:fixture-backfill.
+PROV_VAL=".claude/scripts/validators/verify-evidence-provenance.py"
+if [ -f "$PROV_VAL" ]; then
+  # Resolve enforcement from config — env var wins, then grep config, default warn
+  PROV_MODE="${VG_PROVENANCE_ENFORCEMENT:-}"
+  if [ -z "$PROV_MODE" ] && [ -n "${CONFIG_RAW:-}" ]; then
+    PROV_MODE=$(echo "$CONFIG_RAW" | grep -A2 '^review:' | grep -E '^\s*provenance:' -A2 | \
+                grep -E '^\s*enforcement:' | head -1 | sed 's/.*enforcement:\s*//;s/[\"'\'']//g' | tr -d ' ')
+  fi
+  [ -z "$PROV_MODE" ] && PROV_MODE="warn"
+  PROV_FLAGS="--severity ${PROV_MODE}"
+  # During migration window, allow legacy phases without provenance
+  [[ "${ARGUMENTS}" =~ --allow-legacy-provenance ]] && PROV_FLAGS="$PROV_FLAGS --allow-legacy"
+  ${PYTHON_BIN:-python3} "$PROV_VAL" --phase "${PHASE_NUMBER}" $PROV_FLAGS
+  PROV_RC=$?
+  if [ "$PROV_RC" -ne 0 ] && [ "$PROV_MODE" = "block" ]; then
+    echo "⛔ Evidence provenance gate failed — mutation steps claim success without"
+    echo "   structured provenance object (RFC v9 D10). Possible fabricated evidence."
+    echo "   Fix path:"
+    echo "     1. Re-run scanner: /vg:review ${PHASE_NUMBER} --retry-failed"
+    echo "        (Haiku scanner records evidence.source=scanner with scanner_run_id)"
+    echo "     2. For legacy phases pre-RFC-v9: --allow-legacy-provenance"
+    echo "        (marks missing-evidence steps as legacy_pre_provenance, informational)"
+    echo "     3. Set review.provenance.enforcement: warn in vg.config.md to defer enforcement"
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.evidence_provenance_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.46 anti-performative-review: ép scanner phải submit mutation goals,
 # không được Cancel modal rồi mark passed. Phase 3.2 dogfood (2026-05-01) tìm
 # 5 false-pass goals (G-31/G-34/G-35/G-44/G-52) modal opened nhưng chưa bao giờ

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1654,8 +1654,20 @@ if [ -d "${REPO_ROOT}/scripts/runtime" ]; then
   # Codex-HIGH-5-ter: guarded by ENV-CONTRACT.md only — independent of FIXTURES.
   if [ -f "${REPO_ROOT}/scripts/preflight-invariants.py" ] && \
      [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ]; then
-    # Resolve base_url from config (sandbox env section)
-    PRE_BASE=$(echo "${CONFIG_RAW:-}" | grep -A2 '^step_env:' | grep -E 'sandbox_test:|sandbox:' | head -1 | sed 's/.*: *//;s/[" ]//g')
+    # Codex-R4-HIGH-2 fix: PREVIOUSLY parsed step_env.sandbox_test from
+    # vg.config.md, but that's an ENV NAME like "local", not a URL. The
+    # actual URL lives in ENV-CONTRACT.md under `target.base_url`. Use
+    # that as canonical source; fall back to VG_BASE_URL env override.
+    PRE_BASE=$("${PYTHON_BIN:-python3}" -c "
+import re, sys
+text = open('${PHASE_DIR}/ENV-CONTRACT.md', encoding='utf-8').read()
+# Match \`target:\n  base_url: \"...\"\` block (handles single+double quotes)
+m = re.search(r'^target:\s*\n((?:[ \t].*\n)+)', text, re.MULTILINE)
+if m:
+    body = m.group(1)
+    bm = re.search(r'^\s*base_url:\s*[\"\\']?([^\"\\'\s#]+)', body, re.MULTILINE)
+    if bm: print(bm.group(1))
+" 2>/dev/null)
     [ -z "$PRE_BASE" ] && PRE_BASE="${VG_BASE_URL:-}"
     if [ -n "$PRE_BASE" ]; then
       PRE_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/preflight-invariants.py" \
@@ -6185,7 +6197,18 @@ fi
 # action actually mutated state correctly. Without this leg, RCRURD is half-
 # wired (Codex review found pre-only).
 # Re-resolve base URL from config (PRE_BASE local to Phase 0.5; not in scope).
-POST_BASE_RC=$(echo "${CONFIG_RAW:-}" | grep -A2 '^step_env:' | grep -E 'sandbox_test:|sandbox:' | head -1 | sed 's/.*: *//;s/[" ]//g')
+# Codex-R4-HIGH-2 fix: read base_url from ENV-CONTRACT.md (canonical),
+# not from vg.config.md step_env (env NAME, not URL).
+POST_BASE_RC=$("${PYTHON_BIN:-python3}" -c "
+import re
+try:
+    text = open('${PHASE_DIR}/ENV-CONTRACT.md', encoding='utf-8').read()
+    m = re.search(r'^target:\s*\n((?:[ \t].*\n)+)', text, re.MULTILINE)
+    if m:
+        bm = re.search(r'^\s*base_url:\s*[\"\\']?([^\"\\'\s#]+)', m.group(1), re.MULTILINE)
+        if bm: print(bm.group(1))
+except FileNotFoundError: pass
+" 2>/dev/null)
 [ -z "$POST_BASE_RC" ] && POST_BASE_RC="${VG_BASE_URL:-}"
 HAS_POST_LIFECYCLE=$(grep -lE '^\s*post_state:' "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
 # Codex-HIGH-5-bis fix: post_state setup error blocks even without runner exec

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1696,7 +1696,21 @@ for g in d.get("gaps", []):
         exit 1
       fi
     else
-      echo "  preflight invariants: SKIPPED (no base_url in config + no VG_BASE_URL)"
+      # Codex-HIGH-5-bis fix: missing base_url WAS silent skip — that's
+      # the original "RFC v9 silently bypassed" failure mode. If
+      # ENV-CONTRACT.md declares data_invariants, missing base_url IS a
+      # setup error → block. If no invariants declared, this is a no-op
+      # phase and skip is fine.
+      HAS_INVARIANTS=$(grep -cE '^\s*data_invariants:' "${PHASE_DIR}/ENV-CONTRACT.md" 2>/dev/null || echo 0)
+      if [ "$HAS_INVARIANTS" -gt 0 ] && [ "${VG_PREFLIGHT_SEVERITY:-block}" = "block" ]; then
+        echo "⛔ Phase 0.5 preflight setup error — ENV-CONTRACT.md declares"
+        echo "   data_invariants but no sandbox base_url found."
+        echo "   Fix path: set step_env.sandbox_test in vg.config.md OR"
+        echo "             export VG_BASE_URL=https://your-sandbox/."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.preflight_no_base_url" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      echo "  preflight invariants: SKIPPED (no base_url + no data_invariants — no-op)"
     fi
   fi
 
@@ -1756,8 +1770,32 @@ for r in d.get("results", []):
         "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_preflight_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
         exit 1
       fi
+
+      # Codex-HIGH-1-bis fix: persist pre_state snapshot so post mode
+      # (final gate after Phase 4) can compute increased_by_at_least
+      # deltas correctly. Without this, post mode samples pre AFTER
+      # action ran → both reads are post-action → delta=0 false-fail.
+      if [ "$RCRURD_RC" -eq 0 ]; then
+        # Re-fetch pre_state payload and stash to .rcrurd-pre-snapshot.json
+        # for post-mode reuse. Best-effort; missing snapshot just means
+        # post mode will skip increased_by_at_least assertions.
+        "${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
+          --phase "$PHASE_NUMBER" --base-url "$PRE_BASE_RC" \
+          --severity warn --capture-snapshot "${PHASE_DIR}/.rcrurd-pre-snapshot.json" \
+          >/dev/null 2>&1 || true
+      fi
     else
-      echo "  RCRURD pre_state: SKIPPED (no base_url)"
+      # Codex-HIGH-5-bis: missing base_url + FIXTURES with lifecycle = setup error
+      HAS_LIFECYCLE=$(grep -lE '^lifecycle:' "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+      if [ "$HAS_LIFECYCLE" -gt 0 ] && [ "${VG_RCRURD_SEVERITY:-block}" = "block" ]; then
+        echo "⛔ Phase 0.5 RCRURD setup error — FIXTURES declare ${HAS_LIFECYCLE}"
+        echo "   lifecycle blocks but no sandbox base_url found."
+        echo "   Fix path: set step_env.sandbox_test in vg.config.md OR"
+        echo "             export VG_BASE_URL=https://your-sandbox/."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_no_base_url" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      echo "  RCRURD pre_state: SKIPPED (no base_url + no lifecycle — no-op)"
     fi
   fi
 fi
@@ -6126,11 +6164,20 @@ fi
 # Re-resolve base URL from config (PRE_BASE local to Phase 0.5; not in scope).
 POST_BASE_RC=$(echo "${CONFIG_RAW:-}" | grep -A2 '^step_env:' | grep -E 'sandbox_test:|sandbox:' | head -1 | sed 's/.*: *//;s/[" ]//g')
 [ -z "$POST_BASE_RC" ] && POST_BASE_RC="${VG_BASE_URL:-}"
+HAS_POST_LIFECYCLE=$(grep -lE '^\s*post_state:' "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+# Codex-HIGH-5-bis fix: post_state setup error blocks even without runner exec
+if [ "$HAS_POST_LIFECYCLE" -gt 0 ] && [ -z "$POST_BASE_RC" ] && \
+   [ "${VG_RCRURD_POST_SEVERITY:-block}" = "block" ]; then
+  echo "⛔ RCRURD post_state setup error — FIXTURES declare post_state"
+  echo "   blocks but no sandbox base_url available at run-complete."
+  exit 1
+fi
 if [ -f "${REPO_ROOT}/scripts/rcrurd-preflight.py" ] && \
    [ -d "${PHASE_DIR}/FIXTURES" ] && [ -n "$POST_BASE_RC" ]; then
   POST_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
     --phase "$PHASE_NUMBER" --base-url "$POST_BASE_RC" \
-    --mode post --severity "${VG_RCRURD_POST_SEVERITY:-block}" 2>&1)
+    --mode post --severity "${VG_RCRURD_POST_SEVERITY:-block}" \
+    --pre-snapshot "${PHASE_DIR}/.rcrurd-pre-snapshot.json" 2>&1)
   POST_RC=$?
   echo "▸ RCRURD post_state: $(echo "$POST_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1634,35 +1634,97 @@ if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/ENV-CONTRACT.md" 
       --phase "$PHASE_NUMBER" --apply --skip-orphans 2>&1 | sed 's/^/  prune: /'
   fi
 
-  # 2. data_invariants N-consumer check (PR-C)
-  # Stub count_fn returns 0 — real implementation wires recipe_executor;
-  # for now we surface gaps so user can populate FIXTURES manually.
-  PRE_INVARIANT=$("${PYTHON_BIN:-python3}" - <<'PY'
-import json, os, sys
-from pathlib import Path
-sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts"))
+  # 2. data_invariants N-consumer check (PR-C, live HTTP wiring stub-1 fix)
+  # Calls scripts/preflight-invariants.py which authenticates per credentials_map
+  # and counts entities via api_index. BLOCK exits the skill so we don't burn
+  # Haiku tokens on a doomed scan.
+  if [ -f "${REPO_ROOT}/scripts/preflight-invariants.py" ] && \
+     [ -f "${PHASE_DIR}/ENV-CONTRACT.md" ]; then
+    # Resolve base_url from config (sandbox env section)
+    PRE_BASE=$(echo "${CONFIG_RAW:-}" | grep -A2 '^step_env:' | grep -E 'sandbox_test:|sandbox:' | head -1 | sed 's/.*: *//;s/[" ]//g')
+    [ -z "$PRE_BASE" ] && PRE_BASE="${VG_BASE_URL:-}"
+    if [ -n "$PRE_BASE" ]; then
+      PRE_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/preflight-invariants.py" \
+        --phase "$PHASE_NUMBER" --base-url "$PRE_BASE" \
+        --severity "${VG_PREFLIGHT_SEVERITY:-warn}" 2>&1)
+      PRE_RC=$?
+      echo "  preflight invariants: $(echo "$PRE_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
 try:
-    from runtime.preflight import parse_env_contract, verify_invariants
-    invs = parse_env_contract(Path(os.environ["PHASE_DIR"]) / "ENV-CONTRACT.md")
-    if invs:
-        # Stub count_fn: returns 0 until recipe_executor wiring lands
-        def count_fn(resource, where): return 0
-        gaps = verify_invariants(invs, count_fn)
-        print(json.dumps({"invariants": len(invs), "gaps": len(gaps)}))
+    d = json.loads(sys.stdin.read())
+    v = d.get("verdict","?")
+    if v == "BLOCK":
+        print(f"BLOCK ({len(d.get(\"gaps\",[]))} gap(s))")
+    elif v == "WARN":
+        print(f"WARN ({len(d.get(\"gaps\",[]))} gap(s) — set VG_PREFLIGHT_SEVERITY=block to enforce)")
+    elif v == "PASS":
+        print(f"PASS (checked {d.get(\"invariants_checked\",\"?\")} invariants)")
+    elif v == "DRY_RUN":
+        print("DRY_RUN")
     else:
-        print(json.dumps({"invariants": 0, "gaps": 0}))
-except Exception as e:
-    print(json.dumps({"error": str(e)[:200]}))
-PY
-)
-  echo "  preflight invariants: $PRE_INVARIANT"
+        print(f"ERROR: {d.get(\"error\",\"unknown\")[:200]}")
+except: print("parse-error")
+')"
+      if [ "$PRE_RC" -eq 1 ] && [ "${VG_PREFLIGHT_SEVERITY:-warn}" = "block" ]; then
+        echo "⛔ Phase 0.5 preflight invariants gate BLOCK — fix path:"
+        echo "$PRE_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+for g in d.get("gaps", []):
+    print("    " + g.get("fix_hint", ""))
+'
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.preflight_invariants_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+    else
+      echo "  preflight invariants: SKIPPED (no base_url in config + no VG_BASE_URL)"
+    fi
+  fi
 
-  # 3. RCRURD pre_state gate (PR-D2) — informational; full wiring requires
-  # recipe_executor session + lifecycle parsing from FIXTURES/{G-XX}.yaml.
-  # For now we count how many mutation goals declare lifecycle blocks.
-  if [ -d "${PHASE_DIR}/FIXTURES" ]; then
-    LIFECYCLE_N=$(grep -lE "^lifecycle:" "${PHASE_DIR}/FIXTURES"/*.yaml 2>/dev/null | wc -l | tr -d ' ')
-    echo "  lifecycle declarations: ${LIFECYCLE_N} fixtures (PR-D2 wiring queued)"
+  # 3. RCRURD pre_state gate (PR-D2, live wiring stub-2 fix)
+  # Calls scripts/rcrurd-preflight.py: walks FIXTURES/*.yaml, runs pre_state
+  # GET + assert_jsonpath for each lifecycle block. Fail-fast before scan.
+  if [ -f "${REPO_ROOT}/scripts/rcrurd-preflight.py" ] && \
+     [ -d "${PHASE_DIR}/FIXTURES" ]; then
+    PRE_BASE_RC="${PRE_BASE:-${VG_BASE_URL:-}}"
+    if [ -n "$PRE_BASE_RC" ]; then
+      RCRURD_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
+        --phase "$PHASE_NUMBER" --base-url "$PRE_BASE_RC" \
+        --severity "${VG_RCRURD_SEVERITY:-warn}" 2>&1)
+      RCRURD_RC=$?
+      echo "  RCRURD pre_state: $(echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    v = d.get("verdict","?")
+    if v == "BLOCK":
+        print(f"BLOCK ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed)")
+    elif v == "WARN":
+        print(f"WARN ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed — set VG_RCRURD_SEVERITY=block to enforce)")
+    elif v == "PASS":
+        print(f"PASS (checked {d.get(\"checked\",0)} fixtures)")
+    else:
+        print(f"ERROR: {d.get(\"error\",\"unknown\")[:200]}")
+except: print("parse-error")
+')"
+      if [ "$RCRURD_RC" -eq 1 ] && [ "${VG_RCRURD_SEVERITY:-warn}" = "block" ]; then
+        echo "⛔ Phase 0.5 RCRURD gate BLOCK — fixture pre_state assertions failed."
+        echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+for r in d.get("results", []):
+    if r.get("passed") is False:
+        print(f"    {r[\"goal\"]}:")
+        for err in r.get("errors", [])[:3]:
+            print(f"      - {err[:200]}")
+'
+        echo "  Fix path: ensure sandbox seed data matches each fixture's lifecycle.pre_state assertions"
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_preflight_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+    else
+      echo "  RCRURD pre_state: SKIPPED (no base_url)"
+    fi
   fi
 fi
 ```

--- a/commands/vg/review.md
+++ b/commands/vg/review.md
@@ -1646,7 +1646,7 @@ if [ -d "${REPO_ROOT}/scripts/runtime" ] && [ -f "${PHASE_DIR}/ENV-CONTRACT.md" 
     if [ -n "$PRE_BASE" ]; then
       PRE_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/preflight-invariants.py" \
         --phase "$PHASE_NUMBER" --base-url "$PRE_BASE" \
-        --severity "${VG_PREFLIGHT_SEVERITY:-warn}" 2>&1)
+        --severity "${VG_PREFLIGHT_SEVERITY:-block}" 2>&1)
       PRE_RC=$?
       echo "  preflight invariants: $(echo "$PRE_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys
@@ -1656,7 +1656,7 @@ try:
     if v == "BLOCK":
         print(f"BLOCK ({len(d.get(\"gaps\",[]))} gap(s))")
     elif v == "WARN":
-        print(f"WARN ({len(d.get(\"gaps\",[]))} gap(s) — set VG_PREFLIGHT_SEVERITY=block to enforce)")
+        print(f"WARN ({len(d.get(\"gaps\",[]))} gap(s) — VG_PREFLIGHT_SEVERITY=warn override active)")
     elif v == "PASS":
         print(f"PASS (checked {d.get(\"invariants_checked\",\"?\")} invariants)")
     elif v == "DRY_RUN":
@@ -1665,7 +1665,26 @@ try:
         print(f"ERROR: {d.get(\"error\",\"unknown\")[:200]}")
 except: print("parse-error")
 ')"
-      if [ "$PRE_RC" -eq 1 ] && [ "${VG_PREFLIGHT_SEVERITY:-warn}" = "block" ]; then
+      # Codex-HIGH-5 fix: setup errors (RC=2) ALWAYS block, regardless of
+      # severity gate. Missing api_index, bad creds, or missing base_url
+      # mean we cannot proceed safely — silent skip would let scan run on
+      # broken sandbox state.
+      if [ "$PRE_RC" -eq 2 ]; then
+        echo "⛔ Phase 0.5 preflight setup error — cannot proceed (RFC v9 PR-C):"
+        echo "$PRE_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(f"   {d.get(\"error\",\"unknown setup error\")[:300]}")
+except: print("   (could not parse error)")
+'
+        echo "   Fix path: ENV-CONTRACT.md must declare api_index for every"
+        echo "   resource referenced in data_invariants. Verify vg.config.md"
+        echo "   credentials_map covers all count_role values."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.preflight_setup_error" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      if [ "$PRE_RC" -eq 1 ] && [ "${VG_PREFLIGHT_SEVERITY:-block}" = "block" ]; then
         echo "⛔ Phase 0.5 preflight invariants gate BLOCK — fix path:"
         echo "$PRE_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys
@@ -1690,7 +1709,7 @@ for g in d.get("gaps", []):
     if [ -n "$PRE_BASE_RC" ]; then
       RCRURD_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
         --phase "$PHASE_NUMBER" --base-url "$PRE_BASE_RC" \
-        --severity "${VG_RCRURD_SEVERITY:-warn}" 2>&1)
+        --severity "${VG_RCRURD_SEVERITY:-block}" 2>&1)
       RCRURD_RC=$?
       echo "  RCRURD pre_state: $(echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys
@@ -1700,14 +1719,29 @@ try:
     if v == "BLOCK":
         print(f"BLOCK ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed)")
     elif v == "WARN":
-        print(f"WARN ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed — set VG_RCRURD_SEVERITY=block to enforce)")
+        print(f"WARN ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed — VG_RCRURD_SEVERITY=warn override active)")
     elif v == "PASS":
         print(f"PASS (checked {d.get(\"checked\",0)} fixtures)")
     else:
         print(f"ERROR: {d.get(\"error\",\"unknown\")[:200]}")
 except: print("parse-error")
 ')"
-      if [ "$RCRURD_RC" -eq 1 ] && [ "${VG_RCRURD_SEVERITY:-warn}" = "block" ]; then
+      # Codex-HIGH-5 fix: RCRURD setup errors (RC=2) ALWAYS block.
+      if [ "$RCRURD_RC" -eq 2 ]; then
+        echo "⛔ Phase 0.5 RCRURD setup error — cannot proceed:"
+        echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(f"   {d.get(\"error\",\"unknown setup error\")[:300]}")
+except: print("   (could not parse error)")
+'
+        echo "   Fix path: vg.config.md credentials_map must cover every role"
+        echo "   referenced in FIXTURES/{G-XX}.yaml lifecycle.pre_state."
+        "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_setup_error" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+        exit 1
+      fi
+      if [ "$RCRURD_RC" -eq 1 ] && [ "${VG_RCRURD_SEVERITY:-block}" = "block" ]; then
         echo "⛔ Phase 0.5 RCRURD gate BLOCK — fixture pre_state assertions failed."
         echo "$RCRURD_OUT" | "${PYTHON_BIN:-python3}" -c '
 import json, sys
@@ -6085,6 +6119,65 @@ if [ -f "$MATRIX_LINK_VAL" ]; then
   fi
 fi
 
+# RFC v9 PR-D2 Codex-HIGH-1 fix: post_state lifecycle gate AFTER scanner ran.
+# Pre_state checked at Phase 0.5 (pre-scanner); post_state must verify the
+# action actually mutated state correctly. Without this leg, RCRURD is half-
+# wired (Codex review found pre-only).
+# Re-resolve base URL from config (PRE_BASE local to Phase 0.5; not in scope).
+POST_BASE_RC=$(echo "${CONFIG_RAW:-}" | grep -A2 '^step_env:' | grep -E 'sandbox_test:|sandbox:' | head -1 | sed 's/.*: *//;s/[" ]//g')
+[ -z "$POST_BASE_RC" ] && POST_BASE_RC="${VG_BASE_URL:-}"
+if [ -f "${REPO_ROOT}/scripts/rcrurd-preflight.py" ] && \
+   [ -d "${PHASE_DIR}/FIXTURES" ] && [ -n "$POST_BASE_RC" ]; then
+  POST_OUT=$("${PYTHON_BIN:-python3}" "${REPO_ROOT}/scripts/rcrurd-preflight.py" \
+    --phase "$PHASE_NUMBER" --base-url "$POST_BASE_RC" \
+    --mode post --severity "${VG_RCRURD_POST_SEVERITY:-block}" 2>&1)
+  POST_RC=$?
+  echo "▸ RCRURD post_state: $(echo "$POST_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    v = d.get("verdict","?")
+    if v == "BLOCK":
+        print(f"BLOCK ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} post-state assertions failed)")
+    elif v == "WARN":
+        print(f"WARN ({d.get(\"failed\",0)}/{d.get(\"checked\",0)} failed)")
+    elif v == "PASS":
+        print(f"PASS ({d.get(\"checked\",0)} fixtures)")
+    else:
+        print(f"ERROR: {d.get(\"error\",\"unknown\")[:200]}")
+except: print("parse-error")
+')"
+  if [ "$POST_RC" -eq 2 ]; then
+    echo "⛔ RCRURD post_state setup error — cannot proceed:"
+    echo "$POST_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(f"   {d.get(\"error\",\"unknown\")[:300]}")
+except: print("   (could not parse error)")
+'
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_post_setup_error" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+  if [ "$POST_RC" -eq 1 ] && [ "${VG_RCRURD_POST_SEVERITY:-block}" = "block" ]; then
+    echo "⛔ RCRURD post_state gate BLOCK — fixture lifecycle assertions failed"
+    echo "   after the scanner action. State did not transition as expected."
+    echo "$POST_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+for r in d.get("results", []):
+    if r.get("passed") is False:
+        print(f"    {r[\"goal\"]}:")
+        for err in r.get("errors", [])[:3]:
+            print(f"      - {err[:200]}")
+'
+    echo "   Fix path: re-run scanner if action genuinely succeeded; or fix"
+    echo "   the action's expected_network/post_state assertion drift."
+    "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator emit-event "review.rcrurd_post_state_blocked" --payload "{\"phase\":\"${PHASE_NUMBER}\"}" >/dev/null 2>&1 || true
+    exit 1
+  fi
+fi
+
 # v2.46-wave3.2 matrix-staleness final gate: after matrix is BUILT (Phase 4),
 # re-run staleness validator at review-complete time. Step 0 entry pass catches
 # stale entries from PRIOR runs; this catches stale entries created by THIS run
@@ -6121,18 +6214,18 @@ fi
 # layer2_proposal_id}. Closes the trust hole where executor agents could
 # fabricate evidence to flip matrix-staleness bidirectional sync.
 #
-# Migration grace: provenance.enforcement=warn (default) emits findings
-# without blocking. Set provenance.enforcement=block in vg.config.md once
-# all phases have been migrated via /vg:fixture-backfill.
+# Codex-HIGH-4 fix: default to BLOCK (was warn). Migration grace via
+# explicit `review.provenance.enforcement: warn` in vg.config.md OR
+# --allow-legacy-provenance flag for phases pre-dating RFC v9.
 PROV_VAL=".claude/scripts/validators/verify-evidence-provenance.py"
 if [ -f "$PROV_VAL" ]; then
-  # Resolve enforcement from config — env var wins, then grep config, default warn
+  # Resolve enforcement from config — env var wins, then grep config, default block
   PROV_MODE="${VG_PROVENANCE_ENFORCEMENT:-}"
   if [ -z "$PROV_MODE" ] && [ -n "${CONFIG_RAW:-}" ]; then
     PROV_MODE=$(echo "$CONFIG_RAW" | grep -A2 '^review:' | grep -E '^\s*provenance:' -A2 | \
                 grep -E '^\s*enforcement:' | head -1 | sed 's/.*enforcement:\s*//;s/[\"'\'']//g' | tr -d ' ')
   fi
-  [ -z "$PROV_MODE" ] && PROV_MODE="warn"
+  [ -z "$PROV_MODE" ] && PROV_MODE="block"
   PROV_FLAGS="--severity ${PROV_MODE}"
   # During migration window, allow legacy phases without provenance
   [[ "${ARGUMENTS}" =~ --allow-legacy-provenance ]] && PROV_FLAGS="$PROV_FLAGS --allow-legacy"

--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -1472,6 +1472,56 @@ Display:
 
 Generate Playwright test files from VERIFIED goals. Assertions come from TEST-GOALS success criteria, navigation paths come from RUNTIME-MAP.json observations, and CRUD list/form/delete/security expectations come from CRUD-SURFACES.md when present.
 
+**RFC v9 PR-E — fixture-aware codegen (NEW, 2026-05-02):**
+
+When `FIXTURES/{G-XX}.yaml` exists for a goal, the codegen wraps the
+spec with a beforeAll hook that loads the captured store from
+`FIXTURES-CACHE.json` and injects values into the test as constants.
+This means deterministic IDs (`pending_id`, `merchant_id`, etc.) flow
+from the recipe's last successful run into the Playwright assertion
+without re-running mutations that the recipe already exercised.
+
+```bash
+# Best-effort: skip when scripts/runtime/ not present (v2.46 phases)
+if [ -d "${REPO_ROOT}/scripts/runtime" ]; then
+  CACHE_PATH="${PHASE_DIR}/FIXTURES-CACHE.json"
+  if [ -f "$CACHE_PATH" ]; then
+    "${PYTHON_BIN:-python3}" - <<'INJECT' || true
+import json, os, sys
+from pathlib import Path
+cache_path = Path(os.environ["PHASE_DIR"]) / "FIXTURES-CACHE.json"
+try:
+    data = json.loads(cache_path.read_text(encoding="utf-8"))
+    entries = data.get("entries") or {}
+    n = len([g for g in entries if entries[g].get("captured")])
+    print(f"  ✓ FIXTURES-CACHE: {n} goal(s) carry captured store for codegen injection")
+except Exception as e:
+    print(f"  ⚠ FIXTURES-CACHE parse error: {e}")
+INJECT
+  fi
+fi
+```
+
+Codegen template emits (when goal has fixture-cache entry):
+
+```ts
+// Generated from FIXTURES-CACHE.json — recipe-captured values
+const FIXTURE = {
+  pending_id: "p7e9-2026-05-02",
+  amount: 0.01,
+};
+test("G-10 approve topup", async ({ page }) => {
+  await page.goto(`/admin/topup/${FIXTURE.pending_id}`);
+  // ...
+});
+```
+
+Validators check that codegen output for a fixture-backed goal references
+`FIXTURE.*` constants, not hard-coded IDs from RUNTIME-MAP — drift between
+recipe and test is now a CI-detectable signal.
+
+
+
 **For each goal group, generate 1 .spec.ts file:**
 
 Write to `${GENERATED_TESTS_DIR}/{phase}-goal-{group}.spec.ts`

--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -1472,69 +1472,16 @@ Display:
 
 Generate Playwright test files from VERIFIED goals. Assertions come from TEST-GOALS success criteria, navigation paths come from RUNTIME-MAP.json observations, and CRUD list/form/delete/security expectations come from CRUD-SURFACES.md when present.
 
-**RFC v9 PR-E — fixture-aware codegen (Codex-HIGH-3 fix — REAL injection):**
+**RFC v9 PR-E — fixture-aware codegen (Codex-HIGH-3 fix):**
 
-After codegen writes `.spec.ts` files, invoke
-`scripts/codegen-fixture-inject.py` in sweep mode. For every goal in
-`FIXTURES-CACHE.json` with a `captured` store, the script walks the
-generated tests dir, finds matching `*-{G-XX}.spec.ts` files, and
-prepends:
+The fixture inject + validator MUST run AFTER spec generation completes,
+not before. They're invoked at the END of step 5d_codegen (search for
+"RFC v9 codegen fixture inject (post-generation)").
 
-```ts
-// VGFLOW_FIXTURE_INJECTED — DO NOT EDIT BELOW UNTIL CLOSE
-// goal: G-10, phase: 3.2
-// Source: FIXTURES-CACHE.json captured store from last review run.
-// Edit FIXTURES/G-10.yaml + re-run /vg:review to regenerate.
-const FIXTURE = {
-  pending_id: "p7e9-2026-05-02",
-  amount: 0.01,
-} as const;
-// VGFLOW_FIXTURE_INJECTED_END
-```
-
-Idempotent: re-injecting REPLACES the existing block, never stacks.
-Drift detector `verify-codegen-fixture-ref.py` BLOCKs at /vg:test exit
-if a fixture-backed goal's spec doesn't reference `FIXTURE.*`.
-
-```bash
-if [ -f "${REPO_ROOT}/scripts/codegen-fixture-inject.py" ] && \
-   [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
-  echo "▸ RFC v9 codegen fixture inject (sweep mode)"
-  INJECT_OUT=$("${PYTHON_BIN:-python3}" \
-    "${REPO_ROOT}/scripts/codegen-fixture-inject.py" \
-    --phase "$PHASE_NUMBER" \
-    --sweep "${GENERATED_TESTS_DIR:-apps/web/e2e}" 2>&1)
-  echo "$INJECT_OUT" | "${PYTHON_BIN:-python3}" -c '
-import json, sys
-try:
-    d = json.loads(sys.stdin.read())
-    inj = len(d.get("injected", []))
-    skp = len(d.get("skipped", []))
-    err = len(d.get("errors", []))
-    print(f"  ✓ injected={inj}, skipped={skp}, errors={err}")
-except: print("  ⚠ inject parse-error")'
-fi
-```
-
-Then validate at run-complete:
-
-```bash
-CGFR_VAL=".claude/scripts/validators/verify-codegen-fixture-ref.py"
-if [ -f "$CGFR_VAL" ] && [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
-  CGFR_FLAGS="--severity ${VG_CODEGEN_FIXTURE_SEVERITY:-block}"
-  [[ "${ARGUMENTS}" =~ --allow-no-fixture-ref ]] && CGFR_FLAGS="$CGFR_FLAGS --allow-no-fixture-ref"
-  "${PYTHON_BIN:-python3}" "$CGFR_VAL" --phase "$PHASE_NUMBER" \
-    --tests-dir "${GENERATED_TESTS_DIR:-apps/web/e2e}" $CGFR_FLAGS
-  CGFR_RC=$?
-  if [ "$CGFR_RC" -ne 0 ] && [ "${VG_CODEGEN_FIXTURE_SEVERITY:-block}" = "block" ]; then
-    echo "⛔ Codegen fixture-ref gate failed — fixture-backed goals' specs"
-    echo "   are missing FIXTURE.* references. Re-run codegen + inject."
-    exit 1
-  fi
-fi
-```
-
-
+The injector emits a `FIXTURE = {...}` const block AND substitutes hard-coded
+literal occurrences of captured values with `FIXTURE.<name>` references.
+Drift detector `verify-codegen-fixture-ref.py` BLOCKs at /vg:test exit if
+a fixture-backed goal's spec doesn't reference `FIXTURE.*`.
 
 **For each goal group, generate 1 .spec.ts file:**
 
@@ -2094,6 +2041,62 @@ else
   echo "  (no DISCOVERED or EXPANDED goal files — review Phase 2c / blueprint Phase 2b5d either skipped or pre-v2.34/2.36 install)"
 fi
 ```
+
+### RFC v9 codegen fixture inject (post-generation)
+
+**Codex-HIGH-3-bis fix:** This block MUST run AFTER all generation paths
+above (manual codegen, auto-emitted skeletons, interactive_controls
+delegation). Earlier placement at step start meant fresh specs never got
+injected.
+
+The injector now does TWO passes:
+1. Prepend `FIXTURE = {...}` const block (idempotent, sentinel-bracketed).
+2. Substitute literal occurrences of captured STRING values in the spec
+   body with `FIXTURE.<name>` references, when safe to do so. "Safe" =
+   exact-string match of a captured value that looks like a fixture
+   identifier (UUID-like, sentinel-prefixed, or ≥ 8 chars unique).
+
+```bash
+if [ -f "${REPO_ROOT}/scripts/codegen-fixture-inject.py" ] && \
+   [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
+  echo "▸ RFC v9 codegen fixture inject (sweep mode, post-generation)"
+  INJECT_OUT=$("${PYTHON_BIN:-python3}" \
+    "${REPO_ROOT}/scripts/codegen-fixture-inject.py" \
+    --phase "$PHASE_NUMBER" \
+    --sweep "${GENERATED_TESTS_DIR:-apps/web/e2e}" \
+    --substitute 2>&1)
+  echo "$INJECT_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    inj = len(d.get("injected", []))
+    skp = len(d.get("skipped", []))
+    err = len(d.get("errors", []))
+    sub = sum(i.get("substitutions", 0) for i in d.get("injected", []))
+    print(f"  ✓ injected={inj}, substitutions={sub}, skipped={skp}, errors={err}")
+except: print("  ⚠ inject parse-error")'
+fi
+```
+
+Validate at run-complete:
+
+```bash
+CGFR_VAL=".claude/scripts/validators/verify-codegen-fixture-ref.py"
+if [ -f "$CGFR_VAL" ] && [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
+  CGFR_FLAGS="--severity ${VG_CODEGEN_FIXTURE_SEVERITY:-block}"
+  [[ "${ARGUMENTS}" =~ --allow-no-fixture-ref ]] && CGFR_FLAGS="$CGFR_FLAGS --allow-no-fixture-ref"
+  "${PYTHON_BIN:-python3}" "$CGFR_VAL" --phase "$PHASE_NUMBER" \
+    --tests-dir "${GENERATED_TESTS_DIR:-apps/web/e2e}" $CGFR_FLAGS
+  CGFR_RC=$?
+  if [ "$CGFR_RC" -ne 0 ] && [ "${VG_CODEGEN_FIXTURE_SEVERITY:-block}" = "block" ]; then
+    echo "⛔ Codegen fixture-ref gate failed — fixture-backed goals' specs"
+    echo "   are missing FIXTURE.* references after substitution pass."
+    echo "   Investigate: scripts/codegen-fixture-inject.py output above."
+    exit 1
+  fi
+fi
+```
+
 </step>
 
 <step name="5d_binding_gate" profile="web-fullstack,web-frontend-only">

--- a/commands/vg/test.md
+++ b/commands/vg/test.md
@@ -1472,53 +1472,67 @@ Display:
 
 Generate Playwright test files from VERIFIED goals. Assertions come from TEST-GOALS success criteria, navigation paths come from RUNTIME-MAP.json observations, and CRUD list/form/delete/security expectations come from CRUD-SURFACES.md when present.
 
-**RFC v9 PR-E — fixture-aware codegen (NEW, 2026-05-02):**
+**RFC v9 PR-E — fixture-aware codegen (Codex-HIGH-3 fix — REAL injection):**
 
-When `FIXTURES/{G-XX}.yaml` exists for a goal, the codegen wraps the
-spec with a beforeAll hook that loads the captured store from
-`FIXTURES-CACHE.json` and injects values into the test as constants.
-This means deterministic IDs (`pending_id`, `merchant_id`, etc.) flow
-from the recipe's last successful run into the Playwright assertion
-without re-running mutations that the recipe already exercised.
-
-```bash
-# Best-effort: skip when scripts/runtime/ not present (v2.46 phases)
-if [ -d "${REPO_ROOT}/scripts/runtime" ]; then
-  CACHE_PATH="${PHASE_DIR}/FIXTURES-CACHE.json"
-  if [ -f "$CACHE_PATH" ]; then
-    "${PYTHON_BIN:-python3}" - <<'INJECT' || true
-import json, os, sys
-from pathlib import Path
-cache_path = Path(os.environ["PHASE_DIR"]) / "FIXTURES-CACHE.json"
-try:
-    data = json.loads(cache_path.read_text(encoding="utf-8"))
-    entries = data.get("entries") or {}
-    n = len([g for g in entries if entries[g].get("captured")])
-    print(f"  ✓ FIXTURES-CACHE: {n} goal(s) carry captured store for codegen injection")
-except Exception as e:
-    print(f"  ⚠ FIXTURES-CACHE parse error: {e}")
-INJECT
-  fi
-fi
-```
-
-Codegen template emits (when goal has fixture-cache entry):
+After codegen writes `.spec.ts` files, invoke
+`scripts/codegen-fixture-inject.py` in sweep mode. For every goal in
+`FIXTURES-CACHE.json` with a `captured` store, the script walks the
+generated tests dir, finds matching `*-{G-XX}.spec.ts` files, and
+prepends:
 
 ```ts
-// Generated from FIXTURES-CACHE.json — recipe-captured values
+// VGFLOW_FIXTURE_INJECTED — DO NOT EDIT BELOW UNTIL CLOSE
+// goal: G-10, phase: 3.2
+// Source: FIXTURES-CACHE.json captured store from last review run.
+// Edit FIXTURES/G-10.yaml + re-run /vg:review to regenerate.
 const FIXTURE = {
   pending_id: "p7e9-2026-05-02",
   amount: 0.01,
-};
-test("G-10 approve topup", async ({ page }) => {
-  await page.goto(`/admin/topup/${FIXTURE.pending_id}`);
-  // ...
-});
+} as const;
+// VGFLOW_FIXTURE_INJECTED_END
 ```
 
-Validators check that codegen output for a fixture-backed goal references
-`FIXTURE.*` constants, not hard-coded IDs from RUNTIME-MAP — drift between
-recipe and test is now a CI-detectable signal.
+Idempotent: re-injecting REPLACES the existing block, never stacks.
+Drift detector `verify-codegen-fixture-ref.py` BLOCKs at /vg:test exit
+if a fixture-backed goal's spec doesn't reference `FIXTURE.*`.
+
+```bash
+if [ -f "${REPO_ROOT}/scripts/codegen-fixture-inject.py" ] && \
+   [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
+  echo "▸ RFC v9 codegen fixture inject (sweep mode)"
+  INJECT_OUT=$("${PYTHON_BIN:-python3}" \
+    "${REPO_ROOT}/scripts/codegen-fixture-inject.py" \
+    --phase "$PHASE_NUMBER" \
+    --sweep "${GENERATED_TESTS_DIR:-apps/web/e2e}" 2>&1)
+  echo "$INJECT_OUT" | "${PYTHON_BIN:-python3}" -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    inj = len(d.get("injected", []))
+    skp = len(d.get("skipped", []))
+    err = len(d.get("errors", []))
+    print(f"  ✓ injected={inj}, skipped={skp}, errors={err}")
+except: print("  ⚠ inject parse-error")'
+fi
+```
+
+Then validate at run-complete:
+
+```bash
+CGFR_VAL=".claude/scripts/validators/verify-codegen-fixture-ref.py"
+if [ -f "$CGFR_VAL" ] && [ -f "${PHASE_DIR}/FIXTURES-CACHE.json" ]; then
+  CGFR_FLAGS="--severity ${VG_CODEGEN_FIXTURE_SEVERITY:-block}"
+  [[ "${ARGUMENTS}" =~ --allow-no-fixture-ref ]] && CGFR_FLAGS="$CGFR_FLAGS --allow-no-fixture-ref"
+  "${PYTHON_BIN:-python3}" "$CGFR_VAL" --phase "$PHASE_NUMBER" \
+    --tests-dir "${GENERATED_TESTS_DIR:-apps/web/e2e}" $CGFR_FLAGS
+  CGFR_RC=$?
+  if [ "$CGFR_RC" -ne 0 ] && [ "${VG_CODEGEN_FIXTURE_SEVERITY:-block}" = "block" ]; then
+    echo "⛔ Codegen fixture-ref gate failed — fixture-backed goals' specs"
+    echo "   are missing FIXTURE.* references. Re-run codegen + inject."
+    exit 1
+  fi
+fi
+```
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@
 
 pyyaml>=6.0          # validator registry (scripts/validators/registry.yaml) loader
 pytest>=7.0          # regression suite (scripts/tests/) — optional at runtime, required for CI
+jsonschema>=4.0      # RFC v9 fixture/data-invariants schema validation (PR-pre-A onwards)
+jsonpath-ng>=1.6     # RFC v9 PR-A1 recipe runtime — JSONPath capture (RFC 9535-aligned)
+requests>=2.31       # RFC v9 PR-A2 native API executor — no external runtime dep

--- a/schemas/data-invariants.v1.json
+++ b/schemas/data-invariants.v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vgflow.dev/schemas/data-invariants.v1.json",
+  "title": "VGFlow Data Invariants v1.0",
+  "description": "RFC v9 D5 — data_invariants block in ENV-CONTRACT.md. Per-consumer entity creation (no count generic). Closes preflight non-convergence ping-pong.",
+  "type": "object",
+  "required": ["data_invariants"],
+  "properties": {
+    "data_invariants": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/invariant" }
+    }
+  },
+  "$defs": {
+    "invariant": {
+      "type": "object",
+      "required": ["id", "resource", "where", "consumers"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Stable invariant identifier (e.g., tier2_topup_pending)"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Logical resource name (matches API-CONTRACTS.md resource block)"
+        },
+        "where": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Conjunction-only filter (AND across keys). OR via separate invariants."
+        },
+        "consumers": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/consumer" },
+          "description": "List of goals depending on this invariant. Preflight counts destructive consumers, creates N entities."
+        },
+        "isolation": {
+          "type": "string",
+          "enum": ["per_consumer", "shared_when_read_only"],
+          "default": "per_consumer",
+          "description": "per_consumer = N entities for N destructive consumers. shared_when_read_only = 1 entity if all read_only."
+        }
+      }
+    },
+    "consumer": {
+      "type": "object",
+      "required": ["goal", "recipe", "consume_semantics"],
+      "properties": {
+        "goal": {
+          "type": "string",
+          "pattern": "^G-[A-Za-z0-9._-]+$"
+        },
+        "recipe": {
+          "type": "string",
+          "pattern": "^G-[A-Za-z0-9._-]+$",
+          "description": "Owning recipe goal_id (may differ from consumer goal — e.g., G-11 reuses G-10 recipe)"
+        },
+        "consume_semantics": {
+          "type": "string",
+          "enum": ["destructive", "read_only"],
+          "description": "destructive = scanner mutation removes/transitions entity (need own row). read_only = scanner observes only (can share row)."
+        }
+      }
+    }
+  }
+}

--- a/schemas/fixture-recipe.v1.json
+++ b/schemas/fixture-recipe.v1.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vgflow.dev/schemas/fixture-recipe.v1.json",
+  "title": "VGFlow Fixture Recipe v1.0",
+  "description": "RFC v9 D2 — recipe schema for FIXTURES/{G-XX}.yaml. Authored at /vg:build by executor; consumed by /vg:review preflight + /vg:test codegen.",
+  "type": "object",
+  "required": ["schema_version", "goal", "description", "fixture_intent", "steps"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Mandatory. Runner rejects unknown major. See D14 versioning policy."
+    },
+    "goal": {
+      "type": "string",
+      "pattern": "^G-[A-Za-z0-9._-]+$",
+      "description": "Goal ID matching TEST-GOALS.md heading"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 30,
+      "description": "D27 enforcement: min 30 chars, must be specific (not 'TBD')"
+    },
+    "fixture_intent": {
+      "type": "object",
+      "required": ["declared_in", "validates"],
+      "properties": {
+        "declared_in": {
+          "type": "string",
+          "description": "Cross-ref to TEST-GOALS.md anchor (e.g., 'TEST-GOALS.md#G-10')"
+        },
+        "validates": {
+          "type": "string",
+          "minLength": 20,
+          "description": "What this fixture verifies (anti-skim D27)"
+        }
+      }
+    },
+    "allocation": {
+      "type": "object",
+      "description": "D13 concurrency/isolation",
+      "properties": {
+        "lease_id": { "type": "string" },
+        "expires_at": {
+          "type": "string",
+          "pattern": "^\\+\\d+[smhd]$",
+          "description": "Relative offset like +30m, +1h, +1d"
+        },
+        "owner_session": { "type": "string" }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/step" }
+    },
+    "lifecycle": {
+      "$ref": "#/$defs/lifecycle",
+      "description": "D12 RCRURD lifecycle assertion contract — required for mutation goals"
+    }
+  },
+  "$defs": {
+    "step": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["api_call", "loop"]
+        },
+        "role": {
+          "type": "string",
+          "description": "Lookup into vg.config.credentials[env]"
+        },
+        "method": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        },
+        "endpoint": {
+          "type": "string",
+          "pattern": "^/",
+          "description": "Relative path; runner resolves base from config (D2 portability)"
+        },
+        "idempotency_key": {
+          "type": "string",
+          "description": "D13: mandatory for POST/PUT (RFC 7240 Idempotency-Key header)"
+        },
+        "body": { "type": "object" },
+        "side_effect_risk": {
+          "type": "string",
+          "enum": ["none", "money_like", "external_call", "volume_change"],
+          "description": "D9: gates sandbox-only execution"
+        },
+        "capture": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/capture" }
+        },
+        "validate_after": { "$ref": "#/$defs/validate_after" },
+        "over": {
+          "description": "kind: loop — array of values OR int count",
+          "oneOf": [
+            { "type": "array" },
+            { "type": "integer", "minimum": 1 }
+          ]
+        },
+        "each": { "$ref": "#/$defs/step" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "api_call" } } },
+          "then": {
+            "required": ["role", "method", "endpoint"],
+            "anyOf": [
+              { "properties": { "method": { "enum": ["GET", "DELETE"] } } },
+              { "required": ["body"] }
+            ]
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              { "properties": { "kind": { "const": "api_call" } } },
+              { "properties": { "method": { "enum": ["POST", "PUT"] } } }
+            ]
+          },
+          "then": {
+            "required": ["idempotency_key"],
+            "description": "D13: POST/PUT must have idempotency_key"
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "loop" } } },
+          "then": { "required": ["over", "each"] }
+        }
+      ]
+    },
+    "capture": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^\\$",
+          "description": "JSONPath RFC 9535"
+        },
+        "cardinality": {
+          "type": "string",
+          "enum": ["scalar", "array", "optional_scalar"],
+          "default": "scalar"
+        },
+        "on_empty": {
+          "type": "string",
+          "enum": ["fail", "skip", "null"],
+          "default": "fail"
+        },
+        "from_each": {
+          "type": "boolean",
+          "description": "For loop step: collect captures from each iteration into array"
+        }
+      }
+    },
+    "validate_after": {
+      "type": "object",
+      "description": "D3: read-only assertion catching partial-orphan inconsistent state",
+      "required": ["kind", "method", "endpoint"],
+      "properties": {
+        "kind": { "const": "api_call" },
+        "method": { "type": "string", "enum": ["GET"] },
+        "endpoint": { "type": "string", "pattern": "^/" },
+        "expect_status": { "type": "integer" },
+        "assert_jsonpath": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/jsonpath_assert" }
+        }
+      }
+    },
+    "jsonpath_assert": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": { "type": "string", "pattern": "^\\$" },
+        "equals": {},
+        "not_equals": {},
+        "not_null": { "type": "boolean" },
+        "increased_by_at_least": { "type": "number" },
+        "decreased_by_at_least": { "type": "number" },
+        "cardinality": { "type": "string", "pattern": "^[><=]+\\d+$" }
+      }
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "D12 RCRURD: pre_state + action + post_state + side_effects",
+      "required": ["pre_state", "action", "post_state"],
+      "properties": {
+        "pre_state": { "$ref": "#/$defs/lifecycle_check" },
+        "action": {
+          "type": "object",
+          "required": ["surface", "expected_network"],
+          "properties": {
+            "surface": {
+              "type": "string",
+              "enum": ["ui_click", "ui_form_submit", "api_direct"]
+            },
+            "target": { "type": "string" },
+            "expected_network": {
+              "type": "object",
+              "required": ["method", "endpoint", "status_range"],
+              "properties": {
+                "method": { "type": "string" },
+                "endpoint": { "type": "string", "pattern": "^/" },
+                "status_range": {
+                  "type": "array",
+                  "items": { "type": "integer" },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "target_selector_must_include": {
+                  "type": "string",
+                  "description": "D13: scanner click fixture-specific ID, not 'first visible row'"
+                }
+              }
+            }
+          }
+        },
+        "post_state": { "$ref": "#/$defs/lifecycle_check" },
+        "side_effects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/lifecycle_check" }
+        }
+      }
+    },
+    "lifecycle_check": {
+      "type": "object",
+      "required": ["role", "method", "endpoint", "assert_jsonpath"],
+      "properties": {
+        "role": { "type": "string" },
+        "method": { "type": "string", "enum": ["GET"] },
+        "endpoint": { "type": "string", "pattern": "^/" },
+        "retry": {
+          "type": "object",
+          "description": "D12: handle eventual consistency",
+          "properties": {
+            "max_attempts": { "type": "integer", "minimum": 1, "maximum": 20 },
+            "delay_ms": { "type": "integer", "minimum": 50 },
+            "until_assertion_pass": { "type": "boolean" }
+          }
+        },
+        "assert_jsonpath": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/jsonpath_assert" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/codegen-fixture-inject.py
+++ b/scripts/codegen-fixture-inject.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Inject `FIXTURE = {...}` const block into generated Playwright .spec.ts.
+
+RFC v9 PR-E Codex-HIGH-3 fix — was a comment-only stub. Now actually
+reads FIXTURES-CACHE.json captured store and prepends a typed TypeScript
+constant at the top of the spec, so generated tests reference
+`FIXTURE.pending_id` instead of hard-coded values from RUNTIME-MAP.
+
+Mode 1 (single-file): inject for one goal_id into one spec file.
+  scripts/codegen-fixture-inject.py \\
+    --phase 3.2 --goal G-10 \\
+    --spec apps/web/e2e/3.2-goal-G-10.spec.ts
+
+Mode 2 (sweep): walk all generated specs in a directory; inject for any
+spec whose name maps to a goal that has a captured store.
+  scripts/codegen-fixture-inject.py \\
+    --phase 3.2 --sweep apps/web/e2e/
+
+Idempotent: if the spec already starts with `// VGFLOW_FIXTURE_INJECTED`
+sentinel, the script replaces the existing block instead of stacking.
+
+Output JSON:
+  {"injected": [...], "skipped": [...], "errors": [...]}
+
+Exit:
+  0 — success (≥0 specs injected)
+  1 — phase or cache file missing
+  2 — arg error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runtime.fixture_cache import load as cache_load  # noqa: E402
+
+
+SENTINEL_OPEN = "// VGFLOW_FIXTURE_INJECTED — DO NOT EDIT BELOW UNTIL CLOSE"
+SENTINEL_CLOSE = "// VGFLOW_FIXTURE_INJECTED_END"
+
+
+def _find_phase_dir(repo: Path, phase: str) -> Path | None:
+    phases_dir = repo / ".vg" / "phases"
+    if not phases_dir.exists():
+        return None
+    for prefix in (phase, _zero_pad(phase)):
+        matches = sorted(phases_dir.glob(f"{prefix}-*"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _zero_pad(phase: str) -> str:
+    if "." in phase and not phase.split(".")[0].startswith("0"):
+        head, _, tail = phase.partition(".")
+        return f"{head.zfill(2)}.{tail}"
+    return phase
+
+
+def _ts_literal(value: Any, indent: int = 2) -> str:
+    """Render a Python value as a TypeScript literal."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        # Use JSON-escape for safety (handles backslashes, quotes, control chars)
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, list):
+        items = [_ts_literal(v, indent + 2) for v in value]
+        return "[" + ", ".join(items) + "]"
+    if isinstance(value, dict):
+        sp = " " * (indent + 2)
+        ep = " " * indent
+        lines = []
+        for k, v in value.items():
+            key = k if re.match(r"^[a-zA-Z_$][\w$]*$", str(k)) else json.dumps(k)
+            lines.append(f"{sp}{key}: {_ts_literal(v, indent + 2)}")
+        return "{\n" + ",\n".join(lines) + f"\n{ep}}}"
+    # Fallback: stringify
+    return json.dumps(str(value))
+
+
+def render_block(captured: dict, *, goal_id: str, phase: str) -> str:
+    """Build the full FIXTURE injection block (sentinel + const + sentinel)."""
+    body = _ts_literal(captured)
+    return (
+        f"{SENTINEL_OPEN}\n"
+        f"// goal: {goal_id}, phase: {phase}\n"
+        f"// Source: FIXTURES-CACHE.json captured store from last review run.\n"
+        f"// Edit FIXTURES/{goal_id}.yaml + re-run /vg:review to regenerate.\n"
+        f"const FIXTURE = {body} as const;\n"
+        f"{SENTINEL_CLOSE}\n"
+    )
+
+
+def inject_into_spec(spec_path: Path, block: str) -> str:
+    """Idempotent inject. Returns 'injected' | 'replaced' | 'unchanged'."""
+    text = spec_path.read_text(encoding="utf-8")
+
+    # If sentinel block already present → replace it
+    pattern = re.compile(
+        re.escape(SENTINEL_OPEN) + r".*?" + re.escape(SENTINEL_CLOSE) + r"\n?",
+        re.DOTALL,
+    )
+    if pattern.search(text):
+        new_text = pattern.sub(block, text)
+        if new_text == text:
+            return "unchanged"
+        spec_path.write_text(new_text, encoding="utf-8")
+        return "replaced"
+
+    # Else: prepend after any leading comment/import block
+    # Find first non-comment, non-import line
+    lines = text.splitlines(keepends=True)
+    insert_idx = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("//") or stripped.startswith("import ") \
+                or stripped.startswith("/*") or stripped.startswith("*") \
+                or stripped.startswith("*/"):
+            insert_idx = i + 1
+            continue
+        break
+    new_lines = lines[:insert_idx] + [block + "\n"] + lines[insert_idx:]
+    spec_path.write_text("".join(new_lines), encoding="utf-8")
+    return "injected"
+
+
+def find_specs_for_phase(sweep_dir: Path, phase: str) -> list[tuple[str, Path]]:
+    """Return [(goal_id, spec_path)] for all specs naming a goal under sweep_dir."""
+    out: list[tuple[str, Path]] = []
+    if not sweep_dir.exists():
+        return out
+    # Common patterns: {phase}-goal-{G-XX}.spec.ts, {G-XX}.spec.ts, {phase}.{G-XX}.spec.ts
+    pattern = re.compile(r"(G-[\w.-]+)\.spec\.ts$")
+    for spec in sorted(sweep_dir.rglob("*.spec.ts")):
+        m = pattern.search(spec.name)
+        if m:
+            out.append((m.group(1), spec))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True)
+    ap.add_argument("--goal", help="Single goal_id (use with --spec)")
+    ap.add_argument("--spec", help="Single spec.ts path (use with --goal)")
+    ap.add_argument("--sweep", help="Directory to walk for *.spec.ts")
+    ap.add_argument("--repo-root", default=None)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print plan; no writes")
+    args = ap.parse_args()
+
+    if not (args.spec or args.sweep):
+        ap.error("must specify --spec/--goal OR --sweep")
+    if args.spec and not args.goal:
+        ap.error("--spec requires --goal")
+    if args.sweep and (args.goal or args.spec):
+        ap.error("--sweep is mutually exclusive with --spec/--goal")
+
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    phase_dir = _find_phase_dir(repo, args.phase)
+    if phase_dir is None:
+        print(json.dumps({"error": f"phase '{args.phase}' not found"}))
+        return 1
+
+    cache_data = cache_load(phase_dir)
+    entries = cache_data.get("entries") or {}
+    if not entries:
+        print(json.dumps({"error": "FIXTURES-CACHE.json has no captured entries",
+                            "phase": args.phase}))
+        return 1
+
+    targets: list[tuple[str, Path]] = []
+    if args.sweep:
+        sweep_dir = Path(args.sweep).resolve()
+        targets = find_specs_for_phase(sweep_dir, args.phase)
+    else:
+        targets = [(args.goal, Path(args.spec).resolve())]
+
+    injected: list[dict] = []
+    skipped: list[dict] = []
+    errors: list[dict] = []
+
+    for goal_id, spec_path in targets:
+        entry = entries.get(goal_id) or {}
+        captured = entry.get("captured")
+        if not captured:
+            skipped.append({
+                "goal": goal_id,
+                "spec": str(spec_path),
+                "reason": "no captured store in FIXTURES-CACHE",
+            })
+            continue
+        if not spec_path.exists():
+            errors.append({
+                "goal": goal_id,
+                "spec": str(spec_path),
+                "error": "spec file not found",
+            })
+            continue
+        block = render_block(captured, goal_id=goal_id, phase=args.phase)
+        if args.dry_run:
+            injected.append({
+                "goal": goal_id,
+                "spec": str(spec_path),
+                "action": "dry-run",
+                "captured_keys": list(captured.keys()),
+            })
+            continue
+        try:
+            action = inject_into_spec(spec_path, block)
+            injected.append({
+                "goal": goal_id,
+                "spec": str(spec_path),
+                "action": action,
+                "captured_keys": list(captured.keys()),
+            })
+        except OSError as e:
+            errors.append({"goal": goal_id, "spec": str(spec_path),
+                            "error": str(e)})
+
+    print(json.dumps({
+        "phase": args.phase,
+        "injected": injected,
+        "skipped": skipped,
+        "errors": errors,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/codegen-fixture-inject.py
+++ b/scripts/codegen-fixture-inject.py
@@ -131,9 +131,21 @@ def _is_safe_to_substitute(value: str) -> bool:
     return False
 
 
+_VALID_TS_IDENT_RE = re.compile(r"^[a-zA-Z_$][\w$]*$")
+
+
+def _fixture_ref(key: str) -> str:
+    """Render `FIXTURE.<key>` or `FIXTURE["<key>"]` depending on whether
+    `key` is a valid TS identifier (Codex-MEDIUM-2 fix)."""
+    if _VALID_TS_IDENT_RE.match(key):
+        return f"FIXTURE.{key}"
+    # Non-identifier (hyphen, space, starts with digit, etc.) → bracket notation
+    return f'FIXTURE[{json.dumps(key)}]'
+
+
 def substitute_literals(text: str, captured: dict) -> tuple[str, int]:
     """Replace exact-quoted-string occurrences of captured values with
-    FIXTURE.<name> references.
+    FIXTURE.<name> (or FIXTURE["<name>"] for non-identifier keys) refs.
 
     Conservative: only substitutes inside quoted strings ("..." or '...'
     or `...`), never bare identifiers. Skips substitution inside the
@@ -161,11 +173,12 @@ def substitute_literals(text: str, captured: dict) -> tuple[str, int]:
         for key, value in captured.items():
             if not _is_safe_to_substitute(value):
                 continue
+            ref = _fixture_ref(str(key))  # Codex-MEDIUM-2: bracket if non-identifier
             # Match value inside double, single, or backtick quotes
             patterns = [
-                (re.compile('"' + re.escape(value) + '"'), f'FIXTURE.{key}'),
-                (re.compile("'" + re.escape(value) + "'"), f'FIXTURE.{key}'),
-                (re.compile('`' + re.escape(value) + '`'), f'String(FIXTURE.{key})'),
+                (re.compile('"' + re.escape(value) + '"'), ref),
+                (re.compile("'" + re.escape(value) + "'"), ref),
+                (re.compile('`' + re.escape(value) + '`'), f'String({ref})'),
             ]
             for pat, repl in patterns:
                 part, n = pat.subn(repl, part)
@@ -229,16 +242,31 @@ def inject_into_spec(
 
 
 def find_specs_for_phase(sweep_dir: Path, phase: str) -> list[tuple[str, Path]]:
-    """Return [(goal_id, spec_path)] for all specs naming a goal under sweep_dir."""
+    """Return [(goal_id, spec_path)] for all specs naming a goal under sweep_dir.
+
+    Recognized filename patterns (case-insensitive on goal_id):
+    - {anything}-{G-XX}.spec.ts                   — goal-based codegen
+    - {anything}-{g-xx}.spec.ts                   — interactive codegen lowercase
+    - {anything}-{G-XX}.url-state.spec.ts         — interactive subtype
+    - auto-{g-xx-slug}.spec.ts                    — auto-emitted skeletons
+    """
     out: list[tuple[str, Path]] = []
     if not sweep_dir.exists():
         return out
-    # Common patterns: {phase}-goal-{G-XX}.spec.ts, {G-XX}.spec.ts, {phase}.{G-XX}.spec.ts
-    pattern = re.compile(r"(G-[\w.-]+)\.spec\.ts$")
+    # Codex-MEDIUM-1 fix: case-insensitive G- prefix + tolerate
+    # `.url-state.spec.ts` and other suffix variants.
+    pattern = re.compile(
+        r"(?i)\b(G-[\w.-]+?)(?:\.url-state)?\.spec\.ts$",
+    )
     for spec in sorted(sweep_dir.rglob("*.spec.ts")):
         m = pattern.search(spec.name)
         if m:
-            out.append((m.group(1), spec))
+            # Normalize goal_id to canonical uppercase form so cache lookup
+            # works regardless of filename casing.
+            goal_id = m.group(1)
+            head, _, tail = goal_id.partition("-")
+            normalized = head.upper() + ("-" + tail if tail else "")
+            out.append((normalized, spec))
     return out
 
 

--- a/scripts/codegen-fixture-inject.py
+++ b/scripts/codegen-fixture-inject.py
@@ -103,8 +103,96 @@ def render_block(captured: dict, *, goal_id: str, phase: str) -> str:
     )
 
 
-def inject_into_spec(spec_path: Path, block: str) -> str:
-    """Idempotent inject. Returns 'injected' | 'replaced' | 'unchanged'."""
+def _is_safe_to_substitute(value: str) -> bool:
+    """A captured STRING value qualifies for body substitution only when
+    it's distinctive enough that an exact-string match in the spec body
+    is overwhelmingly likely to be the captured value, not a coincidence.
+
+    Codex-HIGH-3-bis safety guard:
+    - Length ≥ 8 (avoids matching short tokens like 'pending').
+    - OR sentinel-prefixed (VG_FIXTURE_*, *@fixture.vgflow.test).
+    - UUID-like, or contains hyphens/underscores typical of identifiers.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if "VG_FIXTURE_" in value:
+        return True
+    if "@fixture.vgflow.test" in value.lower():
+        return True
+    if len(value) < 8:
+        return False
+    # UUID-like (8-4-4-4-12 hex chunks) or contains digits/hyphens
+    if re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", value):
+        return True
+    if any(c.isdigit() for c in value) and re.search(r"[-_]", value):
+        return True
+    if len(value) >= 16:  # very long strings unlikely to coincide
+        return True
+    return False
+
+
+def substitute_literals(text: str, captured: dict) -> tuple[str, int]:
+    """Replace exact-quoted-string occurrences of captured values with
+    FIXTURE.<name> references.
+
+    Conservative: only substitutes inside quoted strings ("..." or '...'
+    or `...`), never bare identifiers. Skips substitution inside the
+    sentinel-bracketed FIXTURE const block itself.
+
+    Returns (new_text, substitution_count).
+    """
+    # Carve out the FIXTURE const block so we don't substitute inside it
+    sentinel_re = re.compile(
+        re.escape(SENTINEL_OPEN) + r".*?" + re.escape(SENTINEL_CLOSE),
+        re.DOTALL,
+    )
+    parts: list[str] = []
+    last_end = 0
+    fixture_blocks: list[str] = []
+    for m in sentinel_re.finditer(text):
+        parts.append(text[last_end:m.start()])
+        fixture_blocks.append(m.group(0))
+        last_end = m.end()
+    parts.append(text[last_end:])
+
+    count = 0
+    new_parts: list[str] = []
+    for part in parts:
+        for key, value in captured.items():
+            if not _is_safe_to_substitute(value):
+                continue
+            # Match value inside double, single, or backtick quotes
+            patterns = [
+                (re.compile('"' + re.escape(value) + '"'), f'FIXTURE.{key}'),
+                (re.compile("'" + re.escape(value) + "'"), f'FIXTURE.{key}'),
+                (re.compile('`' + re.escape(value) + '`'), f'String(FIXTURE.{key})'),
+            ]
+            for pat, repl in patterns:
+                part, n = pat.subn(repl, part)
+                count += n
+        new_parts.append(part)
+
+    # Stitch parts and untouched fixture blocks back together
+    out = []
+    for i, p in enumerate(new_parts):
+        out.append(p)
+        if i < len(fixture_blocks):
+            out.append(fixture_blocks[i])
+    return "".join(out), count
+
+
+def inject_into_spec(
+    spec_path: Path,
+    block: str,
+    *,
+    captured: dict | None = None,
+    substitute: bool = False,
+) -> tuple[str, int]:
+    """Idempotent inject. Returns (action, substitution_count).
+
+    action: 'injected' | 'replaced' | 'unchanged'
+    substitution_count: number of literal→FIXTURE.x replacements (0 unless substitute=True)
+    """
     text = spec_path.read_text(encoding="utf-8")
 
     # If sentinel block already present → replace it
@@ -114,26 +202,30 @@ def inject_into_spec(spec_path: Path, block: str) -> str:
     )
     if pattern.search(text):
         new_text = pattern.sub(block, text)
-        if new_text == text:
-            return "unchanged"
-        spec_path.write_text(new_text, encoding="utf-8")
-        return "replaced"
+        action = "replaced" if new_text != text else "unchanged"
+    else:
+        # Prepend after any leading comment/import block
+        lines = text.splitlines(keepends=True)
+        insert_idx = 0
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped == "" or stripped.startswith("//") or stripped.startswith("import ") \
+                    or stripped.startswith("/*") or stripped.startswith("*") \
+                    or stripped.startswith("*/"):
+                insert_idx = i + 1
+                continue
+            break
+        new_text = "".join(lines[:insert_idx] + [block + "\n"] + lines[insert_idx:])
+        action = "injected"
 
-    # Else: prepend after any leading comment/import block
-    # Find first non-comment, non-import line
-    lines = text.splitlines(keepends=True)
-    insert_idx = 0
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped == "" or stripped.startswith("//") or stripped.startswith("import ") \
-                or stripped.startswith("/*") or stripped.startswith("*") \
-                or stripped.startswith("*/"):
-            insert_idx = i + 1
-            continue
-        break
-    new_lines = lines[:insert_idx] + [block + "\n"] + lines[insert_idx:]
-    spec_path.write_text("".join(new_lines), encoding="utf-8")
-    return "injected"
+    sub_count = 0
+    if substitute and captured:
+        new_text, sub_count = substitute_literals(new_text, captured)
+
+    if new_text != text:
+        spec_path.write_text(new_text, encoding="utf-8")
+
+    return action, sub_count
 
 
 def find_specs_for_phase(sweep_dir: Path, phase: str) -> list[tuple[str, Path]]:
@@ -159,6 +251,11 @@ def main() -> int:
     ap.add_argument("--repo-root", default=None)
     ap.add_argument("--dry-run", action="store_true",
                     help="Print plan; no writes")
+    ap.add_argument("--substitute", action="store_true",
+                    help="Codex-HIGH-3-bis: also substitute literal "
+                         "occurrences of captured values with FIXTURE.<name>. "
+                         "Conservative: only safe-distinctive strings "
+                         "(sentinel-prefixed, UUID-like, or ≥16 chars).")
     args = ap.parse_args()
 
     if not (args.spec or args.sweep):
@@ -216,15 +313,21 @@ def main() -> int:
                 "spec": str(spec_path),
                 "action": "dry-run",
                 "captured_keys": list(captured.keys()),
+                "substitutions": 0,
             })
             continue
         try:
-            action = inject_into_spec(spec_path, block)
+            action, sub_count = inject_into_spec(
+                spec_path, block,
+                captured=captured if args.substitute else None,
+                substitute=args.substitute,
+            )
             injected.append({
                 "goal": goal_id,
                 "spec": str(spec_path),
                 "action": action,
                 "captured_keys": list(captured.keys()),
+                "substitutions": sub_count,
             })
         except OSError as e:
             errors.append({"goal": goal_id, "spec": str(spec_path),

--- a/scripts/fixture-backfill.py
+++ b/scripts/fixture-backfill.py
@@ -116,6 +116,9 @@ def extract_mutation_network(step: dict) -> list[dict]:
     return out
 
 
+_GOAL_ID_RE = re.compile(r"^G-[A-Za-z0-9._-]+$")
+
+
 def collect_goals(runtime: dict, only: set[str] | None) -> dict[str, GoalEvidence]:
     sequences = runtime.get("goal_sequences") or {}
     out: dict[str, GoalEvidence] = {}
@@ -123,6 +126,12 @@ def collect_goals(runtime: dict, only: set[str] | None) -> dict[str, GoalEvidenc
         if only and gid not in only:
             continue
         if not isinstance(seq, dict):
+            continue
+        # Codex-R4-HIGH-3 fix: validate goal_id matches G-XX pattern. RUNTIME-MAP
+        # is untrusted input — `gid="../../etc/x"` would write outside FIXTURES.
+        if not isinstance(gid, str) or not _GOAL_ID_RE.match(gid):
+            print(f"warning: skipping invalid goal_id (path-traversal risk): "
+                  f"{gid!r}", file=sys.stderr)
             continue
         steps = seq.get("steps") or []
         if not isinstance(steps, list):

--- a/scripts/fixture-backfill.py
+++ b/scripts/fixture-backfill.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Generate FIXTURES/{G-XX}.yaml from existing RUNTIME-MAP.json scanner evidence.
+
+RFC v9 PR-A.5 — migration tool for phases that completed /vg:build before
+recipe authoring became required. Walks goal_sequences[].steps[] for mutation
+goals, reconstructs probable POST/PUT/PATCH/DELETE shape from scanner-recorded
+network entries, and emits a draft fixture-recipe.v1.json-conformant YAML.
+
+Quality is best-effort:
+- HIGH confidence: scanner captured a complete request body — verbatim copy.
+- MEDIUM confidence: body partially captured; structural skeleton emitted with
+  ${var} placeholders for missing fields.
+- LOW confidence: only network method+endpoint visible; emit a stub with
+  TODO comments for the user. Prints flagged goals after run.
+
+Output:
+  ${PHASE_DIR}/FIXTURES/G-XX.yaml (one per mutation goal)
+  ${PHASE_DIR}/FIXTURES/.backfill-report.json (summary + confidence per goal)
+
+Usage:
+  scripts/fixture-backfill.py --phase 3.2 --dry-run        # preview
+  scripts/fixture-backfill.py --phase 3.2 --apply          # commit
+  scripts/fixture-backfill.py --phase 3.2 --apply --only G-10,G-11
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML required — `pip install pyyaml>=6.0`", file=sys.stderr)
+    sys.exit(2)
+
+
+MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+SUBMIT_VERBS = (
+    "submit", "approve", "confirm", "save", "create", "update",
+    "delete", "reject", "send", "duyệt", "xác nhận", "gửi",
+    "tạo", "cập nhật", "xóa", "từ chối",
+)
+SUBMIT_ACTIONS = {"click", "submit", "tap", "press"}
+
+
+@dataclass
+class GoalEvidence:
+    goal_id: str
+    title: str
+    steps: list[dict] = field(default_factory=list)
+    mutation_steps: list[dict] = field(default_factory=list)
+    confidence: str = "LOW"
+    rationale: list[str] = field(default_factory=list)
+
+
+def find_phase_dir(repo_root: Path, phase: str) -> Path | None:
+    phases_dir = repo_root / ".vg" / "phases"
+    if not phases_dir.exists():
+        return None
+    candidates = sorted(phases_dir.glob(f"{phase}-*"))
+    if not candidates and "." in phase and not phase.split(".")[0].startswith("0"):
+        head, _, tail = phase.partition(".")
+        candidates = sorted(phases_dir.glob(f"{head.zfill(2)}.{tail}-*"))
+    return candidates[0] if candidates else None
+
+
+def is_mutation_step(step: dict) -> bool:
+    if not isinstance(step, dict):
+        return False
+    action = str(step.get("do") or step.get("action") or "").lower()
+    if action not in SUBMIT_ACTIONS:
+        return False
+    target = " ".join(
+        str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+    ).lower()
+    return any(v in target for v in SUBMIT_VERBS)
+
+
+def extract_mutation_network(step: dict) -> list[dict]:
+    """Return all 2xx mutation network entries for a step."""
+    out: list[dict] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            net = value.get("network")
+            entries = []
+            if isinstance(net, list):
+                entries = net
+            elif isinstance(net, dict):
+                entries = [net]
+            for e in entries:
+                if not isinstance(e, dict):
+                    continue
+                method = str(e.get("method") or "").upper()
+                status = e.get("status", e.get("status_code"))
+                try:
+                    code = int(status)
+                except (TypeError, ValueError):
+                    continue
+                if method in MUTATION_METHODS and 200 <= code < 300:
+                    out.append(e)
+            for v in value.values():
+                walk(v)
+        elif isinstance(value, list):
+            for v in value:
+                walk(v)
+
+    walk(step)
+    return out
+
+
+def collect_goals(runtime: dict, only: set[str] | None) -> dict[str, GoalEvidence]:
+    sequences = runtime.get("goal_sequences") or {}
+    out: dict[str, GoalEvidence] = {}
+    for gid, seq in sequences.items():
+        if only and gid not in only:
+            continue
+        if not isinstance(seq, dict):
+            continue
+        steps = seq.get("steps") or []
+        if not isinstance(steps, list):
+            continue
+        ge = GoalEvidence(goal_id=gid, title=str(seq.get("title", ""))[:120])
+        for step in steps:
+            if isinstance(step, dict):
+                ge.steps.append(step)
+                if is_mutation_step(step):
+                    nets = extract_mutation_network(step)
+                    if nets:
+                        ge.mutation_steps.append({"step": step, "network": nets})
+        if ge.mutation_steps:
+            out[gid] = ge
+    return out
+
+
+def assess_confidence(evidence: GoalEvidence) -> None:
+    """Annotate confidence based on what was captured."""
+    if not evidence.mutation_steps:
+        evidence.confidence = "LOW"
+        evidence.rationale.append("no mutation step with 2xx network found")
+        return
+    has_body = False
+    has_url_path = False
+    for ms in evidence.mutation_steps:
+        for net in ms["network"]:
+            if net.get("body") or net.get("request_body"):
+                has_body = True
+            if net.get("endpoint") or net.get("url"):
+                has_url_path = True
+    if has_body and has_url_path:
+        evidence.confidence = "HIGH"
+        evidence.rationale.append("body + endpoint captured")
+    elif has_url_path:
+        evidence.confidence = "MEDIUM"
+        evidence.rationale.append("endpoint captured; body missing → skeleton emitted")
+    else:
+        evidence.confidence = "LOW"
+        evidence.rationale.append("only network method known; user must complete")
+
+
+def derive_recipe(evidence: GoalEvidence) -> dict[str, Any]:
+    """Build a fixture-recipe.v1.json-shaped dict from captured evidence."""
+    steps_out: list[dict] = []
+    for i, ms in enumerate(evidence.mutation_steps):
+        for j, net in enumerate(ms["network"]):
+            method = str(net.get("method", "POST")).upper()
+            endpoint = net.get("endpoint") or net.get("url") or "/TODO"
+            if not endpoint.startswith("/"):
+                endpoint = "/" + endpoint.lstrip("/")
+            body = net.get("body") or net.get("request_body")
+            step_id = f"mutation_{i}_{j}" if len(evidence.mutation_steps) > 1 else f"mutation_{i}"
+            step: dict[str, Any] = {
+                "id": step_id,
+                "kind": "api_call",
+                "role": "TODO_role",
+                "method": method,
+                "endpoint": endpoint,
+            }
+            if method in {"POST", "PUT"}:
+                step["idempotency_key"] = f"backfill-${{phase}}-${{goal}}-${{step}}-${{timestamp}}"
+            if body:
+                step["body"] = body
+            elif method in {"POST", "PUT", "PATCH"}:
+                step["body"] = {"TODO": "scanner did not capture request body — fill in"}
+            steps_out.append(step)
+
+    title = evidence.title or evidence.goal_id
+    description = (
+        f"Backfilled from RUNTIME-MAP scanner evidence on "
+        f"{datetime.now(timezone.utc).isoformat(timespec='seconds')}. "
+        f"Confidence: {evidence.confidence}. "
+        f"Reasoning: {'; '.join(evidence.rationale) or 'see backfill report'}. "
+        f"User must verify role assignment and replace TODO_role / TODO body fields."
+    )
+    return {
+        "schema_version": "1.0",
+        "goal": evidence.goal_id,
+        "description": description,
+        "fixture_intent": {
+            "declared_in": f"TEST-GOALS.md#{evidence.goal_id}",
+            "validates": title or "mutation lifecycle (backfill — fill in)",
+        },
+        "_backfill_meta": {
+            "confidence": evidence.confidence,
+            "rationale": evidence.rationale,
+            "tool_version": "1.0",
+        },
+        "steps": steps_out,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Backfill FIXTURES/{G-XX}.yaml from RUNTIME-MAP")
+    ap.add_argument("--phase", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--only", help="Comma-separated goal IDs", default=None)
+    ap.add_argument("--repo-root", default=None)
+    args = ap.parse_args()
+
+    if not args.dry_run and not args.apply:
+        ap.error("must specify --dry-run or --apply")
+    if args.dry_run and args.apply:
+        ap.error("--dry-run and --apply mutually exclusive")
+
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    phase_dir = find_phase_dir(repo, args.phase)
+    if phase_dir is None:
+        print(f"Phase '{args.phase}' not found at {repo / '.vg/phases'}", file=sys.stderr)
+        return 1
+
+    runtime_path = phase_dir / "RUNTIME-MAP.json"
+    if not runtime_path.exists():
+        print(f"RUNTIME-MAP.json not found at {runtime_path}", file=sys.stderr)
+        return 1
+    runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+
+    only = {g.strip() for g in args.only.split(",")} if args.only else None
+    evidences = collect_goals(runtime, only)
+    if not evidences:
+        print(f"No mutation goals with 2xx evidence found in {runtime_path}")
+        return 0
+
+    for ge in evidences.values():
+        assess_confidence(ge)
+
+    fixtures_dir = phase_dir / "FIXTURES"
+    print(f"{'APPLY' if args.apply else 'DRY-RUN'}: {len(evidences)} mutation goal(s)")
+    print(f"Output dir: {fixtures_dir}")
+    print()
+
+    summary = {
+        "phase": args.phase,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "goals": [],
+    }
+    by_confidence = {"HIGH": 0, "MEDIUM": 0, "LOW": 0}
+
+    if args.apply:
+        fixtures_dir.mkdir(exist_ok=True)
+
+    for gid, ge in evidences.items():
+        recipe = derive_recipe(ge)
+        target = fixtures_dir / f"{gid}.yaml"
+        by_confidence[ge.confidence] += 1
+
+        print(f"  {gid:10s} confidence={ge.confidence:6s} steps={len(recipe['steps'])} "
+              f"existing={'yes' if target.exists() else 'no'}")
+        if args.apply:
+            if target.exists():
+                # Don't clobber existing recipes; user can manually merge.
+                target = target.with_suffix(".yaml.backfill-draft")
+            target.write_text(
+                yaml.safe_dump(recipe, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+
+        summary["goals"].append({
+            "goal_id": gid,
+            "confidence": ge.confidence,
+            "rationale": ge.rationale,
+            "step_count": len(recipe["steps"]),
+            "output_path": str(target.relative_to(repo)) if args.apply else None,
+        })
+
+    print()
+    print(f"  HIGH: {by_confidence['HIGH']}, MEDIUM: {by_confidence['MEDIUM']}, "
+          f"LOW: {by_confidence['LOW']}")
+
+    if args.apply:
+        report_path = fixtures_dir / ".backfill-report.json"
+        report_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"  Report: {report_path}")
+        if by_confidence["LOW"] > 0:
+            print()
+            print(f"⚠ {by_confidence['LOW']} LOW-confidence goal(s) — review manually before /vg:review.")
+    else:
+        print()
+        print("Re-run with --apply to write FIXTURES/{G-XX}.yaml.")
+        if by_confidence["LOW"] > 0:
+            print(f"⚠ {by_confidence['LOW']} LOW-confidence goal(s) flagged.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fixture-prune.py
+++ b/scripts/fixture-prune.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Prune sandbox fixture cache + expired leases (RFC v9 PR-F follow-up).
+
+Two cleanup operations:
+1. Reap expired leases — fixture rows where expires_at < now. The lease
+   holder either crashed or finished without releasing.
+2. Reap orphan cache entries — goals no longer in TEST-GOALS.md (e.g.,
+   user removed a goal but FIXTURES-CACHE.json kept the entry).
+
+Designed to run periodically (cron, weekly), at /vg:review entry, or on
+demand with `/vg:fixture-prune {phase}`.
+
+Usage:
+  scripts/fixture-prune.py --phase 3.2 --dry-run
+  scripts/fixture-prune.py --phase 3.2 --apply
+  scripts/fixture-prune.py --all-phases --apply --skip-orphans  # leases only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runtime.fixture_cache import (  # noqa: E402
+    cache_path,
+    load,
+    reap_expired_leases,
+    reap_orphans,
+)
+
+
+def find_phase_dirs(repo: Path, phase_filter: str | None) -> list[Path]:
+    phases_dir = repo / ".vg" / "phases"
+    if not phases_dir.exists():
+        return []
+    if phase_filter:
+        zero_padded = phase_filter
+        if "." in phase_filter and not phase_filter.split(".")[0].startswith("0"):
+            head, _, tail = phase_filter.partition(".")
+            zero_padded = f"{head.zfill(2)}.{tail}"
+        for prefix in (phase_filter, zero_padded):
+            matches = sorted(phases_dir.glob(f"{prefix}-*"))
+            if matches:
+                return matches
+        return []
+    return sorted([p for p in phases_dir.iterdir() if p.is_dir()])
+
+
+def parse_known_goals(phase_dir: Path) -> set[str]:
+    test_goals = phase_dir / "TEST-GOALS.md"
+    if not test_goals.exists():
+        return set()
+    text = test_goals.read_text(encoding="utf-8")
+    return set(re.findall(r"^##\s+Goal\s+(G-[\w.-]+)", text, re.MULTILINE))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", help="Single phase (e.g., 3.2)")
+    ap.add_argument("--all-phases", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--skip-orphans", action="store_true",
+                    help="Reap expired leases only; leave orphan cache entries")
+    ap.add_argument("--skip-leases", action="store_true",
+                    help="Reap orphans only; leave lease ownership untouched")
+    ap.add_argument("--repo-root", default=None)
+    args = ap.parse_args()
+
+    if not args.dry_run and not args.apply:
+        ap.error("must specify --dry-run or --apply")
+    if args.dry_run and args.apply:
+        ap.error("--dry-run and --apply mutually exclusive")
+    if args.skip_orphans and args.skip_leases:
+        ap.error("can't skip both — pick at least one cleanup")
+    if not args.phase and not args.all_phases:
+        ap.error("must specify --phase or --all-phases")
+
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    phase_dirs = find_phase_dirs(repo, args.phase if not args.all_phases else None)
+    if not phase_dirs:
+        print(f"No phases found at {repo / '.vg/phases'}", file=sys.stderr)
+        return 1
+
+    grand_leases = 0
+    grand_orphans = 0
+    print(f"{'APPLY' if args.apply else 'DRY-RUN'}: scanning {len(phase_dirs)} phase(s)")
+
+    for phase_dir in phase_dirs:
+        cp = cache_path(phase_dir)
+        if not cp.exists():
+            continue
+        data = load(phase_dir)
+        entries = data.get("entries") or {}
+
+        # Count what would be reaped (without mutating)
+        expired_count = 0
+        orphan_count = 0
+        from datetime import datetime, timezone
+        now_t = datetime.now(timezone.utc).timestamp()
+        for gid, entry in entries.items():
+            lease = entry.get("lease") or {}
+            try:
+                ex_t = datetime.fromisoformat(
+                    lease["expires_at"].replace("Z", "+00:00"),
+                ).timestamp()
+                if ex_t < now_t:
+                    expired_count += 1
+            except (KeyError, ValueError):
+                pass
+        known = parse_known_goals(phase_dir)
+        if known:
+            orphan_count = sum(1 for gid in entries if gid not in known)
+
+        if expired_count == 0 and orphan_count == 0:
+            continue
+
+        print(f"  {phase_dir.name:50s} expired_leases={expired_count:3d} orphans={orphan_count:3d}")
+
+        if args.apply:
+            if not args.skip_leases:
+                grand_leases += reap_expired_leases(phase_dir)
+            if not args.skip_orphans and known:
+                grand_orphans += reap_orphans(phase_dir, known)
+
+    print()
+    if args.apply:
+        print(f"Reaped: {grand_leases} expired leases, {grand_orphans} orphan entries")
+    else:
+        print("Re-run with --apply to commit cleanup.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate-legacy-provenance.py
+++ b/scripts/migrate-legacy-provenance.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Mark mutation steps lacking structured provenance as legacy_pre_provenance.
+
+RFC v9 D10 migration tool. Walks every .vg/phases/*/RUNTIME-MAP.json and tags
+mutation steps (submit-intent click + 2xx network) that lack `step.evidence`
+with `step.provenance_status: legacy_pre_provenance`. The provenance validator
+treats this tag as informational (cannot trigger matrix promotion) but allows
+the phase to ship without re-scanning.
+
+Workflow:
+1. Run pre-flight (--dry-run) — see how many steps would be tagged.
+2. Run with --apply — atomic rewrite with .bak backup.
+3. Configure review.provenance.enforcement: block in vg.config.md.
+4. /vg:review {phase} runs cleanly — legacy steps skipped, new steps enforced.
+5. Optional: /vg:fixture-backfill {phase} (PR-A.5) generates real recipes
+   from the tagged steps so they can be re-scanned with scanner-source
+   evidence on the next /vg:review.
+
+Usage:
+  scripts/migrate-legacy-provenance.py --dry-run                        # all phases
+  scripts/migrate-legacy-provenance.py --phase 3.2 --dry-run            # one phase
+  scripts/migrate-legacy-provenance.py --apply                          # commit changes
+  scripts/migrate-legacy-provenance.py --apply --no-backup              # skip .bak
+
+Exit:
+  0 → success
+  1 → I/O or parse error
+  2 → unsupported flags
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Mirror provenance validator's mutation detection (kept inline so this
+# migration script has no validator dependency).
+MUTATION_ACTIONS = {"click", "submit", "tap", "press"}
+SUBMIT_VERBS = (
+    "submit", "approve", "confirm", "save", "create", "update", "delete",
+    "reject", "send", "duyệt", "xác nhận", "gửi", "tạo", "cập nhật",
+    "xóa", "từ chối",
+)
+
+
+def is_mutation_step(step: dict) -> bool:
+    if not isinstance(step, dict):
+        return False
+    action = str(step.get("do") or step.get("action") or "").lower()
+    if action not in MUTATION_ACTIONS:
+        return False
+    target = " ".join(
+        str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+    ).lower()
+    return any(v in target for v in SUBMIT_VERBS)
+
+
+def has_2xx_mutation_network(step: dict) -> bool:
+    def walk(value):
+        if isinstance(value, dict):
+            net = value.get("network")
+            entries = []
+            if isinstance(net, list):
+                entries = net
+            elif isinstance(net, dict):
+                entries = [net]
+            for e in entries:
+                if not isinstance(e, dict):
+                    continue
+                method = str(e.get("method") or "").upper()
+                status = e.get("status", e.get("status_code"))
+                try:
+                    code = int(status)
+                except (TypeError, ValueError):
+                    continue
+                if method in {"POST", "PUT", "PATCH", "DELETE"} and 200 <= code < 300:
+                    return True
+            for v in value.values():
+                if walk(v):
+                    return True
+        elif isinstance(value, list):
+            for v in value:
+                if walk(v):
+                    return True
+        return False
+    return walk(step)
+
+
+def find_phases(repo_root: Path, phase_filter: str | None) -> list[Path]:
+    phases_dir = repo_root / ".vg" / "phases"
+    if not phases_dir.exists():
+        return []
+    if phase_filter:
+        # Mirror find_phase_dir prefix logic: "3.2" matches "03.2-*", "3.2-*", etc.
+        zero_padded = phase_filter
+        if "." in phase_filter and not phase_filter.split(".")[0].startswith("0"):
+            head, _, tail = phase_filter.partition(".")
+            zero_padded = f"{head.zfill(2)}.{tail}"
+        candidates = []
+        for prefix in (phase_filter, zero_padded):
+            candidates += sorted(phases_dir.glob(f"{prefix}-*"))
+            candidates += sorted(phases_dir.glob(prefix))
+        # Dedupe preserving order
+        seen = set()
+        return [p for p in candidates if not (p in seen or seen.add(p))]
+    return sorted([p for p in phases_dir.iterdir() if p.is_dir()])
+
+
+def process_runtime_map(
+    runtime_path: Path,
+    apply_changes: bool,
+    backup: bool,
+) -> dict:
+    """Returns stats dict with phase-level counts."""
+    stats = {
+        "phase": runtime_path.parent.name,
+        "total_mutation_steps": 0,
+        "already_tagged_legacy": 0,
+        "newly_tagged": 0,
+        "has_evidence": 0,
+        "no_2xx_skipped": 0,
+        "errors": [],
+    }
+    try:
+        runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        stats["errors"].append(f"parse: {e}")
+        return stats
+
+    sequences = runtime.get("goal_sequences") or {}
+    if not isinstance(sequences, dict):
+        return stats
+
+    changed = False
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    for gid, seq in sequences.items():
+        if not isinstance(seq, dict):
+            continue
+        steps = seq.get("steps") or []
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            if not is_mutation_step(step):
+                continue
+            if not has_2xx_mutation_network(step):
+                stats["no_2xx_skipped"] += 1
+                continue
+            stats["total_mutation_steps"] += 1
+            if step.get("evidence") is not None:
+                stats["has_evidence"] += 1
+                continue
+            if step.get("provenance_status") == "legacy_pre_provenance":
+                stats["already_tagged_legacy"] += 1
+                continue
+            stats["newly_tagged"] += 1
+            if apply_changes:
+                step["provenance_status"] = "legacy_pre_provenance"
+                step["provenance_migrated_at"] = now
+                changed = True
+
+    if apply_changes and changed:
+        if backup:
+            bak = runtime_path.with_suffix(runtime_path.suffix + ".bak")
+            bak.write_text(runtime_path.read_text(encoding="utf-8"), encoding="utf-8")
+        # Atomic rewrite via temp file + rename
+        tmp = runtime_path.with_suffix(runtime_path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(runtime, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        tmp.replace(runtime_path)
+
+    return stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Tag pre-RFC-v9 mutation steps as legacy_pre_provenance",
+    )
+    ap.add_argument("--phase", help="Single phase (e.g., '3.2'). Default: all phases.")
+    ap.add_argument("--dry-run", action="store_true", help="Report only, no writes")
+    ap.add_argument("--apply", action="store_true", help="Commit changes")
+    ap.add_argument("--no-backup", action="store_true",
+                    help="Skip writing .bak alongside RUNTIME-MAP.json")
+    ap.add_argument("--repo-root", default=None,
+                    help="Override VG_REPO_ROOT / cwd")
+    args = ap.parse_args()
+
+    if not args.dry_run and not args.apply:
+        ap.error("must specify --dry-run or --apply")
+    if args.dry_run and args.apply:
+        ap.error("--dry-run and --apply are mutually exclusive")
+
+    import os
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+
+    phases = find_phases(repo, args.phase)
+    if not phases:
+        print(f"No phases found at {repo / '.vg/phases'} (filter={args.phase or 'none'})",
+              file=sys.stderr)
+        return 1
+
+    apply_changes = args.apply
+    backup = not args.no_backup
+
+    print(f"{'APPLY' if apply_changes else 'DRY-RUN'}: scanning {len(phases)} phase(s)")
+    print(f"Repo:   {repo}")
+    print(f"Backup: {'yes (.bak)' if backup and apply_changes else 'no'}")
+    print()
+
+    grand_totals = {
+        "total_mutation_steps": 0,
+        "already_tagged_legacy": 0,
+        "newly_tagged": 0,
+        "has_evidence": 0,
+        "no_2xx_skipped": 0,
+        "errors": 0,
+        "phases_touched": 0,
+    }
+
+    for phase_dir in phases:
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not runtime_path.exists():
+            continue
+        stats = process_runtime_map(runtime_path, apply_changes, backup)
+        if stats["errors"]:
+            for e in stats["errors"]:
+                print(f"  [error] {phase_dir.name}: {e}", file=sys.stderr)
+            grand_totals["errors"] += 1
+            continue
+        if stats["total_mutation_steps"] == 0:
+            continue
+        grand_totals["phases_touched"] += 1
+        print(
+            f"{phase_dir.name:50s} "
+            f"mutations={stats['total_mutation_steps']:3d} "
+            f"evidence={stats['has_evidence']:3d} "
+            f"already-legacy={stats['already_tagged_legacy']:3d} "
+            f"newly-tagged={stats['newly_tagged']:3d}"
+        )
+        for k in ("total_mutation_steps", "already_tagged_legacy",
+                  "newly_tagged", "has_evidence", "no_2xx_skipped"):
+            grand_totals[k] += stats[k]
+
+    print()
+    print("─" * 60)
+    print(f"Phases touched: {grand_totals['phases_touched']}")
+    print(f"Mutation steps: {grand_totals['total_mutation_steps']} total")
+    print(f"  Already-tagged legacy:   {grand_totals['already_tagged_legacy']}")
+    print(f"  Has structured evidence: {grand_totals['has_evidence']}")
+    print(f"  Newly tagged legacy:     {grand_totals['newly_tagged']}")
+    print(f"  Errors:                  {grand_totals['errors']}")
+
+    if not apply_changes and grand_totals["newly_tagged"] > 0:
+        print()
+        print("Re-run with --apply to commit. Add --no-backup to skip .bak files.")
+
+    return 0 if grand_totals["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight-invariants.py
+++ b/scripts/preflight-invariants.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Live preflight runner — RFC v9 PR-C wiring (replaces stub count_fn=0).
+
+Walks ENV-CONTRACT.md data_invariants + api_index, authenticates via
+recipe_executor, counts entities matching each invariant's `where`
+filter, emits BLOCK if any invariant is short.
+
+Output JSON:
+  {"verdict": "PASS"|"BLOCK", "gaps": [{...InvariantGap...}], "errors": [...]}
+
+Exit codes:
+  0 — PASS (all invariants satisfied)
+  1 — BLOCK (one or more gaps)
+  2 — config / setup error (missing api_index, bad creds, network)
+
+Usage:
+  scripts/preflight-invariants.py --phase 3.2 --base-url https://sandbox.example.com
+  scripts/preflight-invariants.py --phase 3.2 --dry-run        # show what'd be checked
+  scripts/preflight-invariants.py --phase 3.2 --severity warn  # downgrade BLOCK→WARN
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runtime.api_index import (  # noqa: E402
+    ApiIndexError,
+    count_fn_factory,
+    parse_api_index,
+)
+from runtime.preflight import (  # noqa: E402
+    PreflightError,
+    fix_hint,
+    parse_env_contract,
+    verify_invariants,
+)
+
+
+def _find_phase_dir(repo: Path, phase: str) -> Path | None:
+    phases_dir = repo / ".vg" / "phases"
+    if not phases_dir.exists():
+        return None
+    for prefix_candidate in (phase, _zero_pad(phase)):
+        matches = sorted(phases_dir.glob(f"{prefix_candidate}-*"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _zero_pad(phase: str) -> str:
+    if "." in phase and not phase.split(".")[0].startswith("0"):
+        head, _, tail = phase.partition(".")
+        return f"{head.zfill(2)}.{tail}"
+    return phase
+
+
+def _load_credentials_map(config_path: Path | None) -> dict:
+    """Read credentials_map from project vg.config.md or env override.
+
+    Returns the raw mapping {role: {kind, ...}} without secrets transformation.
+    Caller (RecipeRunner) handles auth dispatch.
+    """
+    if config_path and config_path.exists():
+        text = config_path.read_text(encoding="utf-8")
+        # Extract YAML block under `credentials:` heading
+        import re
+        m = re.search(
+            r"^credentials:\s*\n(?P<body>(?:[ \t].*\n)+)",
+            text, re.MULTILINE,
+        )
+        if m:
+            try:
+                import yaml
+                full = yaml.safe_load("credentials:\n" + m.group("body"))
+                if isinstance(full, dict):
+                    return full.get("credentials") or {}
+            except (ImportError, Exception):
+                pass
+    # Fallback: VG_CREDENTIALS_JSON env var (for CI / scripted use)
+    env_creds = os.environ.get("VG_CREDENTIALS_JSON")
+    if env_creds:
+        try:
+            return json.loads(env_creds)
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True)
+    ap.add_argument("--base-url", help="Sandbox API root URL (overrides env)")
+    ap.add_argument("--severity", choices=["block", "warn"], default="block")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Parse + report what'd be checked; do NOT call API")
+    ap.add_argument("--repo-root", default=None)
+    ap.add_argument("--vg-config", default=None,
+                    help="Path to vg.config.md (default: $REPO_ROOT/.claude/vg.config.md)")
+    args = ap.parse_args()
+
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    phase_dir = _find_phase_dir(repo, args.phase)
+    if phase_dir is None:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": f"phase '{args.phase}' not found at {repo / '.vg/phases'}",
+        }))
+        return 2
+
+    env_contract = phase_dir / "ENV-CONTRACT.md"
+    if not env_contract.exists():
+        # No invariants declared → trivial PASS (PR-C is opt-in)
+        print(json.dumps({"verdict": "PASS", "reason": "no ENV-CONTRACT.md"}))
+        return 0
+
+    try:
+        invariants = parse_env_contract(env_contract)
+    except PreflightError as e:
+        print(json.dumps({"verdict": "ERROR", "error": str(e)}))
+        return 2
+
+    if not invariants:
+        print(json.dumps({"verdict": "PASS", "reason": "no data_invariants block"}))
+        return 0
+
+    try:
+        api_index = parse_api_index(env_contract)
+    except ApiIndexError as e:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": f"api_index parse: {e}",
+        }))
+        return 2
+
+    if args.dry_run:
+        print(json.dumps({
+            "verdict": "DRY_RUN",
+            "invariants": len(invariants),
+            "api_index_resources": list(api_index),
+            "would_check": [
+                {"id": inv.get("id"), "resource": inv.get("resource"),
+                 "where": inv.get("where")}
+                for inv in invariants
+            ],
+        }, indent=2))
+        return 0
+
+    base_url = args.base_url or os.environ.get("VG_BASE_URL")
+    if not base_url:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": "no --base-url and VG_BASE_URL not set",
+        }))
+        return 2
+
+    config_path = Path(args.vg_config) if args.vg_config else \
+        (repo / ".claude" / "vg.config.md")
+    credentials_map = _load_credentials_map(config_path)
+
+    if not credentials_map:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": (
+                f"credentials_map empty — load from {config_path} OR set "
+                f"VG_CREDENTIALS_JSON env var. Without auth we cannot count."
+            ),
+        }))
+        return 2
+
+    # Need RecipeRunner instance for the count_fn closure
+    try:
+        from runtime.recipe_executor import RecipeRunner
+    except ImportError as e:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": f"recipe_executor import failed: {e} (install requests>=2.31)",
+        }))
+        return 2
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map=credentials_map,
+    )
+    try:
+        count_fn = count_fn_factory(api_index, runner)
+        gaps = verify_invariants(invariants, count_fn)
+    except (ApiIndexError, PreflightError) as e:
+        print(json.dumps({"verdict": "ERROR", "error": str(e)}))
+        return 2
+
+    if not gaps:
+        print(json.dumps({
+            "verdict": "PASS",
+            "invariants_checked": len(invariants),
+            "phase": args.phase,
+        }))
+        return 0
+
+    verdict = "BLOCK" if args.severity == "block" else "WARN"
+    print(json.dumps({
+        "verdict": verdict,
+        "phase": args.phase,
+        "gaps": [{**asdict(g), "fix_hint": fix_hint(g)} for g in gaps],
+    }, indent=2))
+    return 1 if verdict == "BLOCK" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rcrurd-preflight.py
+++ b/scripts/rcrurd-preflight.py
@@ -96,6 +96,15 @@ def main() -> int:
     ap.add_argument("--only", help="Comma-separated goal IDs to check")
     ap.add_argument("--repo-root", default=None)
     ap.add_argument("--vg-config", default=None)
+    ap.add_argument("--capture-snapshot", default=None,
+                    help="In --mode pre, persist payloads to this JSON path so "
+                         "--mode post can compute increased_by_at_least deltas "
+                         "against the actual pre-action state (Codex-HIGH-1-bis).")
+    ap.add_argument("--pre-snapshot", default=None,
+                    help="In --mode post, read pre-state payloads from this "
+                         "JSON path (written by an earlier --mode pre invocation "
+                         "with --capture-snapshot). Without it, increased_by_at_least "
+                         "deltas use post-action GET as 'pre' which is wrong.")
     args = ap.parse_args()
 
     repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
@@ -207,6 +216,21 @@ def main() -> int:
         except Exception:
             return {}
 
+    # Codex-HIGH-1-bis: load pre-snapshot for post mode (real pre-action state)
+    pre_snapshot: dict[str, dict] = {}
+    if args.mode == "post" and args.pre_snapshot:
+        snap_path = Path(args.pre_snapshot)
+        if snap_path.exists():
+            try:
+                pre_snapshot = json.loads(snap_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                pre_snapshot = {}
+
+    # Codex-HIGH-1-bis: capture pre-snapshot in pre mode for downstream post mode
+    capture_snapshot: dict[str, dict] = {} if (
+        args.mode == "pre" and args.capture_snapshot
+    ) else {}
+
     results = []
     failed_count = 0
     for entry in plan:
@@ -226,16 +250,32 @@ def main() -> int:
                 })
                 if not res.pre_state_passed and res.skipped_reason is None:
                     failed_count += 1
+                # Capture for downstream post mode (Codex-HIGH-1-bis)
+                if args.capture_snapshot:
+                    pre_block = entry["lifecycle"].get("pre_state") or {}
+                    if pre_block.get("endpoint") and pre_block.get("role"):
+                        try:
+                            capture_snapshot[entry["goal"]] = get_fn(
+                                pre_block["role"], pre_block["endpoint"],
+                            )
+                        except Exception:
+                            pass  # best-effort
             else:  # post
-                # Capture pre_payload for increased_by_at_least delta checks
-                pre_payload = None
-                pre_block = entry["lifecycle"].get("pre_state") or {}
-                if pre_block.get("endpoint") and pre_block.get("role"):
-                    try:
-                        pre_payload = get_fn(pre_block["role"],
-                                              pre_block["endpoint"])
-                    except Exception:
-                        pre_payload = None  # best-effort
+                # Codex-HIGH-1-bis fix: prefer the pre-snapshot from
+                # before the action ran. Falling back to a fresh GET
+                # would sample post-action state, breaking
+                # increased_by_at_least delta semantics.
+                pre_payload = pre_snapshot.get(entry["goal"]) if pre_snapshot else None
+                if pre_payload is None:
+                    # Fallback: best-effort live read (may be wrong for
+                    # delta assertions; equality assertions still work).
+                    pre_block = entry["lifecycle"].get("pre_state") or {}
+                    if pre_block.get("endpoint") and pre_block.get("role"):
+                        try:
+                            pre_payload = get_fn(pre_block["role"],
+                                                  pre_block["endpoint"])
+                        except Exception:
+                            pre_payload = None
                 res = run_post_state_with_retry(
                     entry["goal"], entry["lifecycle"], get_fn,
                     pre_payload=pre_payload,
@@ -245,6 +285,8 @@ def main() -> int:
                     "passed": res.post_state_passed,
                     "skipped": res.skipped_reason,
                     "errors": res.post_state_failures,
+                    "pre_snapshot_used": pre_payload is not None and
+                        pre_snapshot.get(entry["goal"]) is not None,
                 })
                 if not res.post_state_passed and res.skipped_reason is None:
                     failed_count += 1
@@ -253,6 +295,15 @@ def main() -> int:
                              "errors": [str(e)]})
             failed_count += 1
 
+    # Persist pre-snapshot for downstream post mode (Codex-HIGH-1-bis)
+    if args.mode == "pre" and args.capture_snapshot and capture_snapshot:
+        snap_path = Path(args.capture_snapshot)
+        snap_path.parent.mkdir(parents=True, exist_ok=True)
+        snap_path.write_text(
+            json.dumps(capture_snapshot, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
     if failed_count == 0:
         print(json.dumps({
             "verdict": "PASS",
@@ -260,6 +311,8 @@ def main() -> int:
             "phase": args.phase,
             "checked": len(plan),
             "results": results,
+            "snapshot_captured": bool(args.mode == "pre" and capture_snapshot),
+            "pre_snapshot_loaded": bool(args.mode == "post" and pre_snapshot),
         }, indent=2))
         return 0
 

--- a/scripts/rcrurd-preflight.py
+++ b/scripts/rcrurd-preflight.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Walk FIXTURES/*.yaml + run pre_state assertions (RFC v9 PR-D2 stub-2 fix).
+
+For every fixture with a `lifecycle.pre_state` block, authenticate via
+recipe_executor and run the GET + assert_jsonpath. Failure = data not in
+declared start state, fixtures not idempotently set up, or seed data
+drifted. Fail-fast at /vg:review entry before browser scan.
+
+Output JSON:
+  {"verdict": "PASS"|"BLOCK"|"WARN", "results": [{...}], "errors": [...]}
+
+Exit:
+  0 — PASS or WARN
+  1 — BLOCK
+  2 — config / setup error
+
+Usage:
+  scripts/rcrurd-preflight.py --phase 3.2 --base-url https://sandbox.example.com
+  scripts/rcrurd-preflight.py --phase 3.2 --severity warn
+  scripts/rcrurd-preflight.py --phase 3.2 --dry-run
+  scripts/rcrurd-preflight.py --phase 3.2 --only G-10,G-11
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+try:
+    import yaml
+except ImportError:
+    print(json.dumps({"verdict": "ERROR", "error": "PyYAML required"}))
+    sys.exit(2)
+
+from runtime.rcrurd_gate import run_pre_state, LifecycleGateError  # noqa: E402
+
+
+def _find_phase_dir(repo: Path, phase: str) -> Path | None:
+    phases_dir = repo / ".vg" / "phases"
+    if not phases_dir.exists():
+        return None
+    for prefix in (phase, _zero_pad(phase)):
+        matches = sorted(phases_dir.glob(f"{prefix}-*"))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _zero_pad(phase: str) -> str:
+    if "." in phase and not phase.split(".")[0].startswith("0"):
+        head, _, tail = phase.partition(".")
+        return f"{head.zfill(2)}.{tail}"
+    return phase
+
+
+def _load_credentials_map(config_path: Path | None) -> dict:
+    if config_path and config_path.exists():
+        text = config_path.read_text(encoding="utf-8")
+        import re
+        m = re.search(
+            r"^credentials:\s*\n(?P<body>(?:[ \t].*\n)+)",
+            text, re.MULTILINE,
+        )
+        if m:
+            try:
+                full = yaml.safe_load("credentials:\n" + m.group("body"))
+                if isinstance(full, dict):
+                    return full.get("credentials") or {}
+            except Exception:
+                pass
+    env_creds = os.environ.get("VG_CREDENTIALS_JSON")
+    if env_creds:
+        try:
+            return json.loads(env_creds)
+        except json.JSONDecodeError:
+            pass
+    return {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True)
+    ap.add_argument("--base-url", help="Sandbox API root URL (or VG_BASE_URL)")
+    ap.add_argument("--severity", choices=["block", "warn"], default="warn")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--only", help="Comma-separated goal IDs to check")
+    ap.add_argument("--repo-root", default=None)
+    ap.add_argument("--vg-config", default=None)
+    args = ap.parse_args()
+
+    repo = Path(args.repo_root or os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+    phase_dir = _find_phase_dir(repo, args.phase)
+    if phase_dir is None:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": f"phase '{args.phase}' not found",
+        }))
+        return 2
+
+    fixtures_dir = phase_dir / "FIXTURES"
+    if not fixtures_dir.exists():
+        print(json.dumps({"verdict": "PASS", "reason": "no FIXTURES dir"}))
+        return 0
+
+    only = {g.strip() for g in args.only.split(",")} if args.only else None
+    fixture_files = sorted(fixtures_dir.glob("*.yaml"))
+    if not fixture_files:
+        print(json.dumps({"verdict": "PASS", "reason": "no fixture yaml files"}))
+        return 0
+
+    plan: list[dict] = []
+    for fp in fixture_files:
+        gid = fp.stem
+        if only and gid not in only:
+            continue
+        try:
+            recipe = yaml.safe_load(fp.read_text(encoding="utf-8"))
+        except yaml.YAMLError as e:
+            plan.append({"goal": gid, "error": f"yaml parse: {e}"})
+            continue
+        if not isinstance(recipe, dict):
+            plan.append({"goal": gid, "error": "not an object"})
+            continue
+        lifecycle = recipe.get("lifecycle")
+        if not isinstance(lifecycle, dict) or "pre_state" not in lifecycle:
+            continue  # no pre_state to check
+        plan.append({"goal": gid, "lifecycle": lifecycle})
+
+    if not plan:
+        print(json.dumps({"verdict": "PASS",
+                           "reason": "no fixtures declare pre_state"}))
+        return 0
+
+    if args.dry_run:
+        print(json.dumps({
+            "verdict": "DRY_RUN",
+            "would_check": [
+                {"goal": p["goal"],
+                 "endpoint": p.get("lifecycle", {}).get("pre_state", {}).get("endpoint")}
+                for p in plan if "lifecycle" in p
+            ],
+            "errors": [p for p in plan if "error" in p],
+        }, indent=2))
+        return 0
+
+    base_url = args.base_url or os.environ.get("VG_BASE_URL")
+    if not base_url:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": "no --base-url and VG_BASE_URL not set",
+        }))
+        return 2
+
+    config_path = Path(args.vg_config) if args.vg_config else \
+        (repo / ".claude" / "vg.config.md")
+    credentials_map = _load_credentials_map(config_path)
+    if not credentials_map:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": (
+                f"credentials_map empty — load from {config_path} OR set "
+                f"VG_CREDENTIALS_JSON env var."
+            ),
+        }))
+        return 2
+
+    try:
+        from runtime.recipe_executor import RecipeRunner
+    except ImportError as e:
+        print(json.dumps({
+            "verdict": "ERROR",
+            "error": f"recipe_executor import failed: {e}",
+        }))
+        return 2
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map=credentials_map,
+    )
+
+    def get_fn(role: str, endpoint: str) -> dict:
+        auth = runner._auth_context(role)
+        url = base_url.rstrip("/") + endpoint
+        resp = auth.session.get(url, timeout=runner.request_timeout)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"{resp.status_code}: {resp.text[:120]}")
+        try:
+            return resp.json() if resp.text else {}
+        except Exception:
+            return {}
+
+    results = []
+    failed_count = 0
+    for entry in plan:
+        if "error" in entry:
+            results.append({"goal": entry["goal"], "passed": False,
+                             "errors": [entry["error"]]})
+            failed_count += 1
+            continue
+        try:
+            res = run_pre_state(entry["goal"], entry["lifecycle"], get_fn)
+            results.append({
+                "goal": res.goal_id,
+                "passed": res.pre_state_passed,
+                "skipped": res.skipped_reason,
+                "errors": res.pre_state_failures,
+            })
+            if not res.pre_state_passed and res.skipped_reason is None:
+                failed_count += 1
+        except LifecycleGateError as e:
+            results.append({"goal": entry["goal"], "passed": False,
+                             "errors": [str(e)]})
+            failed_count += 1
+
+    if failed_count == 0:
+        print(json.dumps({
+            "verdict": "PASS",
+            "phase": args.phase,
+            "checked": len(plan),
+            "results": results,
+        }, indent=2))
+        return 0
+
+    verdict = "BLOCK" if args.severity == "block" else "WARN"
+    print(json.dumps({
+        "verdict": verdict,
+        "phase": args.phase,
+        "failed": failed_count,
+        "checked": len(plan),
+        "results": results,
+    }, indent=2))
+    return 1 if verdict == "BLOCK" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rcrurd-preflight.py
+++ b/scripts/rcrurd-preflight.py
@@ -37,7 +37,9 @@ except ImportError:
     print(json.dumps({"verdict": "ERROR", "error": "PyYAML required"}))
     sys.exit(2)
 
-from runtime.rcrurd_gate import run_pre_state, LifecycleGateError  # noqa: E402
+from runtime.rcrurd_gate import (  # noqa: E402
+    LifecycleGateError, run_post_state_with_retry, run_pre_state,
+)
 
 
 def _find_phase_dir(repo: Path, phase: str) -> Path | None:
@@ -86,7 +88,10 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--phase", required=True)
     ap.add_argument("--base-url", help="Sandbox API root URL (or VG_BASE_URL)")
-    ap.add_argument("--severity", choices=["block", "warn"], default="warn")
+    ap.add_argument("--severity", choices=["block", "warn"], default="block")
+    ap.add_argument("--mode", choices=["pre", "post"], default="pre",
+                    help="pre = pre_state at review entry (default); "
+                         "post = post_state after action (Codex-HIGH-1 wiring)")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--only", help="Comma-separated goal IDs to check")
     ap.add_argument("--repo-root", default=None)
@@ -127,21 +132,28 @@ def main() -> int:
             plan.append({"goal": gid, "error": "not an object"})
             continue
         lifecycle = recipe.get("lifecycle")
-        if not isinstance(lifecycle, dict) or "pre_state" not in lifecycle:
-            continue  # no pre_state to check
+        if not isinstance(lifecycle, dict):
+            continue
+        # Mode determines which leg of the lifecycle to assert
+        required_key = "pre_state" if args.mode == "pre" else "post_state"
+        if required_key not in lifecycle:
+            continue
         plan.append({"goal": gid, "lifecycle": lifecycle})
 
     if not plan:
+        leg = "pre_state" if args.mode == "pre" else "post_state"
         print(json.dumps({"verdict": "PASS",
-                           "reason": "no fixtures declare pre_state"}))
+                           "reason": f"no fixtures declare {leg}"}))
         return 0
 
     if args.dry_run:
+        leg_key = "pre_state" if args.mode == "pre" else "post_state"
         print(json.dumps({
             "verdict": "DRY_RUN",
+            "mode": args.mode,
             "would_check": [
                 {"goal": p["goal"],
-                 "endpoint": p.get("lifecycle", {}).get("pre_state", {}).get("endpoint")}
+                 "endpoint": p.get("lifecycle", {}).get(leg_key, {}).get("endpoint")}
                 for p in plan if "lifecycle" in p
             ],
             "errors": [p for p in plan if "error" in p],
@@ -204,15 +216,38 @@ def main() -> int:
             failed_count += 1
             continue
         try:
-            res = run_pre_state(entry["goal"], entry["lifecycle"], get_fn)
-            results.append({
-                "goal": res.goal_id,
-                "passed": res.pre_state_passed,
-                "skipped": res.skipped_reason,
-                "errors": res.pre_state_failures,
-            })
-            if not res.pre_state_passed and res.skipped_reason is None:
-                failed_count += 1
+            if args.mode == "pre":
+                res = run_pre_state(entry["goal"], entry["lifecycle"], get_fn)
+                results.append({
+                    "goal": res.goal_id,
+                    "passed": res.pre_state_passed,
+                    "skipped": res.skipped_reason,
+                    "errors": res.pre_state_failures,
+                })
+                if not res.pre_state_passed and res.skipped_reason is None:
+                    failed_count += 1
+            else:  # post
+                # Capture pre_payload for increased_by_at_least delta checks
+                pre_payload = None
+                pre_block = entry["lifecycle"].get("pre_state") or {}
+                if pre_block.get("endpoint") and pre_block.get("role"):
+                    try:
+                        pre_payload = get_fn(pre_block["role"],
+                                              pre_block["endpoint"])
+                    except Exception:
+                        pre_payload = None  # best-effort
+                res = run_post_state_with_retry(
+                    entry["goal"], entry["lifecycle"], get_fn,
+                    pre_payload=pre_payload,
+                )
+                results.append({
+                    "goal": res.goal_id,
+                    "passed": res.post_state_passed,
+                    "skipped": res.skipped_reason,
+                    "errors": res.post_state_failures,
+                })
+                if not res.post_state_passed and res.skipped_reason is None:
+                    failed_count += 1
         except LifecycleGateError as e:
             results.append({"goal": entry["goal"], "passed": False,
                              "errors": [str(e)]})
@@ -221,6 +256,7 @@ def main() -> int:
     if failed_count == 0:
         print(json.dumps({
             "verdict": "PASS",
+            "mode": args.mode,
             "phase": args.phase,
             "checked": len(plan),
             "results": results,
@@ -230,6 +266,7 @@ def main() -> int:
     verdict = "BLOCK" if args.severity == "block" else "WARN"
     print(json.dumps({
         "verdict": verdict,
+        "mode": args.mode,
         "phase": args.phase,
         "failed": failed_count,
         "checked": len(plan),

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -1,0 +1,40 @@
+"""Recipe runtime — RFC v9 native Python orchestrator.
+
+Modules:
+- recipe_loader: parse YAML + jsonschema validate against fixture-recipe.v1.json
+- recipe_capture: JSONPath capture with cardinality enforcement (RFC 9535)
+- recipe_interpolate: ${var} interpolation from captured store
+- recipe_executor (PR-A2): API execution + 4 auth handlers + sandbox safety
+- fixture_cache (PR-A3): FIXTURES-CACHE.json + lease management
+
+Public surface (PR-A1):
+- load_recipe(path) → dict
+- ValidationError on schema mismatch
+- capture_paths(payload, capture_spec) → dict[str, Any]
+- interpolate(template, store) → resolved string
+
+Stability: schema_version: "1.0" pinned. Major bump rejected at load time.
+"""
+from .recipe_loader import load_recipe, ValidationError
+from .recipe_capture import capture_paths, CaptureError
+from .recipe_interpolate import interpolate, InterpolationError
+from .recipe_safety import assert_step_safe, SandboxSafetyError, is_sentinel_value
+from .recipe_auth import authenticate, AuthContext, AuthError
+from .recipe_executor import RecipeRunner, RecipeExecutionError
+
+__all__ = [
+    "load_recipe",
+    "ValidationError",
+    "capture_paths",
+    "CaptureError",
+    "interpolate",
+    "InterpolationError",
+    "assert_step_safe",
+    "SandboxSafetyError",
+    "is_sentinel_value",
+    "authenticate",
+    "AuthContext",
+    "AuthError",
+    "RecipeRunner",
+    "RecipeExecutionError",
+]

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -46,9 +46,16 @@ from .preflight import (
 from .recipe_loader import load_recipe, ValidationError
 from .recipe_capture import capture_paths, CaptureError
 from .recipe_interpolate import interpolate, InterpolationError
-from .recipe_safety import assert_step_safe, SandboxSafetyError, is_sentinel_value
+from .recipe_safety import (
+    SandboxEchoMissingError,
+    SandboxSafetyError,
+    assert_response_echo,
+    assert_step_safe,
+    assert_url_in_allowlist,
+    is_sentinel_value,
+)
 from .recipe_auth import authenticate, AuthContext, AuthError
-from .recipe_executor import RecipeRunner, RecipeExecutionError
+from .recipe_executor import AuthDegradedError, RecipeRunner, RecipeExecutionError
 
 __all__ = [
     "load_recipe",
@@ -58,8 +65,12 @@ __all__ = [
     "interpolate",
     "InterpolationError",
     "assert_step_safe",
+    "assert_url_in_allowlist",
+    "assert_response_echo",
     "SandboxSafetyError",
+    "SandboxEchoMissingError",
     "is_sentinel_value",
+    "AuthDegradedError",
     "authenticate",
     "AuthContext",
     "AuthError",

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -15,6 +15,20 @@ Public surface (PR-A1):
 
 Stability: schema_version: "1.0" pinned. Major bump rejected at load time.
 """
+from .fixture_cache import (
+    CacheError,
+    LeaseError,
+    acquire_lease,
+    find_orphans,
+    get_captured,
+    load as cache_load,
+    reap_expired_leases,
+    reap_orphans,
+    recipe_hash,
+    release_lease,
+    save as cache_save,
+    write_captured,
+)
 from .recipe_loader import load_recipe, ValidationError
 from .recipe_capture import capture_paths, CaptureError
 from .recipe_interpolate import interpolate, InterpolationError
@@ -37,4 +51,16 @@ __all__ = [
     "AuthError",
     "RecipeRunner",
     "RecipeExecutionError",
+    "CacheError",
+    "LeaseError",
+    "acquire_lease",
+    "release_lease",
+    "write_captured",
+    "get_captured",
+    "find_orphans",
+    "reap_orphans",
+    "reap_expired_leases",
+    "recipe_hash",
+    "cache_load",
+    "cache_save",
 ]

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -29,6 +29,14 @@ from .fixture_cache import (
     save as cache_save,
     write_captured,
 )
+from .preflight import (
+    InvariantGap,
+    PreflightError,
+    fix_hint,
+    parse_env_contract,
+    required_count,
+    verify_invariants,
+)
 from .recipe_loader import load_recipe, ValidationError
 from .recipe_capture import capture_paths, CaptureError
 from .recipe_interpolate import interpolate, InterpolationError
@@ -63,4 +71,10 @@ __all__ = [
     "recipe_hash",
     "cache_load",
     "cache_save",
+    "InvariantGap",
+    "PreflightError",
+    "parse_env_contract",
+    "required_count",
+    "verify_invariants",
+    "fix_hint",
 ]

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -29,6 +29,12 @@ from .fixture_cache import (
     save as cache_save,
     write_captured,
 )
+from .api_index import (
+    ApiIndexError,
+    ResourceCounter,
+    count_fn_factory,
+    parse_api_index,
+)
 from .preflight import (
     InvariantGap,
     PreflightError,
@@ -77,4 +83,8 @@ __all__ = [
     "required_count",
     "verify_invariants",
     "fix_hint",
+    "ApiIndexError",
+    "ResourceCounter",
+    "count_fn_factory",
+    "parse_api_index",
 ]

--- a/scripts/runtime/api_index.py
+++ b/scripts/runtime/api_index.py
@@ -1,0 +1,186 @@
+"""Parse api_index from ENV-CONTRACT.md (RFC v9 PR-C wiring).
+
+`api_index` maps logical resource names to:
+- count_endpoint: GET endpoint that returns a count or list-with-meta
+- count_jsonpath: JSONPath into the response body to extract an integer
+- count_role: which credentials_map role to authenticate as
+
+ENV-CONTRACT.md fragment:
+```yaml
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+    count_query_keys: [tier, status]   # which `where` keys map to query params
+  withdraw:
+    count_endpoint: /api/admin/withdraw
+    count_jsonpath: $.data.length
+    count_role: admin
+```
+
+Used by preflight.verify_invariants's count_fn — for every invariant
+`{resource: topup, where: {tier:2, status:pending}}`, the count_fn:
+1. Looks up api_index[topup].
+2. Builds GET {count_endpoint}?tier=2&status=pending (only count_query_keys
+   passed through; extras dropped to avoid backend confusion).
+3. Authenticates as count_role.
+4. Captures count_jsonpath into an integer.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+class ApiIndexError(Exception):
+    """api_index missing, malformed, or incomplete for a requested resource."""
+
+
+@dataclass
+class ResourceCounter:
+    resource: str
+    count_endpoint: str
+    count_jsonpath: str
+    count_role: str
+    count_query_keys: list[str] = field(default_factory=list)
+
+
+def parse_api_index(path: Path | str) -> dict[str, ResourceCounter]:
+    """Extract `api_index:` block from ENV-CONTRACT.md.
+
+    Same parsing strategy as preflight.parse_env_contract — accepts both
+    fenced ```yaml block and pure-yaml file.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    if yaml is None:
+        raise ApiIndexError("PyYAML required for ENV-CONTRACT parsing")
+
+    parsed: Any = None
+    blocks = re.findall(r"```ya?ml\s*\n(.*?)\n```", text, re.DOTALL)
+    for block in blocks:
+        if "api_index:" in block:
+            try:
+                parsed = yaml.safe_load(block)
+                if isinstance(parsed, dict) and "api_index" in parsed:
+                    break
+            except yaml.YAMLError as e:
+                raise ApiIndexError(f"Malformed YAML block in ENV-CONTRACT: {e}") from e
+            parsed = None
+    if parsed is None:
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError:
+            return {}
+        if not isinstance(parsed, dict) or "api_index" not in parsed:
+            return {}
+
+    raw = parsed.get("api_index") or {}
+    if not isinstance(raw, dict):
+        raise ApiIndexError(f"api_index must be object, got {type(raw).__name__}")
+
+    out: dict[str, ResourceCounter] = {}
+    for resource, spec in raw.items():
+        if not isinstance(spec, dict):
+            raise ApiIndexError(f"api_index['{resource}'] must be object")
+        for required in ("count_endpoint", "count_jsonpath", "count_role"):
+            if required not in spec:
+                raise ApiIndexError(
+                    f"api_index['{resource}'] missing '{required}'"
+                )
+        out[str(resource)] = ResourceCounter(
+            resource=str(resource),
+            count_endpoint=str(spec["count_endpoint"]),
+            count_jsonpath=str(spec["count_jsonpath"]),
+            count_role=str(spec["count_role"]),
+            count_query_keys=[str(k) for k in (spec.get("count_query_keys") or [])],
+        )
+    return out
+
+
+def count_fn_factory(
+    api_index: dict[str, ResourceCounter],
+    runner: Any,  # RecipeRunner — duck-typed to avoid circular import
+):
+    """Return a count_fn(resource, where) → int closing over runner + index.
+
+    Drops `where` keys not in count_query_keys (when configured) so the
+    backend doesn't 400 on unknown query params. When count_query_keys is
+    empty, all keys pass through.
+    """
+    from .recipe_capture import capture_paths
+
+    def count_fn(resource: str, where: dict[str, Any]) -> int:
+        spec = api_index.get(resource)
+        if spec is None:
+            raise ApiIndexError(
+                f"api_index has no entry for resource '{resource}'. "
+                f"Add it to ENV-CONTRACT.md api_index block, or remove the "
+                f"invariant referencing it."
+            )
+        # Filter where → query params per count_query_keys allowlist
+        if spec.count_query_keys:
+            params = {
+                k: v for k, v in where.items() if k in spec.count_query_keys
+            }
+        else:
+            params = dict(where)
+
+        auth = runner._auth_context(spec.count_role)
+        url = runner.base_url.rstrip("/") + spec.count_endpoint
+        resp = auth.session.get(url, params=params, timeout=runner.request_timeout)
+        if resp.status_code >= 400:
+            raise ApiIndexError(
+                f"count GET {spec.count_endpoint} for resource '{resource}' "
+                f"returned {resp.status_code}: {resp.text[:200]}"
+            )
+        try:
+            payload = resp.json() if resp.text else {}
+        except Exception as e:
+            raise ApiIndexError(f"count response not JSON: {e}") from e
+
+        # Capture as array first; treat single-match as scalar, multi-match as len.
+        captured = capture_paths(
+            payload,
+            {"_n": {"path": spec.count_jsonpath, "cardinality": "array",
+                    "on_empty": "null"}},
+        )
+        matches = captured.get("_n")
+
+        if matches is None or matches == []:
+            return 0
+        if len(matches) == 1:
+            value = matches[0]
+            if isinstance(value, bool):  # bool subclasses int — reject
+                raise ApiIndexError(
+                    f"count_jsonpath '{spec.count_jsonpath}' resolved to bool"
+                )
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float) and value.is_integer():
+                return int(value)
+            if isinstance(value, str):
+                try:
+                    return int(value)
+                except ValueError:
+                    raise ApiIndexError(
+                        f"count_jsonpath '{spec.count_jsonpath}' resolved to "
+                        f"non-numeric string {value!r}"
+                    )
+            if isinstance(value, list):
+                return len(value)
+            raise ApiIndexError(
+                f"count_jsonpath '{spec.count_jsonpath}' resolved to "
+                f"{type(value).__name__}={value!r}; expected int, str, or list"
+            )
+        # Multi-match: caller asked for an array path → count is the list size
+        return len(matches)
+
+    return count_fn

--- a/scripts/runtime/block_aggregator.py
+++ b/scripts/runtime/block_aggregator.py
@@ -1,0 +1,135 @@
+"""D28 multi-Type-A BLOCK aggregator (RFC v9 PR-block-aggregator).
+
+When a /vg:* run hits N gate failures of the same family (e.g., 12 missing
+artifacts, 8 traceability orphans), invoking block-resolver L2 N times
+spends N × architect-spawn token cost. Aggregator collects same-family
+blocks into ONE proposal request — architect sees all N instances in a
+single context window, returns a multi-fix proposal that the resolver
+applies in a single pass.
+
+Aggregator policy:
+- Group key: gate_id (e.g., "review-prereq-missing", "traceability-orphan")
+- Threshold: aggregate when count ≥ 3 (configurable)
+- Below threshold: pass through unchanged (single-block path)
+- Sort instances by severity then chronologically
+- Cap merged context at config.max_merged_evidence (default 50 instances)
+
+Output shape mirrors single-block input so block-resolver consumes
+without modification.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class BlockInstance:
+    gate_id: str
+    family: str
+    severity: str = "block"  # block | warn | advisory
+    evidence: dict[str, Any] = field(default_factory=dict)
+    timestamp: str | None = None
+
+
+@dataclass
+class AggregatedBlock:
+    gate_id: str
+    family: str
+    instance_count: int
+    severity: str
+    instances: list[BlockInstance]
+    sample_evidence: list[dict[str, Any]]
+    merged_context: str
+
+    @property
+    def is_aggregated(self) -> bool:
+        return self.instance_count > 1
+
+
+SEVERITY_RANK = {"block": 3, "warn": 2, "advisory": 1}
+
+
+def aggregate(
+    instances: list[BlockInstance],
+    *,
+    threshold: int = 3,
+    max_merged_evidence: int = 50,
+) -> list[AggregatedBlock]:
+    """Group block instances by gate_id and emit aggregated or passthrough.
+
+    Threshold rule: groups with size ≥ threshold → AggregatedBlock with
+    merged context. Smaller groups → AggregatedBlock with instance_count=1
+    (the single-block path; resolver treats it as one-shot).
+    """
+    by_family: dict[str, list[BlockInstance]] = {}
+    for inst in instances:
+        if not isinstance(inst, BlockInstance):
+            raise TypeError(f"expected BlockInstance, got {type(inst).__name__}")
+        by_family.setdefault(inst.gate_id, []).append(inst)
+
+    out: list[AggregatedBlock] = []
+    for gate_id, group in by_family.items():
+        # Sort: highest severity first, then by timestamp ascending
+        group_sorted = sorted(
+            group,
+            key=lambda i: (
+                -SEVERITY_RANK.get(i.severity, 0),
+                i.timestamp or "",
+            ),
+        )
+        capped = group_sorted[:max_merged_evidence]
+        max_sev = max(group_sorted, key=lambda i: SEVERITY_RANK.get(i.severity, 0))
+        family = capped[0].family
+        merged = _merge_context(capped, len(group_sorted), max_merged_evidence)
+        out.append(AggregatedBlock(
+            gate_id=gate_id,
+            family=family,
+            instance_count=len(group_sorted),
+            severity=max_sev.severity,
+            instances=capped,
+            sample_evidence=[i.evidence for i in capped[:5]],
+            merged_context=merged,
+        ))
+    # Sort output: aggregated (size ≥ threshold) first, then singletons
+    out.sort(key=lambda a: (
+        0 if a.instance_count >= threshold else 1,
+        -a.instance_count,
+    ))
+    return out
+
+
+def _merge_context(
+    instances: list[BlockInstance],
+    total: int,
+    cap: int,
+) -> str:
+    """Render a markdown-ish context blob the architect can read."""
+    lines = [f"# Aggregated BLOCK: {instances[0].gate_id}",
+             f"Total instances: {total}"]
+    if total > cap:
+        lines.append(f"⚠ Capped to first {cap} instances (sorted by severity)")
+    lines.append("")
+    lines.append("## Instances")
+    for i, inst in enumerate(instances, 1):
+        lines.append(f"### {i}. severity={inst.severity}")
+        if inst.timestamp:
+            lines.append(f"- timestamp: {inst.timestamp}")
+        if inst.evidence:
+            lines.append("- evidence:")
+            for k, v in inst.evidence.items():
+                lines.append(f"  - {k}: {v!r}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def should_aggregate(
+    instances: list[BlockInstance],
+    *,
+    threshold: int = 3,
+) -> bool:
+    """Convenience: True if any gate_id family has ≥ threshold instances."""
+    counts: dict[str, int] = {}
+    for inst in instances:
+        counts[inst.gate_id] = counts.get(inst.gate_id, 0) + 1
+    return any(n >= threshold for n in counts.values())

--- a/scripts/runtime/block_aggregator.py
+++ b/scripts/runtime/block_aggregator.py
@@ -41,10 +41,15 @@ class AggregatedBlock:
     instances: list[BlockInstance]
     sample_evidence: list[dict[str, Any]]
     merged_context: str
+    threshold_used: int = 3  # Codex-MEDIUM follow-up: track threshold for routing decision
 
     @property
     def is_aggregated(self) -> bool:
-        return self.instance_count > 1
+        """True only when instance_count crosses the threshold the caller
+        used to build the aggregator. Codex MEDIUM fix: previously returned
+        True for instance_count > 1 unconditionally, which conflicted with
+        should_aggregate(threshold=3) semantics. Now both align."""
+        return self.instance_count >= self.threshold_used
 
 
 SEVERITY_RANK = {"block": 3, "warn": 2, "advisory": 1}
@@ -90,6 +95,7 @@ def aggregate(
             instances=capped,
             sample_evidence=[i.evidence for i in capped[:5]],
             merged_context=merged,
+            threshold_used=threshold,
         ))
     # Sort output: aggregated (size ≥ threshold) first, then singletons
     out.sort(key=lambda a: (

--- a/scripts/runtime/content_depth.py
+++ b/scripts/runtime/content_depth.py
@@ -1,0 +1,152 @@
+"""D27 anti-skim content-depth validators (RFC v9 PR-content-depth).
+
+Closes the failure mode where AI authors bare-minimum sections to pass
+schema gates: "## Edge cases\n- TBD\n" technically satisfies "section
+exists" but adds zero value. The validators below catch this:
+
+1. word_count(text, min) — section body has minimum substantive words
+2. cross_reference(refs_in_doc, decisions_required, ...) — every required
+   decision/contract anchor is referenced
+3. edge_case_substance(section_text) — listed edge cases have non-trivial
+   bodies (not just bullets with "TBD"/"N/A")
+4. instruction_repetition(text, key_phrases) — required instruction
+   phrases reappear at the right cadence (catches "AI skim" where the
+   instruction is ack'd at top but ignored later)
+
+Each returns a (passed, failure_message) tuple so the caller can compose
+into a single validator output JSON.
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Iterable
+
+
+_WORD_RE = re.compile(r"\b\w+\b", re.UNICODE)
+_BULLET_LINE_RE = re.compile(r"^\s*[-*+]\s+(.+?)$", re.MULTILINE)
+_TBD_LINE_RE = re.compile(
+    r"^\s*[-*+]\s*(?:TBD|TODO|N/?A|none|tbd|todo|chưa|cần\s*bổ\s*sung)\s*\.?\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def word_count(text: str, *, min_words: int) -> tuple[bool, str | None]:
+    """Substantive word count (excludes punctuation but counts inside code/quotes)."""
+    n = len(_WORD_RE.findall(text or ""))
+    if n < min_words:
+        return False, f"word_count={n} < min={min_words}"
+    return True, None
+
+
+def cross_reference(
+    text: str,
+    *,
+    required_anchors: Iterable[str],
+    min_unique: int | None = None,
+) -> tuple[bool, str | None]:
+    """Every required_anchors must appear at least once in `text`."""
+    found = []
+    missing = []
+    for anchor in required_anchors:
+        if anchor and anchor in text:
+            found.append(anchor)
+        elif anchor:
+            missing.append(anchor)
+    if missing:
+        return False, f"missing cross-references: {missing[:10]}"
+    if min_unique is not None and len(found) < min_unique:
+        return False, f"only {len(found)} unique anchors (min={min_unique})"
+    return True, None
+
+
+def edge_case_substance(
+    section_text: str,
+    *,
+    min_bullets_with_body: int = 3,
+    bullet_min_words: int = 8,
+) -> tuple[bool, str | None]:
+    """Edge case section must have N bullets each with substantive body.
+
+    Definition of substantive:
+    - Bullet line ≥ bullet_min_words.
+    - NOT a TBD-style placeholder (TBD/TODO/N/A/none/chưa/cần bổ sung).
+    """
+    placeholder_count = len(_TBD_LINE_RE.findall(section_text))
+    bullets = _BULLET_LINE_RE.findall(section_text)
+    substantive = [
+        b for b in bullets
+        if len(_WORD_RE.findall(b)) >= bullet_min_words
+        and not _TBD_LINE_RE.match(f"- {b}")
+    ]
+    if placeholder_count > 0:
+        return False, (
+            f"{placeholder_count} placeholder bullet(s) (TBD/TODO/N/A) — "
+            f"replace with concrete edge cases"
+        )
+    if len(substantive) < min_bullets_with_body:
+        return False, (
+            f"{len(substantive)} substantive bullets (≥{bullet_min_words} words each) "
+            f"< min={min_bullets_with_body}; total bullets={len(bullets)}"
+        )
+    return True, None
+
+
+def instruction_repetition(
+    text: str,
+    *,
+    key_phrase: str,
+    min_occurrences: int = 2,
+    case_insensitive: bool = True,
+) -> tuple[bool, str | None]:
+    """A critical instruction must appear ≥ min_occurrences times.
+
+    Catches the AI-skim pattern: instruction stated once at the top, then
+    ignored. Re-stating at relevant section anchors makes each step
+    locally enforceable.
+    """
+    flags = re.IGNORECASE if case_insensitive else 0
+    matches = re.findall(re.escape(key_phrase), text or "", flags=flags)
+    if len(matches) < min_occurrences:
+        return False, (
+            f"key phrase '{key_phrase}' occurs {len(matches)}× "
+            f"< min={min_occurrences}"
+        )
+    return True, None
+
+
+def llm_judge_sample(
+    sections: dict[str, str],
+    *,
+    sample_size: int = 3,
+    rng_seed: int = 0,
+) -> dict[str, str]:
+    """Pick a deterministic sample of sections for LLM-as-judge review.
+
+    Returns {section_name: text}. Caller forwards to a Haiku spawn that
+    rates substance: "is this section providing real value or surface fluff?"
+    Determinism allows reproducible CI.
+    """
+    import random
+    rng = random.Random(rng_seed)
+    keys = sorted(sections.keys())
+    if len(keys) <= sample_size:
+        return dict(sections)
+    sampled = rng.sample(keys, sample_size)
+    return {k: sections[k] for k in sampled}
+
+
+def aggregate_failures(
+    results: list[tuple[bool, str | None]],
+    *,
+    name: str,
+) -> dict:
+    """Combine multiple sub-checks into a single validator-shaped dict."""
+    failures = [msg for ok, msg in results if not ok and msg]
+    return {
+        "validator": name,
+        "verdict": "BLOCK" if failures else "PASS",
+        "failures": failures,
+        "checks_run": len(results),
+        "checks_passed": sum(1 for ok, _ in results if ok),
+    }

--- a/scripts/runtime/diagnostic_l2.py
+++ b/scripts/runtime/diagnostic_l2.py
@@ -1,0 +1,174 @@
+"""Layer 2 Diagnostic UX — universal Type-B BLOCK resolver (RFC v9 D11+D26+PR-D3).
+
+Layer 0 deterministic gate fails on a Type-B BLOCK (semantic, needs
+reasoning) → Layer 1 cheap auto-fix candidates fail too → Layer 2
+spawns a Diagnostic AI subagent in an isolated context window to:
+1. Survey the gate evidence + nearby files.
+2. Propose a fix with audit trail (layer2_proposal_id).
+3. Surface to user via SINGLE-ADVISORY (not 3-option menu — D26).
+
+D26 single-advisory pattern: when the right answer is clear, advise it
+straight: "Recommend: <fix>. Apply? [Y/n]". Don't fabricate alternatives
+just to feel democratic.
+
+This module owns the proposal lifecycle (open → applied|rejected) and
+emits the audit trail that the matrix-staleness validator and the
+evidence-provenance validator both consume to decide if a SUSPECTED →
+READY promotion is trustworthy.
+
+Storage: .vg/phases/{phase}/.l2-proposals/{proposal_id}.json
+Format:
+  {
+    "schema_version": "1.0",
+    "proposal_id": "l2-{epoch}-{rand6}",
+    "gate_id": "...",
+    "block_family": "missing-evidence|content-depth|...",
+    "evidence_in": {...},
+    "diagnosis": "...",
+    "proposed_fix": "...",
+    "confidence": 0.85,
+    "spawned_at": "2026-05-02T10:00:00Z",
+    "decided_at": null,
+    "decision": null,        # accepted | rejected | applied
+    "applied_artifacts": []  # paths touched during fix
+  }
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class L2Proposal:
+    proposal_id: str
+    gate_id: str
+    block_family: str
+    evidence_in: dict[str, Any]
+    diagnosis: str
+    proposed_fix: str
+    confidence: float
+    spawned_at: str
+    schema_version: str = SCHEMA_VERSION
+    decided_at: str | None = None
+    decision: str | None = None  # accepted | rejected | applied
+    applied_artifacts: list[str] = field(default_factory=list)
+
+
+def proposal_dir(phase_dir: Path) -> Path:
+    return phase_dir / ".l2-proposals"
+
+
+def new_proposal_id() -> str:
+    epoch = int(time.time())
+    rand6 = secrets.token_hex(3)
+    return f"l2-{epoch}-{rand6}"
+
+
+def render_single_advisory(
+    proposal: L2Proposal,
+    *,
+    locale: str = "vi",
+) -> str:
+    """Render a tight Vietnamese-default advisory body for AskUserQuestion.
+
+    D26 anti-pattern: don't list 3 fake options when one fix is clearly
+    correct. Lead with the recommendation, explain why, ask Y/n.
+    """
+    if locale == "vi":
+        return (
+            f"⚠ {proposal.gate_id}\n\n"
+            f"Chẩn đoán: {proposal.diagnosis}\n\n"
+            f"Đề xuất sửa (confidence={proposal.confidence:.0%}):\n"
+            f"  {proposal.proposed_fix}\n\n"
+            f"Áp dụng đề xuất này? [Y]es / [n]o / [d]etails"
+        )
+    return (
+        f"⚠ {proposal.gate_id}\n\n"
+        f"Diagnosis: {proposal.diagnosis}\n\n"
+        f"Recommended fix (confidence={proposal.confidence:.0%}):\n"
+        f"  {proposal.proposed_fix}\n\n"
+        f"Apply? [Y]es / [n]o / [d]etails"
+    )
+
+
+def write_proposal(phase_dir: Path, proposal: L2Proposal) -> Path:
+    pdir = proposal_dir(phase_dir)
+    pdir.mkdir(parents=True, exist_ok=True)
+    target = pdir / f"{proposal.proposal_id}.json"
+    target.write_text(
+        json.dumps(asdict(proposal), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def load_proposal(phase_dir: Path, proposal_id: str) -> L2Proposal:
+    path = proposal_dir(phase_dir) / f"{proposal_id}.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return L2Proposal(**data)
+
+
+def record_decision(
+    phase_dir: Path,
+    proposal_id: str,
+    decision: str,
+    *,
+    applied_artifacts: list[str] | None = None,
+) -> L2Proposal:
+    """Mark proposal accepted | rejected | applied. Returns updated proposal."""
+    if decision not in {"accepted", "rejected", "applied"}:
+        raise ValueError(f"unknown decision: {decision}")
+    proposal = load_proposal(phase_dir, proposal_id)
+    proposal.decision = decision
+    proposal.decided_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    if applied_artifacts:
+        proposal.applied_artifacts = list(applied_artifacts)
+    write_proposal(phase_dir, proposal)
+    return proposal
+
+
+def list_open_proposals(phase_dir: Path) -> list[L2Proposal]:
+    """Return proposals without a decision (still pending user/system)."""
+    pdir = proposal_dir(phase_dir)
+    if not pdir.exists():
+        return []
+    out: list[L2Proposal] = []
+    for f in sorted(pdir.glob("l2-*.json")):
+        try:
+            p = L2Proposal(**json.loads(f.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if p.decision is None:
+            out.append(p)
+    return out
+
+
+def make_proposal(
+    *,
+    gate_id: str,
+    block_family: str,
+    evidence_in: dict[str, Any],
+    diagnosis: str,
+    proposed_fix: str,
+    confidence: float,
+) -> L2Proposal:
+    """Construct a new proposal (NOT yet persisted — caller invokes write_proposal)."""
+    return L2Proposal(
+        proposal_id=new_proposal_id(),
+        gate_id=gate_id,
+        block_family=block_family,
+        evidence_in=evidence_in,
+        diagnosis=diagnosis,
+        proposed_fix=proposed_fix,
+        confidence=max(0.0, min(1.0, confidence)),
+        spawned_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )

--- a/scripts/runtime/fixture_cache.py
+++ b/scripts/runtime/fixture_cache.py
@@ -1,0 +1,278 @@
+"""FIXTURES-CACHE.json — RFC v9 D2/D13 cross-run state.
+
+What lives in the cache:
+- Captured values from the last successful recipe execution (so /vg:test
+  codegen can reuse `pending_id` etc. without re-running mutations).
+- Lease metadata (RFC v9 D13 concurrency): owner_session, expires_at,
+  recipe_hash. Two parallel /vg:review sessions cannot both consume the
+  same destructive fixture row.
+- Cache key = sha256 of recipe text. Recipe edit invalidates cache.
+
+File layout:
+    .vg/phases/{phase}/FIXTURES-CACHE.json
+    {
+      "schema_version": "1.0",
+      "entries": {
+        "G-10": {
+          "recipe_hash": "sha256:abc...",
+          "captured": { "pending_id": "...", "amount": 0.01 },
+          "lease": {
+            "owner_session": "vg-3.2-review-12345",
+            "expires_at": "2026-05-02T10:30:00Z",
+            "consume_semantics": "destructive"
+          },
+          "executed_at": "2026-05-02T10:00:00Z"
+        }
+      }
+    }
+
+Concurrency model: file-locked write via fcntl.LOCK_EX (POSIX). Atomic
+rename on save. Stale leases (expired) are reapable by any session — TTL
+acts as a lease watchdog so a crashed session can't hold a fixture forever.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = "1.0"
+
+
+class CacheError(Exception):
+    """Cache I/O or state error."""
+
+
+class LeaseError(Exception):
+    """Lease conflict (someone else owns destructive fixture)."""
+
+
+def recipe_hash(recipe_text: str) -> str:
+    return "sha256:" + hashlib.sha256(recipe_text.encode("utf-8")).hexdigest()
+
+
+def cache_path(phase_dir: Path) -> Path:
+    return phase_dir / "FIXTURES-CACHE.json"
+
+
+@contextmanager
+def _exclusive_lock(path: Path, timeout_s: float = 5.0) -> Iterator[None]:
+    """fcntl-based exclusive lock on a sidecar .lock file.
+
+    POSIX-only. Times out after `timeout_s` to avoid hangs from crashed
+    sessions that left the lock acquired (rare — fcntl release on process
+    exit, but defensive).
+    """
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    deadline = time.time() + timeout_s
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (errno.EAGAIN, errno.EACCES):
+                    raise
+                if time.time() > deadline:
+                    raise CacheError(
+                        f"Could not acquire {lock_path} within {timeout_s}s"
+                    ) from e
+                time.sleep(0.05)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def load(phase_dir: Path) -> dict[str, Any]:
+    path = cache_path(phase_dir)
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "entries": {}}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise CacheError(f"FIXTURES-CACHE.json corrupt at {path}: {e}") from e
+
+
+def save(phase_dir: Path, data: dict[str, Any]) -> None:
+    path = cache_path(phase_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                    encoding="utf-8")
+    tmp.replace(path)
+
+
+def acquire_lease(
+    phase_dir: Path,
+    goal: str,
+    *,
+    owner_session: str,
+    consume_semantics: str,
+    ttl_seconds: int = 1800,
+    recipe_hash_value: str | None = None,
+) -> dict[str, Any]:
+    """Atomically claim a fixture row.
+
+    Rules:
+    - read_only: shared lease — any session can co-hold.
+    - destructive: exclusive — fail if another session's lease is unexpired.
+    - Expired leases are reapable (any session can take over).
+    - Same session re-acquiring its own lease extends expiry.
+    - recipe_hash mismatch → cache invalid; reset captured + take lease.
+    """
+    if consume_semantics not in {"read_only", "destructive"}:
+        raise LeaseError(f"unknown consume_semantics: {consume_semantics}")
+
+    path = cache_path(phase_dir)
+    with _exclusive_lock(path):
+        data = load(phase_dir)
+        entries = data.setdefault("entries", {})
+        entry = entries.get(goal) or {}
+        existing_lease = entry.get("lease") or {}
+        now = datetime.now(timezone.utc)
+        expires_at = now.timestamp() + ttl_seconds
+
+        if existing_lease:
+            try:
+                ex_t = datetime.fromisoformat(
+                    existing_lease["expires_at"].replace("Z", "+00:00")
+                ).timestamp()
+            except (KeyError, ValueError):
+                ex_t = 0
+            ex_owner = existing_lease.get("owner_session")
+            ex_sem = existing_lease.get("consume_semantics")
+            still_valid = ex_t > now.timestamp()
+
+            if still_valid and ex_owner != owner_session:
+                if ex_sem == "destructive" or consume_semantics == "destructive":
+                    raise LeaseError(
+                        f"Goal {goal} held by {ex_owner!r} (expires_at={existing_lease.get('expires_at')}); "
+                        f"consume_semantics={ex_sem}/{consume_semantics} → exclusive conflict"
+                    )
+
+        # Recipe hash drift → drop captured (stale)
+        if recipe_hash_value and entry.get("recipe_hash") and \
+                entry["recipe_hash"] != recipe_hash_value:
+            entry.pop("captured", None)
+
+        entry["lease"] = {
+            "owner_session": owner_session,
+            "expires_at": datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(timespec="seconds"),
+            "consume_semantics": consume_semantics,
+        }
+        if recipe_hash_value:
+            entry["recipe_hash"] = recipe_hash_value
+        entries[goal] = entry
+        save(phase_dir, data)
+        return entry["lease"]
+
+
+def release_lease(phase_dir: Path, goal: str, owner_session: str) -> bool:
+    """Drop lease only if owned by the session. Returns True if released."""
+    path = cache_path(phase_dir)
+    with _exclusive_lock(path):
+        data = load(phase_dir)
+        entries = data.get("entries") or {}
+        entry = entries.get(goal)
+        if not entry or "lease" not in entry:
+            return False
+        if entry["lease"].get("owner_session") != owner_session:
+            return False
+        del entry["lease"]
+        save(phase_dir, data)
+        return True
+
+
+def write_captured(
+    phase_dir: Path,
+    goal: str,
+    captured: dict[str, Any],
+    *,
+    owner_session: str,
+    recipe_hash_value: str | None = None,
+) -> None:
+    """Persist captured store after successful recipe run.
+
+    Idempotency: only the lease holder may write captured values.
+    """
+    path = cache_path(phase_dir)
+    with _exclusive_lock(path):
+        data = load(phase_dir)
+        entries = data.setdefault("entries", {})
+        entry = entries.get(goal) or {}
+        lease = entry.get("lease") or {}
+        if lease.get("owner_session") != owner_session:
+            raise LeaseError(
+                f"write_captured: goal {goal} not owned by {owner_session!r} "
+                f"(owner={lease.get('owner_session')!r})"
+            )
+        entry["captured"] = captured
+        entry["executed_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        if recipe_hash_value:
+            entry["recipe_hash"] = recipe_hash_value
+        entries[goal] = entry
+        save(phase_dir, data)
+
+
+def get_captured(phase_dir: Path, goal: str) -> dict[str, Any] | None:
+    """Return last successful captured store for goal (no lock)."""
+    data = load(phase_dir)
+    entry = (data.get("entries") or {}).get(goal) or {}
+    captured = entry.get("captured")
+    return dict(captured) if isinstance(captured, dict) else None
+
+
+def find_orphans(phase_dir: Path, known_goals: set[str]) -> list[str]:
+    """Return goals in cache that no longer exist in known_goals (TEST-GOALS)."""
+    data = load(phase_dir)
+    entries = data.get("entries") or {}
+    return [g for g in entries if g not in known_goals]
+
+
+def reap_orphans(phase_dir: Path, known_goals: set[str]) -> int:
+    """Remove cache entries for goals not in known_goals. Returns # removed."""
+    path = cache_path(phase_dir)
+    with _exclusive_lock(path):
+        data = load(phase_dir)
+        entries = data.get("entries") or {}
+        orphans = [g for g in entries if g not in known_goals]
+        for g in orphans:
+            del entries[g]
+        save(phase_dir, data)
+        return len(orphans)
+
+
+def reap_expired_leases(phase_dir: Path) -> int:
+    """Remove expired leases. Returns # removed."""
+    path = cache_path(phase_dir)
+    with _exclusive_lock(path):
+        data = load(phase_dir)
+        entries = data.get("entries") or {}
+        now_t = datetime.now(timezone.utc).timestamp()
+        n = 0
+        for g, entry in entries.items():
+            lease = entry.get("lease") or {}
+            try:
+                ex_t = datetime.fromisoformat(
+                    lease["expires_at"].replace("Z", "+00:00")
+                ).timestamp()
+            except (KeyError, ValueError):
+                continue
+            if ex_t < now_t:
+                del entry["lease"]
+                n += 1
+        save(phase_dir, data)
+        return n

--- a/scripts/runtime/pattern_catalog.py
+++ b/scripts/runtime/pattern_catalog.py
@@ -1,0 +1,157 @@
+"""D25 pattern catalog + selective web augmentation (RFC v9 PR-research-augment).
+
+Test-strategy step needs edge-case patterns. Web search is expensive, slow,
+non-deterministic. Pattern catalog is a curated local store of common
+edge cases per surface kind (auth, payments, file upload, etc.) that the
+strategy step queries first. Only on a catalog miss does it escalate to
+WebSearch.
+
+Catalog format (markdown frontmatter + body):
+    ---
+    id: payments-idempotency-collision
+    surface: api
+    tags: [payments, idempotency, retry]
+    severity: high
+    ---
+    Pattern: Same Idempotency-Key with different body returns the cached
+    response, not a 4xx — silent data corruption when caller retries with
+    drift.
+
+    Edge cases:
+    - Caller A POST {amt: 100, key: K}; Caller B POST {amt: 200, key: K}
+      → both see 100 receipt; B never billed.
+    ...
+
+API:
+    catalog = load_catalog(catalog_dir)
+    matches = match_patterns(catalog, surface="api", tags=["payments", "auth"])
+    if not matches:
+        # caller invokes WebSearch
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+
+_FRONTMATTER_RE = re.compile(
+    r"^---\s*\n(?P<fm>.*?)\n---\s*\n(?P<body>.*)$",
+    re.DOTALL,
+)
+
+
+@dataclass
+class Pattern:
+    id: str
+    surface: str
+    tags: list[str] = field(default_factory=list)
+    severity: str = "medium"
+    body: str = ""
+    path: Path | None = None
+
+
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Lightweight YAML-frontmatter parser (no full YAML dep needed for this format)."""
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm_lines = m.group("fm").splitlines()
+    body = m.group("body").strip()
+    out: dict = {}
+    current_key: str | None = None
+    for line in fm_lines:
+        if not line.strip():
+            continue
+        if line.startswith("  - ") and current_key is not None:
+            out.setdefault(current_key, []).append(line[4:].strip())
+            continue
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        k = k.strip()
+        v = v.strip()
+        current_key = k
+        if v.startswith("[") and v.endswith("]"):
+            inner = v[1:-1]
+            out[k] = [t.strip() for t in inner.split(",") if t.strip()]
+        elif v:
+            out[k] = v
+        else:
+            out[k] = []  # awaiting bullet items
+    return out, body
+
+
+def load_pattern(path: Path) -> Pattern:
+    text = path.read_text(encoding="utf-8")
+    fm, body = _parse_frontmatter(text)
+    if "id" not in fm:
+        raise ValueError(f"pattern at {path} missing id frontmatter")
+    if "surface" not in fm:
+        raise ValueError(f"pattern at {path} missing surface frontmatter")
+    tags = fm.get("tags", [])
+    if isinstance(tags, str):
+        tags = [tags]
+    return Pattern(
+        id=str(fm["id"]),
+        surface=str(fm["surface"]),
+        tags=[str(t) for t in tags],
+        severity=str(fm.get("severity", "medium")),
+        body=body,
+        path=path,
+    )
+
+
+def load_catalog(catalog_dir: Path) -> list[Pattern]:
+    if not catalog_dir.exists():
+        return []
+    out: list[Pattern] = []
+    for f in sorted(catalog_dir.glob("*.md")):
+        try:
+            out.append(load_pattern(f))
+        except ValueError:
+            continue  # skip malformed
+    return out
+
+
+def match_patterns(
+    catalog: list[Pattern],
+    *,
+    surface: str | None = None,
+    tags: Iterable[str] | None = None,
+    require_all_tags: bool = False,
+    severity_min: str | None = None,
+) -> list[Pattern]:
+    """Filter catalog by surface + tag overlap + severity floor."""
+    sev_rank = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+    floor = sev_rank.get(severity_min or "", 0)
+    tags_set = set(tags or [])
+
+    out: list[Pattern] = []
+    for p in catalog:
+        if surface and p.surface != surface:
+            continue
+        if tags_set:
+            p_tags = set(p.tags)
+            if require_all_tags:
+                if not tags_set.issubset(p_tags):
+                    continue
+            else:
+                if not (tags_set & p_tags):
+                    continue
+        if floor and sev_rank.get(p.severity, 2) < floor:
+            continue
+        out.append(p)
+    # Sort: high severity first, then by id for determinism
+    out.sort(key=lambda p: (-sev_rank.get(p.severity, 2), p.id))
+    return out
+
+
+def needs_web_augment(
+    matches: list[Pattern],
+    *,
+    min_matches: int = 2,
+) -> bool:
+    """Caller signal: catalog hit insufficient → escalate to WebSearch."""
+    return len(matches) < min_matches

--- a/scripts/runtime/preflight.py
+++ b/scripts/runtime/preflight.py
@@ -1,0 +1,156 @@
+"""data_invariants N-consumer preflight verifier (RFC v9 D5).
+
+Closes the wave-3.x non-convergence ping-pong: when 3 destructive consumers
+all run preflight checking "tier2 topup pending count >= 1", they each see 1
+row, each thinks they're fine, all three try to mutate it, two collide.
+
+D5 algorithm:
+1. Parse `data_invariants:` block from ENV-CONTRACT.md.
+2. Validate against schemas/data-invariants.v1.json.
+3. For each invariant:
+   destructive_n = count of consumers with consume_semantics='destructive'
+   read_only_n   = count of consumers with consume_semantics='read_only'
+   if isolation = 'per_consumer' (default):
+     required = destructive_n + (1 if read_only_n > 0 else 0)
+   if isolation = 'shared_when_read_only':
+     required = max(destructive_n, 1 if read_only_n > 0 else 0)
+4. Count actual entities via project-supplied count_fn(resource, where) → int.
+5. If actual < required → BLOCK with fix-hint listing the gap.
+
+The count_fn is pluggable so this verifier can be unit-tested without
+hitting an HTTP API. /vg:review wires count_fn to the recipe_executor.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+class PreflightError(Exception):
+    """data_invariants block missing, malformed, or unsatisfied."""
+
+
+@dataclass
+class InvariantGap:
+    invariant_id: str
+    resource: str
+    required: int
+    actual: int
+    consumers: list[str] = field(default_factory=list)
+    isolation: str = "per_consumer"
+    where: dict = field(default_factory=dict)
+
+
+def parse_env_contract(path: Path | str) -> list[dict]:
+    """Extract data_invariants[] from ENV-CONTRACT.md.
+
+    Format: a fenced ```yaml block starting with `data_invariants:` OR
+    a top-level YAML document (whole file is YAML). Both are supported.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    if yaml is None:
+        raise PreflightError("PyYAML required for ENV-CONTRACT parsing")
+
+    # Try fenced yaml block first
+    blocks = re.findall(r"```ya?ml\s*\n(.*?)\n```", text, re.DOTALL)
+    for block in blocks:
+        if "data_invariants:" in block:
+            try:
+                parsed = yaml.safe_load(block)
+            except yaml.YAMLError as e:
+                raise PreflightError(f"Malformed YAML block in ENV-CONTRACT: {e}") from e
+            if isinstance(parsed, dict) and "data_invariants" in parsed:
+                inv = parsed["data_invariants"]
+                if not isinstance(inv, list):
+                    raise PreflightError("data_invariants must be a list")
+                return inv
+
+    # Fall back: treat full file as YAML
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise PreflightError(f"ENV-CONTRACT not valid YAML: {e}") from e
+    if isinstance(parsed, dict) and "data_invariants" in parsed:
+        inv = parsed["data_invariants"]
+        if not isinstance(inv, list):
+            raise PreflightError("data_invariants must be a list")
+        return inv
+
+    return []
+
+
+def required_count(invariant: dict) -> int:
+    """Compute required entity count for an invariant per D5 algorithm."""
+    consumers = invariant.get("consumers") or []
+    if not consumers:
+        raise PreflightError(
+            f"invariant '{invariant.get('id')}' has no consumers (D5 expects ≥1)"
+        )
+    destructive_n = sum(1 for c in consumers if c.get("consume_semantics") == "destructive")
+    read_only_n = sum(1 for c in consumers if c.get("consume_semantics") == "read_only")
+    isolation = invariant.get("isolation", "per_consumer")
+
+    if isolation == "shared_when_read_only":
+        if destructive_n == 0 and read_only_n > 0:
+            return 1  # all read_only → share
+        return destructive_n  # any destructive → per_consumer fallback
+    if isolation == "per_consumer":
+        return destructive_n + (1 if read_only_n > 0 else 0)
+    raise PreflightError(
+        f"invariant '{invariant.get('id')}' unknown isolation='{isolation}'"
+    )
+
+
+CountFn = Callable[[str, dict[str, Any]], int]
+
+
+def verify_invariants(
+    invariants: list[dict],
+    count_fn: CountFn,
+) -> list[InvariantGap]:
+    """Returns gaps where actual < required.
+
+    count_fn(resource, where_filter) → int. Project supplies via
+    /vg:review wiring (uses recipe_executor against env's API).
+    """
+    gaps: list[InvariantGap] = []
+    for inv in invariants:
+        inv_id = inv.get("id")
+        resource = inv.get("resource")
+        where = inv.get("where") or {}
+        if not (inv_id and resource):
+            raise PreflightError(f"invariant missing id or resource: {inv}")
+        required = required_count(inv)
+        actual = count_fn(resource, where)
+        if actual < required:
+            consumer_ids = [c.get("goal", "?") for c in (inv.get("consumers") or [])]
+            gaps.append(InvariantGap(
+                invariant_id=inv_id,
+                resource=resource,
+                required=required,
+                actual=actual,
+                consumers=consumer_ids,
+                isolation=inv.get("isolation", "per_consumer"),
+                where=where,
+            ))
+    return gaps
+
+
+def fix_hint(gap: InvariantGap) -> str:
+    """Render a deterministic fix-hint for a gap."""
+    needed = gap.required - gap.actual
+    consumers_str = ", ".join(gap.consumers[:5])
+    return (
+        f"invariant {gap.invariant_id!r} on {gap.resource!r}: required={gap.required} "
+        f"(consumers: {consumers_str}), actual={gap.actual} → create {needed} more "
+        f"row(s) matching {gap.where!r}. Run /vg:review {{phase}} once consumers' "
+        f"FIXTURES recipes can populate the gap, OR adjust isolation to "
+        f"'shared_when_read_only' if all consumers are read_only."
+    )

--- a/scripts/runtime/rcrurd_gate.py
+++ b/scripts/runtime/rcrurd_gate.py
@@ -198,6 +198,11 @@ def run_post_state_with_retry(
             if "increased_by_at_least" in a and isinstance(pre_payload, (dict, list)):
                 _check_increase(a, pre_payload, payload, attempt_failures,
                                  endpoint=endpoint)
+            # Codex-R4-HIGH-1 fix: decreased_by_at_least was schema-declared
+            # but never evaluated → silent pass on failed decrease assertions.
+            if "decreased_by_at_least" in a and isinstance(pre_payload, (dict, list)):
+                _check_decrease(a, pre_payload, payload, attempt_failures,
+                                 endpoint=endpoint)
 
         if not attempt_failures:
             result.post_state_passed = True
@@ -255,5 +260,52 @@ def _check_increase(
     if delta < threshold:
         failures.append(
             f"increased_by_at_least {path}: delta={delta} < threshold={threshold} "
+            f"(pre={pre_n}, post={post_n} from {endpoint})"
+        )
+
+
+def _check_decrease(
+    assertion: dict[str, Any],
+    pre_payload: Any,
+    post_payload: Any,
+    failures: list[str],
+    *,
+    endpoint: str,
+) -> None:
+    """Codex-R4-HIGH-1 fix: mirror of _check_increase for decreases.
+    Threshold of 50 means post must be ≥ 50 LOWER than pre."""
+    path = assertion.get("path")
+    if not path:
+        return
+    try:
+        pre_v = capture_paths(
+            pre_payload,
+            {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+        ).get("_v", [])
+        post_v = capture_paths(
+            post_payload,
+            {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+        ).get("_v", [])
+    except CaptureError as e:
+        failures.append(f"decreased_by jsonpath eval error: {e}")
+        return
+    if not pre_v or not post_v:
+        failures.append(
+            f"decreased_by_at_least {path}: pre={pre_v} post={post_v}"
+        )
+        return
+    try:
+        pre_n = float(pre_v[0])
+        post_n = float(post_v[0])
+    except (TypeError, ValueError):
+        failures.append(
+            f"decreased_by_at_least {path}: not numeric pre={pre_v[0]!r} post={post_v[0]!r}"
+        )
+        return
+    delta = pre_n - post_n  # positive when value DECREASED
+    threshold = float(assertion["decreased_by_at_least"])
+    if delta < threshold:
+        failures.append(
+            f"decreased_by_at_least {path}: drop={delta} < threshold={threshold} "
             f"(pre={pre_n}, post={post_n} from {endpoint})"
         )

--- a/scripts/runtime/rcrurd_gate.py
+++ b/scripts/runtime/rcrurd_gate.py
@@ -1,0 +1,259 @@
+"""Layer 0 RCRURD lifecycle gate (RFC v9 D12).
+
+Deterministic gate at /vg:review entry. For every mutation goal with a
+declared `lifecycle` block in its FIXTURES/{G-XX}.yaml:
+1. Run pre_state GET → assert assertions (initial conditions met).
+2. (action skipped — gate is read-only verification of bookends).
+3. Run post_state GET — but skip; this gate runs BEFORE the action.
+
+Wait — re-reading RFC v9 D12 carefully: the L0 gate verifies that the
+fixture WOULD work end-to-end without actually mutating. So it:
+1. Runs pre_state GET → confirms initial state matches assertions.
+2. Notes the action's expected_network shape so /vg:review can later
+   verify the scanner hit the right endpoint.
+3. Records the lifecycle invariant for downstream comparison.
+
+Why it's deterministic Layer 0: no AI, no scanner — pure HTTP + JSONPath
+asserts against the recipe's lifecycle block. If pre_state fails, the
+fixture is broken (data not in expected start state) — fail-fast before
+spending tokens on browser scan.
+
+The post_state assertion runs LATER (after browser scan completes) to
+close the loop and verify the action took effect.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .recipe_capture import CaptureError, capture_paths
+
+
+class LifecycleGateError(Exception):
+    """Lifecycle pre/post-state assertion failed."""
+
+
+@dataclass
+class LifecycleResult:
+    goal_id: str
+    pre_state_passed: bool = False
+    post_state_passed: bool = False
+    pre_state_failures: list[str] = field(default_factory=list)
+    post_state_failures: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+
+GetFn = Callable[[str, str], dict[str, Any]]
+"""(role, endpoint) → response payload (dict). Project supplies via
+recipe_executor session lookup."""
+
+
+def _check_assertion(
+    assertion: dict[str, Any],
+    payload: Any,
+    *,
+    where: str,
+    failures: list[str],
+) -> None:
+    path = assertion.get("path")
+    if not path:
+        failures.append(f"{where}: assertion missing path")
+        return
+    try:
+        captured = capture_paths(
+            payload,
+            {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+        )
+    except CaptureError as e:
+        failures.append(f"{where} jsonpath '{path}' eval error: {e}")
+        return
+    matches = captured.get("_v", [])
+
+    if "equals" in assertion:
+        expected = assertion["equals"]
+        if not matches or matches[0] != expected:
+            failures.append(
+                f"{where} {path} expected={expected!r}, got={matches!r}"
+            )
+    if "not_equals" in assertion:
+        expected = assertion["not_equals"]
+        if matches and matches[0] == expected:
+            failures.append(
+                f"{where} {path} not_equals failed: value={matches[0]!r}"
+            )
+    if assertion.get("not_null"):
+        if not matches or matches[0] is None:
+            failures.append(f"{where} {path} not_null failed: matches={matches}")
+    if "increased_by_at_least" in assertion:
+        # Comparative assertions only meaningful in post_state when paired
+        # with pre_state value — handled by caller. Here, just check non-zero.
+        pass
+    if "cardinality" in assertion:
+        spec = str(assertion["cardinality"])
+        actual = len(matches)
+        if not _check_cardinality(spec, actual):
+            failures.append(
+                f"{where} {path} cardinality '{spec}' failed: actual={actual}"
+            )
+
+
+def _check_cardinality(spec: str, actual: int) -> bool:
+    import re
+    m = re.fullmatch(r"\s*([><]=?|==|=)\s*(\d+)\s*", spec)
+    if not m:
+        return False
+    op, num_s = m.group(1), m.group(2)
+    num = int(num_s)
+    if op in {"=", "=="}:
+        return actual == num
+    if op == ">":
+        return actual > num
+    if op == ">=":
+        return actual >= num
+    if op == "<":
+        return actual < num
+    if op == "<=":
+        return actual <= num
+    return False
+
+
+def run_pre_state(
+    goal_id: str,
+    lifecycle: dict[str, Any],
+    get_fn: GetFn,
+) -> LifecycleResult:
+    """Execute pre_state GET + assertions only. Caller runs the action."""
+    result = LifecycleResult(goal_id=goal_id)
+    pre = lifecycle.get("pre_state")
+    if not pre:
+        result.skipped_reason = "no pre_state declared"
+        return result
+    role = pre.get("role")
+    endpoint = pre.get("endpoint")
+    if not (role and endpoint):
+        result.pre_state_failures.append("pre_state missing role or endpoint")
+        return result
+    try:
+        payload = get_fn(role, endpoint)
+    except Exception as e:
+        result.pre_state_failures.append(f"pre_state GET {endpoint} raised: {e}")
+        return result
+    asserts = pre.get("assert_jsonpath") or []
+    for a in asserts:
+        _check_assertion(a, payload, where=f"pre_state {endpoint}",
+                         failures=result.pre_state_failures)
+    result.pre_state_passed = not result.pre_state_failures
+    return result
+
+
+def run_post_state_with_retry(
+    goal_id: str,
+    lifecycle: dict[str, Any],
+    get_fn: GetFn,
+    *,
+    pre_payload: Any = None,
+) -> LifecycleResult:
+    """Execute post_state GET + assertions with eventual-consistency retry.
+
+    D12 retry config:
+      retry:
+        max_attempts: 5
+        delay_ms: 200
+        until_assertion_pass: true
+
+    If until_assertion_pass=True, the GET re-runs until all assertions
+    pass OR max_attempts exhausted. delay_ms applied between attempts.
+    """
+    import time
+    result = LifecycleResult(goal_id=goal_id)
+    post = lifecycle.get("post_state")
+    if not post:
+        result.skipped_reason = "no post_state declared"
+        return result
+    role = post.get("role")
+    endpoint = post.get("endpoint")
+    if not (role and endpoint):
+        result.post_state_failures.append("post_state missing role or endpoint")
+        return result
+    asserts = post.get("assert_jsonpath") or []
+    retry_cfg = post.get("retry") or {}
+    max_attempts = int(retry_cfg.get("max_attempts", 1))
+    delay_ms = int(retry_cfg.get("delay_ms", 0))
+    until_pass = bool(retry_cfg.get("until_assertion_pass", False))
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            payload = get_fn(role, endpoint)
+        except Exception as e:
+            result.post_state_failures.append(
+                f"post_state GET {endpoint} (attempt {attempt}) raised: {e}"
+            )
+            break
+
+        attempt_failures: list[str] = []
+        for a in asserts:
+            _check_assertion(a, payload,
+                             where=f"post_state {endpoint} (attempt {attempt})",
+                             failures=attempt_failures)
+            if "increased_by_at_least" in a and isinstance(pre_payload, (dict, list)):
+                _check_increase(a, pre_payload, payload, attempt_failures,
+                                 endpoint=endpoint)
+
+        if not attempt_failures:
+            result.post_state_passed = True
+            result.post_state_failures = []
+            return result
+
+        if attempt < max_attempts and until_pass:
+            time.sleep(delay_ms / 1000.0)
+            continue
+
+        result.post_state_failures = attempt_failures
+        break
+
+    return result
+
+
+def _check_increase(
+    assertion: dict[str, Any],
+    pre_payload: Any,
+    post_payload: Any,
+    failures: list[str],
+    *,
+    endpoint: str,
+) -> None:
+    path = assertion.get("path")
+    if not path:
+        return
+    try:
+        pre_v = capture_paths(
+            pre_payload,
+            {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+        ).get("_v", [])
+        post_v = capture_paths(
+            post_payload,
+            {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+        ).get("_v", [])
+    except CaptureError as e:
+        failures.append(f"increased_by jsonpath eval error: {e}")
+        return
+    if not pre_v or not post_v:
+        failures.append(
+            f"increased_by_at_least {path}: pre={pre_v} post={post_v}"
+        )
+        return
+    try:
+        pre_n = float(pre_v[0])
+        post_n = float(post_v[0])
+    except (TypeError, ValueError):
+        failures.append(
+            f"increased_by_at_least {path}: not numeric pre={pre_v[0]!r} post={post_v[0]!r}"
+        )
+        return
+    delta = post_n - pre_n
+    threshold = float(assertion["increased_by_at_least"])
+    if delta < threshold:
+        failures.append(
+            f"increased_by_at_least {path}: delta={delta} < threshold={threshold} "
+            f"(pre={pre_n}, post={post_n} from {endpoint})"
+        )

--- a/scripts/runtime/recipe_auth.py
+++ b/scripts/runtime/recipe_auth.py
@@ -185,12 +185,27 @@ def auth_command(
     timeout = int(creds.get("timeout", 30))
 
     args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
+    # Codex-R4-HIGH-5 fix: scrub env so the project's auth-plugin command
+    # does NOT inherit caller's secrets (CLAUDE_API_KEY, AWS_*, etc.).
+    # Allowlist + opt-in passthrough via creds.env_passthrough.
+    _AUTH_CMD_ENV_ALLOW = {
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TERM",
+        "LANG", "LC_ALL", "TMPDIR", "PWD",
+    }
+    passthrough = creds.get("env_passthrough") or []
+    if isinstance(passthrough, str):
+        passthrough = [k.strip() for k in passthrough.split(",") if k.strip()]
+    scrubbed_env = {
+        k: v for k, v in os.environ.items()
+        if k in _AUTH_CMD_ENV_ALLOW or k in set(passthrough)
+    }
+    scrubbed_env["VGFLOW_RECIPE_RUNTIME"] = "1"
     proc = subprocess.run(
         args,
         capture_output=True,
         text=True,
         timeout=timeout,
-        env={**os.environ, "VGFLOW_RECIPE_RUNTIME": "1"},
+        env=scrubbed_env,
     )
     if proc.returncode != 0:
         raise AuthError(

--- a/scripts/runtime/recipe_auth.py
+++ b/scripts/runtime/recipe_auth.py
@@ -1,0 +1,247 @@
+"""4 auth kinds for recipe execution (RFC v9 D2/D9).
+
+Each handler returns a `requests.Session` (or compatible) with auth applied,
+plus optional `auth_verify` step to confirm credentials are valid before
+executing the recipe (D2 portability — fail fast on bad creds).
+
+Auth kinds:
+- cookie_login: POST /login → captured Set-Cookie, attached as session.cookies.
+- api_key:      static header `Authorization: ApiKey {key}` or per-config name.
+- bearer_jwt:   POST /auth/token → captured `access_token`, set Authorization.
+                Token refresh on 401 → re-runs login.
+- command:      project-supplied auth-plugin.sh emits cookie/token to stdout.
+                Runner trusts the script. Sandbox-only by D9 — main env reject.
+
+All handlers honor X-VGFlow-Sandbox: true (D9 sandbox safety) — the
+executor wires this into every outgoing request when env=sandbox.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+try:
+    import requests
+except ImportError:
+    requests = None  # type: ignore[assignment]
+
+
+class AuthError(Exception):
+    """Auth step failed (login 4xx/5xx, command non-zero, missing creds)."""
+
+
+@dataclass
+class AuthContext:
+    """Result of an auth handler. Wraps a requests.Session ready to use."""
+    session: Any  # requests.Session
+    role: str
+    refresh_callable: Callable[[], None] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _ensure_requests():
+    if requests is None:
+        raise ImportError(
+            "requests required for recipe execution — install with `pip install requests>=2.31`"
+        )
+
+
+def _new_session() -> Any:
+    _ensure_requests()
+    s = requests.Session()
+    # Identifier so backend logs show vgflow recipe traffic
+    s.headers["User-Agent"] = "vgflow-recipe-runtime/1.0"
+    return s
+
+
+def _apply_sandbox_header(session: Any, sandbox: bool) -> None:
+    if sandbox:
+        session.headers["X-VGFlow-Sandbox"] = "true"
+
+
+def auth_cookie_login(
+    base_url: str,
+    creds: dict[str, Any],
+    sandbox: bool = False,
+) -> AuthContext:
+    """POST creds.endpoint with creds.body; relies on Set-Cookie."""
+    _ensure_requests()
+    endpoint = creds.get("endpoint") or "/login"
+    body = creds.get("body") or {}
+    session = _new_session()
+    _apply_sandbox_header(session, sandbox)
+    url = base_url.rstrip("/") + endpoint
+    resp = session.post(url, json=body, timeout=10)
+    if resp.status_code >= 400:
+        raise AuthError(
+            f"cookie_login failed: POST {endpoint} → {resp.status_code} "
+            f"{resp.text[:200]}"
+        )
+    if not session.cookies:
+        raise AuthError(
+            f"cookie_login {endpoint} returned {resp.status_code} but no Set-Cookie "
+            f"headers — backend may not be cookie-based?"
+        )
+    return AuthContext(session=session, role=creds.get("role", "unknown"))
+
+
+def auth_api_key(
+    base_url: str,
+    creds: dict[str, Any],
+    sandbox: bool = False,
+) -> AuthContext:
+    """Header-based API key. Default Authorization: ApiKey {key}.
+
+    creds:
+      key: <required>
+      header_name: Authorization (default)
+      scheme: ApiKey (default; set "" for raw key)
+    """
+    _ensure_requests()
+    key = creds.get("key")
+    if not key:
+        raise AuthError("api_key auth requires creds.key")
+    header_name = creds.get("header_name", "Authorization")
+    scheme = creds.get("scheme", "ApiKey")
+    value = f"{scheme} {key}".strip() if scheme else key
+    session = _new_session()
+    session.headers[header_name] = value
+    _apply_sandbox_header(session, sandbox)
+    return AuthContext(session=session, role=creds.get("role", "unknown"))
+
+
+def auth_bearer_jwt(
+    base_url: str,
+    creds: dict[str, Any],
+    sandbox: bool = False,
+) -> AuthContext:
+    """POST creds.endpoint → capture access_token → Authorization: Bearer ...
+
+    Refresh callable retries the login on 401. Recipe executor invokes
+    refresh once; if 401 persists, raises AuthError.
+    """
+    _ensure_requests()
+    endpoint = creds.get("endpoint") or "/auth/token"
+    body = creds.get("body") or {}
+    token_path = creds.get("token_path", "access_token")
+
+    session = _new_session()
+    _apply_sandbox_header(session, sandbox)
+
+    def _login() -> None:
+        url = base_url.rstrip("/") + endpoint
+        resp = session.post(url, json=body, timeout=10)
+        if resp.status_code >= 400:
+            raise AuthError(
+                f"bearer_jwt login failed: POST {endpoint} → {resp.status_code}"
+            )
+        try:
+            payload = resp.json()
+        except Exception as e:
+            raise AuthError(f"bearer_jwt response not JSON: {e}") from e
+        token = payload
+        for part in token_path.split("."):
+            if not isinstance(token, dict) or part not in token:
+                raise AuthError(
+                    f"bearer_jwt token_path='{token_path}' did not resolve "
+                    f"in response: {list(payload.keys())[:5]}"
+                )
+            token = token[part]
+        if not isinstance(token, str) or not token:
+            raise AuthError(f"bearer_jwt resolved token is not a non-empty string")
+        session.headers["Authorization"] = f"Bearer {token}"
+
+    _login()
+    return AuthContext(
+        session=session,
+        role=creds.get("role", "unknown"),
+        refresh_callable=_login,
+    )
+
+
+def auth_command(
+    base_url: str,
+    creds: dict[str, Any],
+    sandbox: bool = False,
+) -> AuthContext:
+    """Run external command; expect JSON on stdout: {kind, header|cookies}.
+
+    D9 SAFETY: command auth is sandbox-only. main/prod env raises AuthError.
+
+    creds.command: shell command (must be in PATH or absolute).
+    creds.timeout: seconds (default 30).
+    """
+    if not sandbox:
+        raise AuthError(
+            "auth kind 'command' is sandbox-only (D9 hard gate). "
+            "Project must define separate creds for main env."
+        )
+    cmd = creds.get("command")
+    if not cmd:
+        raise AuthError("auth kind 'command' requires creds.command")
+    timeout = int(creds.get("timeout", 30))
+
+    args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
+    proc = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "VGFLOW_RECIPE_RUNTIME": "1"},
+    )
+    if proc.returncode != 0:
+        raise AuthError(
+            f"auth command exited {proc.returncode}: {proc.stderr[:300]}"
+        )
+
+    import json as _json
+    try:
+        payload = _json.loads(proc.stdout)
+    except _json.JSONDecodeError as e:
+        raise AuthError(
+            f"auth command stdout not JSON: {e} (stdout={proc.stdout[:200]!r})"
+        ) from e
+
+    session = _new_session()
+    _apply_sandbox_header(session, sandbox)
+    kind = payload.get("kind", "header")
+    if kind == "header":
+        for name, value in (payload.get("headers") or {}).items():
+            session.headers[name] = value
+    elif kind == "cookies":
+        for name, value in (payload.get("cookies") or {}).items():
+            session.cookies.set(name, value)
+    else:
+        raise AuthError(f"auth command unknown kind={kind}")
+
+    return AuthContext(
+        session=session,
+        role=creds.get("role", "command-supplied"),
+        metadata={"auth_command": cmd},
+    )
+
+
+_HANDLERS: dict[str, Callable[..., AuthContext]] = {
+    "cookie_login": auth_cookie_login,
+    "api_key": auth_api_key,
+    "bearer_jwt": auth_bearer_jwt,
+    "command": auth_command,
+}
+
+
+def authenticate(
+    kind: str,
+    base_url: str,
+    creds: dict[str, Any],
+    sandbox: bool = False,
+) -> AuthContext:
+    """Dispatch to one of the 4 auth handlers."""
+    handler = _HANDLERS.get(kind)
+    if handler is None:
+        raise AuthError(
+            f"Unknown auth kind '{kind}' — must be one of {sorted(_HANDLERS)}"
+        )
+    return handler(base_url, creds, sandbox=sandbox)

--- a/scripts/runtime/recipe_capture.py
+++ b/scripts/runtime/recipe_capture.py
@@ -1,0 +1,175 @@
+"""JSONPath capture with cardinality enforcement (RFC v9 D2 capture spec).
+
+Capture spec entries:
+    capture:
+      pending_id:
+        path: $.data.id
+        cardinality: scalar          # default
+        on_empty: fail               # default
+      list_ids:
+        path: $.data.items[*].id
+        cardinality: array
+        on_empty: skip
+      optional_token:
+        path: $.token
+        cardinality: optional_scalar
+        on_empty: null
+
+Behavior:
+- scalar     → exactly 1 match. >1 → CaptureError.
+- array      → 0+ matches as list.
+- optional_scalar → 0 or 1 match. on_empty='null' returns None.
+- on_empty='fail' raises CaptureError on 0 matches (default for scalar).
+- on_empty='skip' returns key omitted from result.
+- on_empty='null' returns key with value None.
+
+Uses jsonpath-ng (RFC 9535-aligned). Falls back to a simple in-house parser
+if jsonpath-ng is unavailable, supporting only `$.dotted.path[index]` —
+sufficient for ~90% of recipes.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+class CaptureError(Exception):
+    """Capture failed validation (cardinality mismatch, on_empty=fail)."""
+
+
+def _have_jsonpath_ng() -> bool:
+    try:
+        import jsonpath_ng  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _evaluate_jsonpath(path: str, payload: Any) -> list[Any]:
+    """Return list of matches for `path` in `payload`.
+
+    Prefers jsonpath-ng. Falls back to a stdlib `$.a.b[0].c[*]` evaluator.
+    """
+    if _have_jsonpath_ng():
+        from jsonpath_ng.ext import parse  # ext supports filter expressions
+        try:
+            expr = parse(path)
+        except Exception as e:
+            raise CaptureError(f"Invalid JSONPath '{path}': {e}") from e
+        return [m.value for m in expr.find(payload)]
+    return _fallback_evaluate(path, payload)
+
+
+_FALLBACK_RE = re.compile(r"\$(?:\.[a-zA-Z_][\w]*|\[(?:\*|\d+)\])+")
+
+
+def _fallback_evaluate(path: str, payload: Any) -> list[Any]:
+    if not _FALLBACK_RE.fullmatch(path):
+        raise CaptureError(
+            f"Fallback JSONPath only supports $.a.b[0].c[*] form. Got '{path}'. "
+            f"Install jsonpath-ng for full RFC 9535 support."
+        )
+    # Tokenize: drop leading $ then split on `.` and `[` boundaries.
+    tokens: list[str | int | object] = []
+    STAR = object()
+    cursor = 1  # skip $
+    while cursor < len(path):
+        ch = path[cursor]
+        if ch == ".":
+            cursor += 1
+            m = re.match(r"[a-zA-Z_][\w]*", path[cursor:])
+            assert m is not None, f"unreachable — regex pre-validated {path}"
+            tokens.append(m.group(0))
+            cursor += len(m.group(0))
+        elif ch == "[":
+            close = path.index("]", cursor)
+            inner = path[cursor + 1 : close]
+            tokens.append(STAR if inner == "*" else int(inner))
+            cursor = close + 1
+        else:
+            raise CaptureError(f"Unexpected char '{ch}' at position {cursor} in {path}")
+
+    current: list[Any] = [payload]
+    for tok in tokens:
+        next_layer: list[Any] = []
+        for item in current:
+            if tok is STAR:
+                if isinstance(item, list):
+                    next_layer.extend(item)
+            elif isinstance(tok, int):
+                if isinstance(item, list) and -len(item) <= tok < len(item):
+                    next_layer.append(item[tok])
+            else:  # str key
+                if isinstance(item, dict) and tok in item:
+                    next_layer.append(item[tok])
+        current = next_layer
+    return current
+
+
+def capture_paths(payload: Any, capture_spec: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Apply a capture spec to a response payload.
+
+    Args:
+      payload: parsed JSON response body (dict/list).
+      capture_spec: { name: { path, cardinality, on_empty } }
+
+    Returns:
+      Captured values keyed by name. Missing-with-skip keys omitted entirely.
+
+    Raises:
+      CaptureError: on_empty=fail with 0 matches; cardinality=scalar with
+                    multiple matches; bad path.
+    """
+    out: dict[str, Any] = {}
+    if not isinstance(capture_spec, dict):
+        raise CaptureError(f"capture spec must be dict, got {type(capture_spec).__name__}")
+    for name, spec in capture_spec.items():
+        if not isinstance(spec, dict):
+            raise CaptureError(f"capture[{name}] must be object, got {type(spec).__name__}")
+        path = spec.get("path")
+        if not path:
+            raise CaptureError(f"capture[{name}] missing required 'path'")
+        cardinality = spec.get("cardinality", "scalar")
+        on_empty = spec.get("on_empty", "fail")
+
+        matches = _evaluate_jsonpath(path, payload)
+
+        if not matches:
+            if on_empty == "fail":
+                raise CaptureError(
+                    f"capture[{name}] path '{path}' returned no matches "
+                    f"(cardinality={cardinality}, on_empty=fail)"
+                )
+            if on_empty == "skip":
+                continue
+            if on_empty == "null":
+                out[name] = None
+                continue
+            raise CaptureError(
+                f"capture[{name}] unknown on_empty='{on_empty}' "
+                f"(must be fail|skip|null)"
+            )
+
+        if cardinality == "scalar":
+            if len(matches) > 1:
+                raise CaptureError(
+                    f"capture[{name}] path '{path}' expected scalar, got "
+                    f"{len(matches)} matches"
+                )
+            out[name] = matches[0]
+        elif cardinality == "optional_scalar":
+            if len(matches) > 1:
+                raise CaptureError(
+                    f"capture[{name}] path '{path}' expected optional_scalar, "
+                    f"got {len(matches)} matches"
+                )
+            out[name] = matches[0]
+        elif cardinality == "array":
+            out[name] = matches
+        else:
+            raise CaptureError(
+                f"capture[{name}] unknown cardinality='{cardinality}' "
+                f"(must be scalar|optional_scalar|array)"
+            )
+
+    return out

--- a/scripts/runtime/recipe_executor.py
+++ b/scripts/runtime/recipe_executor.py
@@ -27,11 +27,25 @@ from typing import Any
 from .recipe_auth import AuthContext, AuthError, authenticate
 from .recipe_capture import CaptureError, capture_paths
 from .recipe_interpolate import interpolate
-from .recipe_safety import SandboxSafetyError, assert_step_safe
+from .recipe_safety import (
+    SandboxEchoMissingError,
+    SandboxSafetyError,
+    assert_response_echo,
+    assert_step_safe,
+    assert_url_in_allowlist,
+)
 
 
 class RecipeExecutionError(Exception):
     """Step failed during execution."""
+
+
+class AuthDegradedError(RecipeExecutionError):
+    """Auth refresh exhausted — credentials likely expired/revoked.
+
+    Distinct from generic execution error so callers can prompt for
+    re-auth instead of treating it as a programming bug.
+    """
 
 
 @dataclass
@@ -42,6 +56,17 @@ class RecipeRunner:
     sessions: dict[str, AuthContext] = field(default_factory=dict)
     store: dict[str, Any] = field(default_factory=dict)
     request_timeout: float = 30.0
+    sandbox_url_allowlist: list[str] | tuple[str, ...] = field(default_factory=list)
+    response_echo_check: bool = False
+    _echo_verified_for_role: set[str] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        # Codex-HIGH-7: enforce URL allowlist before any traffic flows
+        if self.env == "sandbox" and self.sandbox_url_allowlist:
+            try:
+                assert_url_in_allowlist(self.base_url, self.sandbox_url_allowlist)
+            except SandboxSafetyError as e:
+                raise RecipeExecutionError(str(e)) from e
 
     def _auth_context(self, role: str) -> AuthContext:
         if role not in self.sessions:
@@ -156,9 +181,12 @@ class RecipeRunner:
 
         url = self.base_url.rstrip("/") + endpoint
         headers: dict[str, str] = {}
-        # D13: idempotency-key for POST/PUT
+        # D13: idempotency-key for ALL mutation verbs (POST/PUT/PATCH/DELETE)
+        # Codex-B-MEDIUM fix: was POST/PUT only; PATCH+DELETE need it too
+        # for safe retry semantics (RFC 7240 §4.3 — idempotency-key applies
+        # to any mutation, not just create/replace).
         idem = step.get("idempotency_key")
-        if idem and method in {"POST", "PUT"}:
+        if idem and method in {"POST", "PUT", "PATCH", "DELETE"}:
             idem_resolved = interpolate(idem, ctx_store)
             headers["Idempotency-Key"] = str(idem_resolved)
 
@@ -175,8 +203,34 @@ class RecipeRunner:
             try:
                 auth.refresh_callable()
             except AuthError as e:
-                raise RecipeExecutionError(f"Auth refresh failed: {e}") from e
+                # Codex-A-MEDIUM fix: typed error so callers can re-prompt
+                raise AuthDegradedError(
+                    f"Auth refresh failed for role={role}: {e}. "
+                    f"Credentials likely expired/revoked — caller should "
+                    f"prompt for new credentials and retry."
+                ) from e
             resp = session.request(method, url, **kwargs)
+            # Refresh succeeded but second response also 401 → token format
+            # OK, but credentials still invalid. Treat as degraded.
+            if resp.status_code == 401:
+                raise AuthDegradedError(
+                    f"Auth refresh succeeded but second {method} {endpoint} "
+                    f"still 401 for role={role}. Refresh-token likely "
+                    f"expired — caller should prompt for new credentials."
+                )
+
+        # Codex-HIGH-7: response echo handshake — proves backend honored
+        # X-VGFlow-Sandbox: true. Verified once per role per run (cheap).
+        if (self.env == "sandbox" and self.response_echo_check
+                and role not in self._echo_verified_for_role
+                and resp.status_code < 400):
+            try:
+                assert_response_echo(resp.headers)
+                self._echo_verified_for_role.add(role)
+            except SandboxEchoMissingError as e:
+                raise RecipeExecutionError(
+                    f"Sandbox echo handshake failed at {method} {endpoint}: {e}"
+                ) from e
 
         expect = step.get("expect_status")
         if expect is not None and resp.status_code != expect:

--- a/scripts/runtime/recipe_executor.py
+++ b/scripts/runtime/recipe_executor.py
@@ -1,0 +1,303 @@
+"""Recipe step executor — RFC v9 PR-A2 native API runtime.
+
+Walks recipe.steps[] in declared order:
+1. Resolve role → AuthContext (cached per role+env).
+2. Apply ${var} interpolation against capture store.
+3. Sandbox safety gate (D9) on body before send.
+4. POST/PUT/PATCH/DELETE: attach idempotency_key as `Idempotency-Key` header
+   (RFC 7240, D13).
+5. Execute via requests.Session.
+6. On 401 with bearer_jwt: invoke refresh_callable, retry once.
+7. validate_after (D3): GET endpoint + assert_jsonpath against response.
+8. capture (D2): JSONPath into response body, write into store.
+9. lifecycle (D12): execute pre_state/post_state assertions, retry on
+   eventual consistency.
+
+Public API:
+    runner = RecipeRunner(base_url, env="sandbox", credentials_map={...})
+    runner.run(recipe)
+    print(runner.store)  # { "pending_id": "...", ... }
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from .recipe_auth import AuthContext, AuthError, authenticate
+from .recipe_capture import CaptureError, capture_paths
+from .recipe_interpolate import interpolate
+from .recipe_safety import SandboxSafetyError, assert_step_safe
+
+
+class RecipeExecutionError(Exception):
+    """Step failed during execution."""
+
+
+@dataclass
+class RecipeRunner:
+    base_url: str
+    env: str = "sandbox"
+    credentials_map: dict[str, dict[str, Any]] = field(default_factory=dict)
+    sessions: dict[str, AuthContext] = field(default_factory=dict)
+    store: dict[str, Any] = field(default_factory=dict)
+    request_timeout: float = 30.0
+
+    def _auth_context(self, role: str) -> AuthContext:
+        if role not in self.sessions:
+            creds = self.credentials_map.get(role)
+            if not creds:
+                raise RecipeExecutionError(
+                    f"Role '{role}' not in credentials_map. Configure in vg.config.md."
+                )
+            kind = creds.get("kind")
+            if not kind:
+                raise RecipeExecutionError(
+                    f"credentials_map[{role}] missing 'kind' (cookie_login|api_key|"
+                    f"bearer_jwt|command)"
+                )
+            try:
+                self.sessions[role] = authenticate(
+                    kind, self.base_url, creds, sandbox=(self.env == "sandbox"),
+                )
+            except AuthError as e:
+                raise RecipeExecutionError(f"Auth failed for role={role}: {e}") from e
+        return self.sessions[role]
+
+    def run(self, recipe: dict[str, Any]) -> dict[str, Any]:
+        """Execute all steps. Returns the capture store."""
+        for step in recipe.get("steps") or []:
+            self.run_step(step)
+        return self.store
+
+    def run_step(self, step: dict[str, Any]) -> None:
+        kind = step.get("kind", "api_call")
+        if kind == "loop":
+            self._run_loop_step(step)
+            return
+        if kind == "api_call":
+            self._run_api_call(step)
+            return
+        raise RecipeExecutionError(f"Unsupported step kind: {kind}")
+
+    def _run_loop_step(self, step: dict[str, Any]) -> None:
+        over = step.get("over")
+        each = step.get("each")
+        if each is None or over is None:
+            raise RecipeExecutionError(
+                f"loop step '{step.get('id', '?')}' requires `over` + `each`"
+            )
+        if isinstance(over, int):
+            iterable = list(range(over))
+        elif isinstance(over, list):
+            iterable = list(over)
+        elif isinstance(over, str):  # variable reference
+            resolved = interpolate(over, self.store)
+            if not isinstance(resolved, list):
+                raise RecipeExecutionError(
+                    f"loop step `over` resolved to {type(resolved).__name__}, want list"
+                )
+            iterable = resolved
+        else:
+            raise RecipeExecutionError(f"loop step `over` must be int|list|str")
+
+        # `from_each: true` captures collect into arrays
+        from_each_keys = {
+            cap_name for cap_name, spec in (each.get("capture") or {}).items()
+            if spec.get("from_each")
+        }
+        accum: dict[str, list[Any]] = {k: [] for k in from_each_keys}
+
+        for i, value in enumerate(iterable):
+            self.store[f"_loop_{i}"] = value
+            try:
+                self._run_api_call(each, _loop_index=i, _loop_value=value,
+                                    _loop_accum=accum)
+            finally:
+                self.store.pop(f"_loop_{i}", None)
+
+        for k, v in accum.items():
+            self.store[k] = v
+
+    def _run_api_call(
+        self,
+        step: dict[str, Any],
+        *,
+        _loop_index: int | None = None,
+        _loop_value: Any = None,
+        _loop_accum: dict[str, list[Any]] | None = None,
+    ) -> None:
+        # Build local context — base store + loop variables
+        ctx_store: dict[str, Any] = dict(self.store)
+        if _loop_index is not None:
+            ctx_store["_index"] = _loop_index
+            ctx_store["_value"] = _loop_value
+
+        method = step.get("method", "GET").upper()
+        endpoint_raw = step.get("endpoint")
+        if not endpoint_raw:
+            raise RecipeExecutionError(f"step '{step.get('id', '?')}' missing endpoint")
+        endpoint = interpolate(endpoint_raw, ctx_store)
+        body = interpolate(step.get("body"), ctx_store) if step.get("body") else None
+
+        # Sandbox safety gate (D9)
+        try:
+            interpolated_step = {
+                **step,
+                "body": body,
+            }
+            assert_step_safe(interpolated_step, self.env)
+        except SandboxSafetyError as e:
+            raise RecipeExecutionError(str(e)) from e
+
+        role = step.get("role", "default")
+        auth = self._auth_context(role)
+        session = auth.session
+
+        url = self.base_url.rstrip("/") + endpoint
+        headers: dict[str, str] = {}
+        # D13: idempotency-key for POST/PUT
+        idem = step.get("idempotency_key")
+        if idem and method in {"POST", "PUT"}:
+            idem_resolved = interpolate(idem, ctx_store)
+            headers["Idempotency-Key"] = str(idem_resolved)
+
+        kwargs: dict[str, Any] = {"timeout": self.request_timeout, "headers": headers}
+        if body is not None and method in {"POST", "PUT", "PATCH", "DELETE"}:
+            kwargs["json"] = body
+        elif body is not None:
+            kwargs["params"] = body if isinstance(body, dict) else None
+
+        resp = session.request(method, url, **kwargs)
+
+        # Refresh-on-401 once for bearer_jwt
+        if resp.status_code == 401 and auth.refresh_callable:
+            try:
+                auth.refresh_callable()
+            except AuthError as e:
+                raise RecipeExecutionError(f"Auth refresh failed: {e}") from e
+            resp = session.request(method, url, **kwargs)
+
+        expect = step.get("expect_status")
+        if expect is not None and resp.status_code != expect:
+            raise RecipeExecutionError(
+                f"step '{step.get('id', '?')}': {method} {endpoint} expected "
+                f"{expect}, got {resp.status_code}: {resp.text[:200]}"
+            )
+        if expect is None and resp.status_code >= 400:
+            raise RecipeExecutionError(
+                f"step '{step.get('id', '?')}': {method} {endpoint} returned "
+                f"{resp.status_code}: {resp.text[:200]}"
+            )
+
+        # Capture (D2)
+        capture_spec = step.get("capture")
+        if capture_spec:
+            try:
+                payload = resp.json() if resp.text else {}
+            except Exception:
+                payload = {}
+            try:
+                captured = capture_paths(payload, capture_spec)
+            except CaptureError as e:
+                raise RecipeExecutionError(
+                    f"step '{step.get('id', '?')}' capture failed: {e}"
+                ) from e
+            if _loop_accum is not None:
+                for k, v in captured.items():
+                    if k in _loop_accum:
+                        _loop_accum[k].append(v)
+                    else:
+                        self.store[k] = v
+            else:
+                self.store.update(captured)
+
+        # validate_after (D3)
+        va = step.get("validate_after")
+        if isinstance(va, dict):
+            self._run_validate_after(va, role)
+
+    def _run_validate_after(self, va: dict[str, Any], role: str) -> None:
+        endpoint = interpolate(va["endpoint"], self.store)
+        url = self.base_url.rstrip("/") + endpoint
+        auth = self._auth_context(role)
+        resp = auth.session.get(url, timeout=self.request_timeout)
+        expect = va.get("expect_status", 200)
+        if resp.status_code != expect:
+            raise RecipeExecutionError(
+                f"validate_after GET {endpoint} expected {expect}, got "
+                f"{resp.status_code}"
+            )
+        asserts = va.get("assert_jsonpath") or []
+        if asserts:
+            try:
+                payload = resp.json() if resp.text else {}
+            except Exception:
+                payload = {}
+            for a in asserts:
+                self._check_assert(a, payload, where=f"validate_after {endpoint}")
+
+    def _check_assert(
+        self,
+        assertion: dict[str, Any],
+        payload: Any,
+        *,
+        where: str,
+    ) -> None:
+        path = assertion.get("path")
+        if not path:
+            raise RecipeExecutionError(f"{where}: assertion missing path")
+        # Use capture machinery to evaluate
+        try:
+            captured = capture_paths(
+                payload,
+                {"_v": {"path": path, "cardinality": "array", "on_empty": "skip"}},
+            )
+        except CaptureError as e:
+            raise RecipeExecutionError(f"{where}: assertion eval error: {e}") from e
+        matches = captured.get("_v", [])
+
+        if "equals" in assertion:
+            expected = assertion["equals"]
+            if not matches or matches[0] != expected:
+                raise RecipeExecutionError(
+                    f"{where} {path} expected={expected!r}, got={matches!r}"
+                )
+        if "not_equals" in assertion:
+            expected = assertion["not_equals"]
+            if matches and matches[0] == expected:
+                raise RecipeExecutionError(
+                    f"{where} {path} not_equals failed: value={matches[0]!r}"
+                )
+        if assertion.get("not_null"):
+            if not matches or matches[0] is None:
+                raise RecipeExecutionError(
+                    f"{where} {path} not_null failed: matches={matches}"
+                )
+        if "cardinality" in assertion:
+            spec = assertion["cardinality"]  # e.g., ">=1", "==3"
+            actual = len(matches)
+            if not _check_cardinality(spec, actual):
+                raise RecipeExecutionError(
+                    f"{where} {path} cardinality '{spec}' failed: actual={actual}"
+                )
+
+
+def _check_cardinality(spec: str, actual: int) -> bool:
+    import re
+    m = re.fullmatch(r"\s*([><]=?|==|=)\s*(\d+)\s*", spec)
+    if not m:
+        return False
+    op, num_s = m.group(1), m.group(2)
+    num = int(num_s)
+    if op in {"=", "=="}:
+        return actual == num
+    if op == ">":
+        return actual > num
+    if op == ">=":
+        return actual >= num
+    if op == "<":
+        return actual < num
+    if op == "<=":
+        return actual <= num
+    return False

--- a/scripts/runtime/recipe_executor.py
+++ b/scripts/runtime/recipe_executor.py
@@ -258,11 +258,15 @@ class RecipeRunner:
                     f"step '{step.get('id', '?')}' capture failed: {e}"
                 ) from e
             if _loop_accum is not None:
+                # Codex-R5-HIGH-2 fix: per-iteration captures with from_each
+                # used to skip self.store entirely → validate_after couldn't
+                # interpolate them. Now we ALSO write to self.store for the
+                # current iteration's lifetime; loop teardown overwrites with
+                # the accumulated array (preserving prior post-loop semantics).
                 for k, v in captured.items():
                     if k in _loop_accum:
                         _loop_accum[k].append(v)
-                    else:
-                        self.store[k] = v
+                    self.store[k] = v
             else:
                 self.store.update(captured)
 

--- a/scripts/runtime/recipe_interpolate.py
+++ b/scripts/runtime/recipe_interpolate.py
@@ -1,0 +1,70 @@
+"""${var} interpolation for recipe step bodies/endpoints/headers.
+
+RFC v9 D2: recipe steps reference earlier captured values via `${name}`.
+Names are dotted paths into the capture store (e.g., `${pending_id}`,
+`${created.user.id}`).
+
+Behavior:
+- Whole-string match `"${name}"` → returns the captured value preserving
+  type (int stays int, list stays list).
+- Substring match `"User ${name} confirmed"` → returns formatted string.
+- Missing variable → InterpolationError.
+- Recurses into dicts and lists.
+- Leaves non-string scalars (int, float, bool, None) untouched.
+
+The whole-string vs substring distinction matters: API bodies often need
+typed values (`{"amount": "${amount}"}` should yield `{"amount": 100}`,
+not `{"amount": "100"}`).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_VAR_RE = re.compile(r"\$\{([a-zA-Z_][\w.]*)\}")
+_WHOLE_VAR_RE = re.compile(r"^\$\{([a-zA-Z_][\w.]*)\}$")
+
+
+class InterpolationError(Exception):
+    """Variable referenced is not in store."""
+
+
+def _resolve_dotted(store: dict[str, Any], dotted: str) -> Any:
+    """Walk dotted path. Raises InterpolationError if any segment missing."""
+    parts = dotted.split(".")
+    current: Any = store
+    for i, part in enumerate(parts):
+        if isinstance(current, dict):
+            if part not in current:
+                raise InterpolationError(
+                    f"Variable '{dotted}' missing — '{part}' not found at "
+                    f"depth {i} (have keys: {sorted(current)[:8]})"
+                )
+            current = current[part]
+        else:
+            raise InterpolationError(
+                f"Variable '{dotted}' resolution hit non-dict at depth {i} "
+                f"(type={type(current).__name__})"
+            )
+    return current
+
+
+def interpolate(value: Any, store: dict[str, Any]) -> Any:
+    """Recursively replace ${var} occurrences in `value`.
+
+    Whole-string `"${var}"` preserves the captured value type.
+    Substring matches stringify all interpolated parts.
+    """
+    if isinstance(value, str):
+        whole = _WHOLE_VAR_RE.match(value)
+        if whole:
+            return _resolve_dotted(store, whole.group(1))
+        return _VAR_RE.sub(
+            lambda m: str(_resolve_dotted(store, m.group(1))),
+            value,
+        )
+    if isinstance(value, list):
+        return [interpolate(v, store) for v in value]
+    if isinstance(value, dict):
+        return {k: interpolate(v, store) for k, v in value.items()}
+    return value

--- a/scripts/runtime/recipe_loader.py
+++ b/scripts/runtime/recipe_loader.py
@@ -1,0 +1,105 @@
+"""Load + validate FIXTURES/{G-XX}.yaml against fixture-recipe.v1.json.
+
+RFC v9 D2 — recipe authoring at /vg:build, consumed by /vg:review preflight
+and /vg:test codegen. schema_version: "1.0" mandatory; runner rejects
+unknown major (D14 versioning policy).
+
+Usage:
+    from scripts.runtime import load_recipe
+    recipe = load_recipe(Path("FIXTURES/G-10.yaml"))
+
+Returns the parsed dict (validated). Raises ValidationError on:
+- missing schema_version / unknown major
+- schema validation failure (jsonschema) — deferred to import-time
+- malformed YAML
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:
+    raise ImportError(
+        "PyYAML required for recipe loading — install with `pip install pyyaml>=6.0`"
+    ) from e
+
+
+class ValidationError(Exception):
+    """Recipe failed schema validation or version check."""
+
+
+def _schema_path() -> Path:
+    """Resolve schemas/fixture-recipe.v1.json relative to repo root."""
+    # __file__ = scripts/runtime/recipe_loader.py
+    return Path(__file__).resolve().parents[2] / "schemas" / "fixture-recipe.v1.json"
+
+
+_SCHEMA: dict[str, Any] | None = None
+
+
+def _load_schema() -> dict[str, Any]:
+    global _SCHEMA
+    if _SCHEMA is None:
+        _SCHEMA = json.loads(_schema_path().read_text(encoding="utf-8"))
+    return _SCHEMA
+
+
+def load_recipe(path: Path | str) -> dict[str, Any]:
+    """Load + validate a recipe YAML.
+
+    Args:
+      path: path to FIXTURES/{G-XX}.yaml
+
+    Returns:
+      Validated recipe dict.
+
+    Raises:
+      ValidationError: schema_version major bump unsupported, or jsonschema
+                       validation error (with path + actual fragment).
+      FileNotFoundError: path does not exist.
+      yaml.YAMLError: malformed YAML.
+    """
+    p = Path(path)
+    raw = p.read_text(encoding="utf-8")
+    try:
+        recipe = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        raise ValidationError(f"YAML parse error in {p}: {e}") from e
+
+    if not isinstance(recipe, dict):
+        raise ValidationError(f"Recipe at {p} did not parse as object: got {type(recipe).__name__}")
+
+    sv = recipe.get("schema_version")
+    if sv is None:
+        raise ValidationError(
+            f"Recipe at {p} missing required field `schema_version` (D14)"
+        )
+    if not isinstance(sv, str) or not sv.startswith("1."):
+        raise ValidationError(
+            f"Recipe at {p} schema_version='{sv}' — runner only supports 1.x. "
+            f"D14: major bump means breaking change, requires runtime upgrade."
+        )
+
+    # jsonschema validation (best-effort — schemas/ has the canonical version)
+    try:
+        import jsonschema
+    except ImportError:
+        # Allow import-time degraded mode for environments without jsonschema.
+        # Runtime callers (PR-A2 executor) will refuse to execute without
+        # validation. For consumers that only need the parsed dict (e.g.,
+        # static analysis), this fall-through is acceptable.
+        return recipe
+
+    schema = _load_schema()
+    try:
+        jsonschema.validate(recipe, schema)
+    except jsonschema.ValidationError as e:
+        path_str = "/".join(str(p) for p in e.absolute_path) or "<root>"
+        raise ValidationError(
+            f"Recipe at {p} failed schema validation at `{path_str}`: {e.message}"
+        ) from e
+
+    return recipe

--- a/scripts/runtime/recipe_loader.py
+++ b/scripts/runtime/recipe_loader.py
@@ -102,4 +102,76 @@ def load_recipe(path: Path | str) -> dict[str, Any]:
             f"Recipe at {p} failed schema validation at `{path_str}`: {e.message}"
         ) from e
 
+    # Codex-R4-HIGH-6 fix: pre-validate JSONPath expressions at load time.
+    # Schema only enforces `^$` regex; an invalid filter expression would
+    # blow up AT runtime AFTER the mutation already executed. Pre-compile
+    # so authoring errors surface before any HTTP traffic.
+    _validate_jsonpaths(recipe, p)
+
     return recipe
+
+
+def _validate_jsonpaths(recipe: dict[str, Any], source: Path) -> None:
+    """Walk recipe.steps[].capture and validate_after.assert_jsonpath plus
+    lifecycle.{pre,post}_state.assert_jsonpath. Compile each path; raise
+    ValidationError on any failure."""
+    try:
+        from jsonpath_ng.ext import parse as _jp_parse
+    except ImportError:
+        return  # jsonpath-ng absent; runtime fallback evaluator catches errors
+
+    paths_to_check: list[tuple[str, str]] = []  # (location, path)
+
+    def collect_step(step: Any, base: str) -> None:
+        if not isinstance(step, dict):
+            return
+        cap = step.get("capture")
+        if isinstance(cap, dict):
+            for name, spec in cap.items():
+                if isinstance(spec, dict) and isinstance(spec.get("path"), str):
+                    paths_to_check.append((f"{base}.capture[{name}].path",
+                                            spec["path"]))
+        va = step.get("validate_after")
+        if isinstance(va, dict):
+            for a in va.get("assert_jsonpath") or []:
+                if isinstance(a, dict) and isinstance(a.get("path"), str):
+                    paths_to_check.append(
+                        (f"{base}.validate_after.assert_jsonpath.path", a["path"])
+                    )
+        # Recurse into loop step `each`
+        each = step.get("each")
+        if isinstance(each, dict):
+            collect_step(each, f"{base}.each")
+
+    for i, step in enumerate(recipe.get("steps") or []):
+        collect_step(step, f"steps[{i}]")
+
+    lifecycle = recipe.get("lifecycle")
+    if isinstance(lifecycle, dict):
+        for leg in ("pre_state", "post_state"):
+            block = lifecycle.get(leg)
+            if isinstance(block, dict):
+                for a in block.get("assert_jsonpath") or []:
+                    if isinstance(a, dict) and isinstance(a.get("path"), str):
+                        paths_to_check.append(
+                            (f"lifecycle.{leg}.assert_jsonpath.path", a["path"])
+                        )
+        side = lifecycle.get("side_effects") or []
+        if isinstance(side, list):
+            for j, eff in enumerate(side):
+                if isinstance(eff, dict):
+                    for a in eff.get("assert_jsonpath") or []:
+                        if isinstance(a, dict) and isinstance(a.get("path"), str):
+                            paths_to_check.append(
+                                (f"lifecycle.side_effects[{j}].assert_jsonpath.path",
+                                 a["path"])
+                            )
+
+    for location, path in paths_to_check:
+        try:
+            _jp_parse(path)
+        except Exception as e:
+            raise ValidationError(
+                f"Recipe at {source} has invalid JSONPath at `{location}`: "
+                f"{path!r} — {e}"
+            ) from e

--- a/scripts/runtime/recipe_safety.py
+++ b/scripts/runtime/recipe_safety.py
@@ -1,0 +1,118 @@
+"""Sandbox safety gate (RFC v9 D9).
+
+Hard rule: when env=sandbox, fixture execution must:
+1. Send `X-VGFlow-Sandbox: true` header (handled by recipe_auth).
+2. Use sentinel values that backend can recognize as test data:
+   - Email pattern: `*@fixture.vgflow.test`
+   - Env-prefixed identifiers: `VG_FIXTURE_*`
+   - Money amounts ≤ 0.01 (configurable per project)
+3. Reject `side_effect_risk` ∈ {money_like, external_call, volume_change}
+   when env != sandbox.
+
+Failure mode this closes: project's fixture goes ROGUE because backend
+doesn't filter by header — money or external API is hit in main. Sentinels
+make the breach detectable in postmortem (DB query for VG_FIXTURE_* and
+fixture.vgflow.test emails surfaces stray data).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+class SandboxSafetyError(Exception):
+    """Sandbox safety gate refused to execute step."""
+
+
+SENTINEL_EMAIL_RE = re.compile(r"@fixture\.vgflow\.test\b", re.IGNORECASE)
+SENTINEL_PREFIX_RE = re.compile(r"\bVG_FIXTURE_[A-Z0-9_]+\b")
+DEFAULT_MAX_MONEY_AMOUNT = 0.01
+
+RISKY_SIDE_EFFECTS = {"money_like", "external_call", "volume_change"}
+
+
+def is_sentinel_value(value: Any) -> bool:
+    """True if value carries an obvious VG fixture sentinel."""
+    if isinstance(value, str):
+        return bool(SENTINEL_EMAIL_RE.search(value)) or bool(SENTINEL_PREFIX_RE.search(value))
+    if isinstance(value, (int, float)):
+        try:
+            return float(value) <= DEFAULT_MAX_MONEY_AMOUNT
+        except (TypeError, ValueError):
+            return False
+    return False
+
+
+def assert_step_safe(
+    step: dict,
+    env: str,
+    *,
+    money_keys: tuple[str, ...] = ("amount", "total", "value", "price"),
+    max_money: float = DEFAULT_MAX_MONEY_AMOUNT,
+) -> None:
+    """Raise if step would be unsafe in this env.
+
+    Rules:
+    - side_effect_risk ∈ RISKY_SIDE_EFFECTS → only sandbox allowed.
+    - In sandbox: money fields > max_money → must carry sentinel marker
+      elsewhere in body (email, prefix). Unprovable safety → reject.
+    - Outside sandbox: side_effect_risk='none' or absent OR explicit
+      `assert_step_safe(env='main', side_effect_risk='read')` accepted.
+    """
+    risk = step.get("side_effect_risk", "none")
+    if risk in RISKY_SIDE_EFFECTS and env != "sandbox":
+        raise SandboxSafetyError(
+            f"step '{step.get('id', '?')}' has side_effect_risk='{risk}' but "
+            f"env='{env}' — risky steps require env=sandbox (D9). Switch env "
+            f"or set side_effect_risk=none if step is safely read-only."
+        )
+
+    if env == "sandbox":
+        body = step.get("body") or {}
+        if not isinstance(body, dict):
+            return  # nothing to check
+        # Collect all string + numeric leaves
+        body_text = _stringify_leaves(body)
+        body_amounts = _collect_money_values(body, money_keys)
+        # Any money field > threshold → require any sentinel anywhere in body
+        suspicious = [v for v in body_amounts if v > max_money]
+        if suspicious:
+            has_sentinel = (
+                SENTINEL_EMAIL_RE.search(body_text)
+                or SENTINEL_PREFIX_RE.search(body_text)
+            )
+            if not has_sentinel:
+                raise SandboxSafetyError(
+                    f"step '{step.get('id', '?')}' body has money-like "
+                    f"value(s) {suspicious} > {max_money} in sandbox but no "
+                    f"sentinel marker (VG_FIXTURE_* or @fixture.vgflow.test). "
+                    f"D9 demands traceable test data."
+                )
+
+
+def _stringify_leaves(value: Any, parts: list[str] | None = None) -> str:
+    if parts is None:
+        parts = []
+    if isinstance(value, dict):
+        for v in value.values():
+            _stringify_leaves(v, parts)
+    elif isinstance(value, list):
+        for v in value:
+            _stringify_leaves(v, parts)
+    elif isinstance(value, str):
+        parts.append(value)
+    return "\n".join(parts)
+
+
+def _collect_money_values(value: Any, money_keys: tuple[str, ...]) -> list[float]:
+    out: list[float] = []
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if k in money_keys and isinstance(v, (int, float)):
+                out.append(float(v))
+            else:
+                out.extend(_collect_money_values(v, money_keys))
+    elif isinstance(value, list):
+        for v in value:
+            out.extend(_collect_money_values(v, money_keys))
+    return out

--- a/scripts/runtime/recipe_safety.py
+++ b/scripts/runtime/recipe_safety.py
@@ -54,11 +54,25 @@ DEFAULT_IDENTITY_FIELDS = (
 )
 
 
-def is_sentinel_value(value: Any) -> bool:
-    """True if value carries an obvious VG fixture sentinel."""
+def is_sentinel_value(value: Any, *, identity: bool = False) -> bool:
+    """True if value carries an obvious VG fixture sentinel.
+
+    Codex-HIGH-7-bis fix: identity=True restricts to string patterns only
+    (VG_FIXTURE_*, @fixture.vgflow.test). Without this, an `account_id: 0`
+    field passes the gate because 0 ≤ DEFAULT_MAX_MONEY_AMOUNT, which is
+    a false positive — numeric values cannot prove the row is disposable
+    without a fixture-ID registry.
+
+    identity=False (legacy/money path) keeps the under-threshold-numeric
+    rule for amount fields, where ≤0.01 IS meaningful.
+    """
     if isinstance(value, str):
         return bool(SENTINEL_EMAIL_RE.search(value)) \
             or bool(SENTINEL_PREFIX_RE.search(value))
+    if identity:
+        # Identity sentinel must be a string pattern. Numeric IDs (e.g.,
+        # account_id: 0) do NOT qualify — they prove nothing about fixture-ness.
+        return False
     if isinstance(value, bool):
         return False  # bool subclasses int — reject early
     if isinstance(value, (int, float)):
@@ -122,7 +136,8 @@ def _has_sentinel_on_identity_field(
             for k, v in value.items():
                 if k in identity_fields:
                     seen_fields.append(k)
-                    if is_sentinel_value(v):
+                    # Codex-HIGH-7-bis: identity=True forbids numeric "sentinels"
+                    if is_sentinel_value(v, identity=True):
                         return True
                 if walk(v, k):
                     return True

--- a/scripts/runtime/recipe_safety.py
+++ b/scripts/runtime/recipe_safety.py
@@ -1,27 +1,38 @@
-"""Sandbox safety gate (RFC v9 D9).
+"""Sandbox safety gate (RFC v9 D9 + Codex-HIGH-7 hardening).
 
-Hard rule: when env=sandbox, fixture execution must:
+Hard rules when env=sandbox:
 1. Send `X-VGFlow-Sandbox: true` header (handled by recipe_auth).
-2. Use sentinel values that backend can recognize as test data:
-   - Email pattern: `*@fixture.vgflow.test`
-   - Env-prefixed identifiers: `VG_FIXTURE_*`
-   - Money amounts ≤ 0.01 (configurable per project)
-3. Reject `side_effect_risk` ∈ {money_like, external_call, volume_change}
-   when env != sandbox.
+2. base_url MUST match a sandbox URL allowlist (Codex-HIGH-7).
+3. Money-like values > threshold MUST carry sentinel ON identity-bearing
+   fields (merchant_id, user_id, account_id, …) — not just anywhere in
+   body (Codex-HIGH-7: closes "anywhere passes" gap).
+4. Risky `side_effect_risk` ∈ {money_like, external_call, volume_change}
+   → reject when env != sandbox.
+
+Recommended (not enforced by default — opt-in via response_check):
+5. Backend echo handshake — first response in sandbox must carry
+   `X-VGFlow-Sandbox-Echo: true` header. Confirms backend honored the
+   sandbox flag rather than silently routing to prod.
 
 Failure mode this closes: project's fixture goes ROGUE because backend
-doesn't filter by header — money or external API is hit in main. Sentinels
-make the breach detectable in postmortem (DB query for VG_FIXTURE_* and
-fixture.vgflow.test emails surfaces stray data).
+doesn't filter by header — money or external API hits prod. Sentinels
+on identity fields make a breach detectable AND prevent it: a sentinel
+on the merchant_id field forces the request to target a fixture row,
+not just have a sentinel buried in a free-text field.
 """
 from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 
 class SandboxSafetyError(Exception):
     """Sandbox safety gate refused to execute step."""
+
+
+class SandboxEchoMissingError(SandboxSafetyError):
+    """Backend response did not echo X-VGFlow-Sandbox-Echo header."""
 
 
 SENTINEL_EMAIL_RE = re.compile(r"@fixture\.vgflow\.test\b", re.IGNORECASE)
@@ -30,11 +41,26 @@ DEFAULT_MAX_MONEY_AMOUNT = 0.01
 
 RISKY_SIDE_EFFECTS = {"money_like", "external_call", "volume_change"}
 
+# Identity-bearing fields that carry "this row matters" semantics. A
+# sentinel here proves the mutation targets a fixture row; sentinel
+# anywhere else (e.g., free-text note field) does NOT.
+DEFAULT_IDENTITY_FIELDS = (
+    "merchant_id", "merchant", "user_id", "user", "account_id",
+    "account", "customer_id", "customer", "tenant_id", "tenant",
+    "owner_id", "owner", "target_id", "target", "recipient_id",
+    "recipient", "source_id", "source", "wallet_id", "wallet",
+    "subject_id", "subject", "id", "uid",
+    "email",  # email field with sentinel domain proves identity
+)
+
 
 def is_sentinel_value(value: Any) -> bool:
     """True if value carries an obvious VG fixture sentinel."""
     if isinstance(value, str):
-        return bool(SENTINEL_EMAIL_RE.search(value)) or bool(SENTINEL_PREFIX_RE.search(value))
+        return bool(SENTINEL_EMAIL_RE.search(value)) \
+            or bool(SENTINEL_PREFIX_RE.search(value))
+    if isinstance(value, bool):
+        return False  # bool subclasses int — reject early
     if isinstance(value, (int, float)):
         try:
             return float(value) <= DEFAULT_MAX_MONEY_AMOUNT
@@ -43,21 +69,91 @@ def is_sentinel_value(value: Any) -> bool:
     return False
 
 
+def assert_url_in_allowlist(
+    base_url: str,
+    allowlist: list[str] | tuple[str, ...] | None,
+) -> None:
+    """Raise if `base_url` host isn't in `allowlist`.
+
+    `allowlist` entries match by exact host OR by '*.' wildcard suffix
+    (e.g., '*.sandbox.example.com' matches 'foo.sandbox.example.com').
+    None or empty list disables the check (legacy behavior).
+    """
+    if not allowlist:
+        return
+    parsed = urlparse(base_url)
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise SandboxSafetyError(
+            f"base_url '{base_url}' has no parseable host — sandbox "
+            f"allowlist cannot be enforced. Use scheme://host[:port]/path."
+        )
+    for entry in allowlist:
+        entry = entry.lower().strip()
+        if not entry:
+            continue
+        if entry == host:
+            return
+        if entry.startswith("*.") and (
+            host == entry[2:] or host.endswith("." + entry[2:])
+        ):
+            return
+    raise SandboxSafetyError(
+        f"base_url host '{host}' NOT in sandbox_url_allowlist={list(allowlist)}. "
+        f"Refusing to send sandbox traffic to a non-sandbox URL (RFC v9 D9 / "
+        f"Codex-HIGH-7). Add the host to vg.config.md sandbox_url_allowlist "
+        f"if intentional."
+    )
+
+
+def _has_sentinel_on_identity_field(
+    body: Any,
+    identity_fields: tuple[str, ...],
+) -> tuple[bool, list[str]]:
+    """Walk `body` checking if any identity-bearing field carries a sentinel.
+
+    Returns (found, identity_fields_inspected). identity_fields_inspected
+    is the list of identity field NAMES seen in the body (for error msgs).
+    """
+    seen_fields: list[str] = []
+
+    def walk(value: Any, parent_key: str | None = None) -> bool:
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if k in identity_fields:
+                    seen_fields.append(k)
+                    if is_sentinel_value(v):
+                        return True
+                if walk(v, k):
+                    return True
+        elif isinstance(value, list):
+            for v in value:
+                if walk(v, parent_key):
+                    return True
+        return False
+
+    found = walk(body)
+    return found, seen_fields
+
+
 def assert_step_safe(
     step: dict,
     env: str,
     *,
     money_keys: tuple[str, ...] = ("amount", "total", "value", "price"),
     max_money: float = DEFAULT_MAX_MONEY_AMOUNT,
+    identity_fields: tuple[str, ...] = DEFAULT_IDENTITY_FIELDS,
+    require_identity_sentinel: bool = True,
 ) -> None:
     """Raise if step would be unsafe in this env.
 
     Rules:
     - side_effect_risk ∈ RISKY_SIDE_EFFECTS → only sandbox allowed.
-    - In sandbox: money fields > max_money → must carry sentinel marker
-      elsewhere in body (email, prefix). Unprovable safety → reject.
-    - Outside sandbox: side_effect_risk='none' or absent OR explicit
-      `assert_step_safe(env='main', side_effect_risk='read')` accepted.
+    - In sandbox: money fields > max_money MUST have a sentinel on at least
+      one identity-bearing field (require_identity_sentinel=True default).
+      Older callers can opt out with require_identity_sentinel=False, which
+      reverts to "any sentinel anywhere in body" (D9 v1).
+    - Outside sandbox: side_effect_risk='none' or absent are accepted.
     """
     risk = step.get("side_effect_risk", "none")
     if risk in RISKY_SIDE_EFFECTS and env != "sandbox":
@@ -67,27 +163,77 @@ def assert_step_safe(
             f"or set side_effect_risk=none if step is safely read-only."
         )
 
-    if env == "sandbox":
-        body = step.get("body") or {}
-        if not isinstance(body, dict):
-            return  # nothing to check
-        # Collect all string + numeric leaves
-        body_text = _stringify_leaves(body)
-        body_amounts = _collect_money_values(body, money_keys)
-        # Any money field > threshold → require any sentinel anywhere in body
-        suspicious = [v for v in body_amounts if v > max_money]
-        if suspicious:
-            has_sentinel = (
-                SENTINEL_EMAIL_RE.search(body_text)
-                or SENTINEL_PREFIX_RE.search(body_text)
+    if env != "sandbox":
+        return
+
+    body = step.get("body") or {}
+    if not isinstance(body, dict):
+        return  # nothing to check
+
+    body_amounts = _collect_money_values(body, money_keys)
+    suspicious = [v for v in body_amounts if v > max_money]
+    if not suspicious:
+        return
+
+    if require_identity_sentinel:
+        found, seen_fields = _has_sentinel_on_identity_field(body, identity_fields)
+        if not found:
+            raise SandboxSafetyError(
+                f"step '{step.get('id', '?')}' body has money-like "
+                f"value(s) {suspicious} > {max_money} in sandbox but no "
+                f"sentinel marker on any identity-bearing field. "
+                f"Identity fields seen in body: {seen_fields or '[none]'}. "
+                f"Required: at least one of {list(identity_fields)} must "
+                f"carry @fixture.vgflow.test or VG_FIXTURE_* (Codex-HIGH-7). "
+                f"D9 demands the mutation provably target a fixture row."
             )
-            if not has_sentinel:
-                raise SandboxSafetyError(
-                    f"step '{step.get('id', '?')}' body has money-like "
-                    f"value(s) {suspicious} > {max_money} in sandbox but no "
-                    f"sentinel marker (VG_FIXTURE_* or @fixture.vgflow.test). "
-                    f"D9 demands traceable test data."
-                )
+        return
+
+    # Legacy behavior: any sentinel anywhere in body
+    body_text = _stringify_leaves(body)
+    has_sentinel = (
+        SENTINEL_EMAIL_RE.search(body_text)
+        or SENTINEL_PREFIX_RE.search(body_text)
+    )
+    if not has_sentinel:
+        raise SandboxSafetyError(
+            f"step '{step.get('id', '?')}' body has money-like "
+            f"value(s) {suspicious} > {max_money} in sandbox but no "
+            f"sentinel marker (VG_FIXTURE_* or @fixture.vgflow.test) "
+            f"anywhere in body. D9 demands traceable test data."
+        )
+
+
+def assert_response_echo(
+    headers: Any,
+    *,
+    expected_header: str = "X-VGFlow-Sandbox-Echo",
+    expected_value: str = "true",
+) -> None:
+    """Raise if backend response didn't carry the sandbox-echo header.
+
+    Opt-in (callers explicitly invoke). When backend supports the echo
+    handshake, this proves it honored X-VGFlow-Sandbox: true. Without
+    backend support, callers should NOT call this — fall back to URL
+    allowlist + identity sentinel.
+    """
+    # requests.structures.CaseInsensitiveDict + plain dict both expose .get
+    if not hasattr(headers, "get"):
+        raise SandboxEchoMissingError(
+            f"headers object lacks .get() — cannot verify {expected_header}"
+        )
+    actual = headers.get(expected_header) or headers.get(expected_header.lower())
+    if not actual:
+        raise SandboxEchoMissingError(
+            f"backend response missing {expected_header} header. "
+            f"Sandbox mode may not have been honored. Either configure "
+            f"backend to echo, or disable response_check in vg.config.md."
+        )
+    if str(actual).lower() != str(expected_value).lower():
+        raise SandboxEchoMissingError(
+            f"{expected_header}='{actual}' != expected '{expected_value}' — "
+            f"backend rejected sandbox mode."
+        )
 
 
 def _stringify_leaves(value: Any, parts: list[str] | None = None) -> str:
@@ -108,7 +254,7 @@ def _collect_money_values(value: Any, money_keys: tuple[str, ...]) -> list[float
     out: list[float] = []
     if isinstance(value, dict):
         for k, v in value.items():
-            if k in money_keys and isinstance(v, (int, float)):
+            if k in money_keys and isinstance(v, (int, float)) and not isinstance(v, bool):
                 out.append(float(v))
             else:
                 out.extend(_collect_money_values(v, money_keys))

--- a/scripts/runtime/tester_pro.py
+++ b/scripts/runtime/tester_pro.py
@@ -1,0 +1,251 @@
+"""Tester-pro artifacts (RFC v9 D17–D23).
+
+Five artifacts the workflow now produces / consumes for tester-grade
+discipline:
+
+D17 — TEST-STRATEGY.md (per phase) — declares scope, surface taxonomy,
+  test types, exit criteria. Produced at /vg:scope, validated at review.
+
+D18 — test_type classification per goal — {smoke|happy|edge|negative|
+  security|perf|integration}. Validators check coverage across types.
+
+D21 — DEFECT-LOG.md — every BLOCK / unexpected behavior recorded with
+  severity, repro steps, root cause, fix ref. Cumulative across runs.
+
+D22 — TEST-SUMMARY-REPORT.md — final report combining stats:
+  - tests run / passed / failed / blocked
+  - coverage by goal / surface / test_type
+  - defects opened / closed / open
+  - effort estimate vs actual
+
+D23 — RTM (Requirements Traceability Matrix) bi-directional:
+  - Forward: requirement → goals → test cases → defects → fix commits
+  - Reverse: any test/defect/commit → owning requirement
+  Closes the feedback loop the AI most often misses.
+
+This module owns the data structures + serialization + parsing. Skill
+markdown invokes via thin Python wrappers. Validators check that each
+artifact exists when the phase profile demands it.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Test-type taxonomy (D18) — keep small + non-overlapping.
+TEST_TYPES = ("smoke", "happy", "edge", "negative", "security", "perf", "integration")
+
+
+# ─── D18 test_type ─────────────────────────────────────────────────
+
+
+def parse_test_type_from_goal_body(body: str) -> str | None:
+    """Extract `**Test type:** <one>` directive from TEST-GOALS.md goal body.
+
+    Defaults to None (validator surfaces missing as warn).
+    """
+    m = re.search(r"\*\*Test\s*type:\*\*\s*([A-Za-z]+)", body, re.IGNORECASE)
+    if not m:
+        return None
+    t = m.group(1).strip().lower()
+    return t if t in TEST_TYPES else None
+
+
+def coverage_by_test_type(
+    goals: list[dict],
+    *,
+    required_types: Iterable[str] = ("smoke", "happy", "edge"),
+) -> dict[str, int]:
+    """Aggregate goal counts per test_type. Caller asserts required floors."""
+    counts: dict[str, int] = {t: 0 for t in TEST_TYPES}
+    for g in goals:
+        t = g.get("test_type")
+        if t in TEST_TYPES:
+            counts[t] += 1
+    return counts
+
+
+def assert_required_coverage(
+    counts: dict[str, int],
+    *,
+    requirements: dict[str, int],
+) -> list[str]:
+    """Returns list of missing-coverage messages."""
+    missing: list[str] = []
+    for t, floor in requirements.items():
+        if counts.get(t, 0) < floor:
+            missing.append(f"test_type='{t}' has {counts.get(t, 0)} goals, requires ≥{floor}")
+    return missing
+
+
+# ─── D21 DEFECT-LOG ────────────────────────────────────────────────
+
+
+@dataclass
+class Defect:
+    id: str
+    title: str
+    severity: str  # critical | high | medium | low
+    discovered_at: str
+    discovered_in: str  # which step (review/test/accept) found it
+    repro_steps: list[str] = field(default_factory=list)
+    root_cause: str | None = None
+    fix_ref: str | None = None  # commit hash | PR number | "wontfix"
+    closed_at: str | None = None
+    related_goals: list[str] = field(default_factory=list)
+    notes: str = ""
+
+
+def new_defect_id(existing: list[Defect]) -> str:
+    """D-NNN sequential per phase."""
+    used = []
+    for d in existing:
+        m = re.match(r"D-(\d+)$", d.id)
+        if m:
+            used.append(int(m.group(1)))
+    n = (max(used) + 1) if used else 1
+    return f"D-{n:03d}"
+
+
+def render_defect_log(defects: list[Defect]) -> str:
+    lines = ["# DEFECT LOG", "",
+             "| ID | Severity | Title | Discovered in | Closed | Goals |",
+             "|----|----------|-------|----------------|--------|-------|"]
+    for d in defects:
+        closed = d.closed_at or "open"
+        goals = ", ".join(d.related_goals) or "—"
+        lines.append(
+            f"| {d.id} | {d.severity} | {d.title} | {d.discovered_in} | "
+            f"{closed} | {goals} |"
+        )
+    lines.append("")
+    for d in defects:
+        lines.append(f"## {d.id} — {d.title}")
+        lines.append(f"- Severity: {d.severity}")
+        lines.append(f"- Discovered: {d.discovered_at} (in {d.discovered_in})")
+        if d.repro_steps:
+            lines.append("- Repro:")
+            for step in d.repro_steps:
+                lines.append(f"  1. {step}")
+        if d.root_cause:
+            lines.append(f"- Root cause: {d.root_cause}")
+        if d.fix_ref:
+            lines.append(f"- Fix: {d.fix_ref}")
+        if d.related_goals:
+            lines.append(f"- Goals: {', '.join(d.related_goals)}")
+        if d.notes:
+            lines.append(f"- Notes: {d.notes}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ─── D22 TEST-SUMMARY-REPORT ───────────────────────────────────────
+
+
+@dataclass
+class TestSummary:
+    __test__ = False  # not a pytest test class
+    phase: str
+    generated_at: str
+    goals_total: int = 0
+    goals_passed: int = 0
+    goals_failed: int = 0
+    goals_blocked: int = 0
+    coverage_by_type: dict[str, int] = field(default_factory=dict)
+    defects_opened: int = 0
+    defects_closed: int = 0
+    defects_open: int = 0
+    notes: str = ""
+
+
+def render_summary_report(summary: TestSummary) -> str:
+    lines = [
+        f"# TEST SUMMARY REPORT — phase {summary.phase}",
+        f"Generated: {summary.generated_at}",
+        "",
+        "## Goals",
+        f"- Total: {summary.goals_total}",
+        f"- Passed: {summary.goals_passed}",
+        f"- Failed: {summary.goals_failed}",
+        f"- Blocked: {summary.goals_blocked}",
+        "",
+        "## Coverage by test_type",
+    ]
+    for t, n in sorted(summary.coverage_by_type.items()):
+        lines.append(f"- {t}: {n}")
+    lines += [
+        "",
+        "## Defects",
+        f"- Opened (this run): {summary.defects_opened}",
+        f"- Closed (this run): {summary.defects_closed}",
+        f"- Still open: {summary.defects_open}",
+    ]
+    if summary.notes:
+        lines += ["", "## Notes", summary.notes]
+    return "\n".join(lines)
+
+
+# ─── D23 RTM (bi-directional) ─────────────────────────────────────
+
+
+@dataclass
+class TraceabilityRow:
+    requirement_id: str
+    goal_ids: list[str] = field(default_factory=list)
+    test_case_ids: list[str] = field(default_factory=list)
+    defect_ids: list[str] = field(default_factory=list)
+    fix_commits: list[str] = field(default_factory=list)
+
+
+def reverse_index(rows: list[TraceabilityRow]) -> dict[str, list[str]]:
+    """Build reverse map: any leaf id → list of requirements covering it.
+
+    Lets caller answer "what requirements does commit XYZ touch?" in O(1).
+    """
+    rev: dict[str, list[str]] = {}
+    for r in rows:
+        for leaf in r.goal_ids + r.test_case_ids + r.defect_ids + r.fix_commits:
+            rev.setdefault(leaf, []).append(r.requirement_id)
+    return rev
+
+
+def detect_orphan_goals(
+    rows: list[TraceabilityRow],
+    *,
+    declared_goals: set[str],
+) -> list[str]:
+    """Return goal IDs in `declared_goals` not covered by any RTM row."""
+    covered: set[str] = set()
+    for r in rows:
+        covered.update(r.goal_ids)
+    return sorted(declared_goals - covered)
+
+
+def detect_orphan_requirements(
+    rows: list[TraceabilityRow],
+    *,
+    declared_requirements: set[str],
+) -> list[str]:
+    """Return requirement IDs declared but absent from RTM rows."""
+    rtm_reqs = {r.requirement_id for r in rows}
+    return sorted(declared_requirements - rtm_reqs)
+
+
+def render_rtm(rows: list[TraceabilityRow]) -> str:
+    lines = ["# RTM (Requirements Traceability Matrix)", "",
+             "## Forward",
+             "| Requirement | Goals | Test cases | Defects | Fix commits |",
+             "|-------------|-------|------------|---------|-------------|"]
+    for r in rows:
+        lines.append(
+            f"| {r.requirement_id} | "
+            f"{', '.join(r.goal_ids) or '—'} | "
+            f"{', '.join(r.test_case_ids) or '—'} | "
+            f"{', '.join(r.defect_ids) or '—'} | "
+            f"{', '.join(r.fix_commits) or '—'} |"
+        )
+    return "\n".join(lines)

--- a/scripts/spawn-diagnostic-l2.py
+++ b/scripts/spawn-diagnostic-l2.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Spawn Diagnostic L2 subagent (RFC v9 PR-D3 stub-3 fix).
+
+When block-resolver L1 inline auto-fix candidates exhaust, spawn a
+Haiku-tier subagent in an isolated context window to:
+1. Receive gate evidence + nearby file snippets.
+2. Return structured JSON with diagnosis + proposed_fix + confidence.
+
+We invoke via `claude -p` (cheapest path) by default; fallback chain to
+codex/gemini handled in the same way crossai-invoke.md does.
+
+Output (stdout): single JSON line:
+  {"proposal_id": "l2-{epoch}-{rand6}", "confidence": 0.85, "decision_pending": true}
+
+Caller (block-resolver bash) reads proposal_id, invokes
+block_resolve_l3_single_advisory with the confidence — orchestrator does
+the AskUserQuestion + record_decision afterwards.
+
+Usage:
+  scripts/spawn-diagnostic-l2.py \\
+    --gate-id missing-evidence \\
+    --block-family provenance \\
+    --phase-dir .vg/phases/03.2-... \\
+    --evidence-json '{"goal":"G-10","step_idx":2}' \\
+    --gate-context "Mutation step at G-10/step[2] missing evidence.source"
+
+Exit codes:
+  0 — proposal written; proposal_id on stdout
+  1 — subagent failed (CLI error, parse error, auth, timeout)
+  2 — arg error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from runtime.diagnostic_l2 import (  # noqa: E402
+    L2Proposal,
+    make_proposal,
+    write_proposal,
+)
+
+
+PROMPT_TEMPLATE = """You are a Diagnostic L2 architect for a software workflow tool.
+
+A gate failed in the workflow. Layer 1 (cheap auto-fix) couldn't resolve it.
+Your job is to read the gate evidence and propose ONE concrete fix.
+
+## Gate
+ID: {gate_id}
+Family: {block_family}
+
+## Context
+{gate_context}
+
+## Evidence
+{evidence_json}
+
+## Output requirements
+
+Respond with EXACTLY one JSON object on a single line, no other text:
+
+{{"diagnosis": "<one sentence — what went wrong, in plain prose>", "proposed_fix": "<one specific actionable fix — a command, a code change, or a config edit>", "confidence": <float 0.0..1.0>}}
+
+Rules:
+- diagnosis must reference the gate evidence specifically (not generic).
+- proposed_fix must be ONE thing the user/operator can execute, not a menu.
+- confidence reflects how certain you are this fix resolves the gate:
+  - 0.9+ if the fix is mechanical (e.g., add a missing field).
+  - 0.7-0.9 if you've inferred the cause but not verified.
+  - <0.7 if you're guessing — the orchestrator will fall through to
+    multi-option L3 in that case so honesty matters.
+- DO NOT wrap output in code fences. DO NOT add prose before/after the JSON.
+"""
+
+
+def _default_cli() -> list[str]:
+    """Return CLI args for the default subagent invocation.
+
+    Configurable via VG_DIAGNOSTIC_L2_CLI env var (e.g.,
+    `claude --model haiku -p` or `codex exec -m gpt-5.5`).
+    """
+    raw = os.environ.get("VG_DIAGNOSTIC_L2_CLI")
+    if raw:
+        return shlex.split(raw)
+    return ["claude", "--model", "haiku", "-p"]
+
+
+def invoke_subagent(
+    prompt: str,
+    *,
+    cli_args: list[str] | None = None,
+    timeout_s: int = 60,
+) -> dict:
+    """Spawn the subagent CLI; return parsed structured JSON.
+
+    Raises RuntimeError on subprocess failure or parse error.
+    """
+    cli = cli_args if cli_args is not None else _default_cli()
+    try:
+        proc = subprocess.run(
+            cli + [prompt],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"subagent timed out after {timeout_s}s") from e
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            f"subagent CLI '{cli[0]}' not in PATH — set VG_DIAGNOSTIC_L2_CLI "
+            f"to override (e.g., 'codex exec -m gpt-5.5')"
+        ) from e
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"subagent exited {proc.returncode}: {proc.stderr[:300]}"
+        )
+
+    # Parse JSON line from stdout — model may emit prose around it; be tolerant.
+    out = proc.stdout.strip()
+    if not out:
+        raise RuntimeError("subagent emitted empty stdout")
+
+    # Try whole-string JSON first
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back: find JSON object substring
+    start = out.find("{")
+    end = out.rfind("}")
+    if start >= 0 and end > start:
+        candidate = out[start:end + 1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+
+    raise RuntimeError(f"subagent stdout not valid JSON: {out[:300]!r}")
+
+
+def validate_subagent_response(data: dict) -> dict:
+    """Coerce + validate the subagent's structured response."""
+    required = {"diagnosis", "proposed_fix", "confidence"}
+    missing = required - set(data)
+    if missing:
+        raise RuntimeError(f"subagent response missing fields: {sorted(missing)}")
+    diag = str(data["diagnosis"]).strip()
+    if len(diag) < 10:
+        raise RuntimeError(f"diagnosis too short ({len(diag)} chars)")
+    fix = str(data["proposed_fix"]).strip()
+    if len(fix) < 10:
+        raise RuntimeError(f"proposed_fix too short ({len(fix)} chars)")
+    try:
+        conf = float(data["confidence"])
+    except (TypeError, ValueError) as e:
+        raise RuntimeError(f"confidence not numeric: {data['confidence']!r}") from e
+    if not (0.0 <= conf <= 1.0):
+        raise RuntimeError(f"confidence out of range [0,1]: {conf}")
+    return {"diagnosis": diag, "proposed_fix": fix, "confidence": conf}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gate-id", required=True)
+    ap.add_argument("--block-family", required=True)
+    ap.add_argument("--phase-dir", required=True,
+                    help="Absolute path to phase dir (where .l2-proposals lives)")
+    ap.add_argument("--gate-context", default="",
+                    help="One-paragraph human description of the gate failure")
+    ap.add_argument("--evidence-json", default="{}",
+                    help="JSON-encoded evidence dict")
+    ap.add_argument("--cli", default=None,
+                    help="Override CLI args (defaults to VG_DIAGNOSTIC_L2_CLI or 'claude --model haiku -p')")
+    ap.add_argument("--timeout", type=int, default=60)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Skip subagent spawn; emit a stub proposal for testing")
+    args = ap.parse_args()
+
+    phase_dir = Path(args.phase_dir).resolve()
+    if not phase_dir.exists():
+        print(json.dumps({"error": f"phase_dir not found: {phase_dir}"}))
+        return 2
+
+    try:
+        evidence = json.loads(args.evidence_json)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"error": f"--evidence-json parse: {e}"}))
+        return 2
+    if not isinstance(evidence, dict):
+        print(json.dumps({"error": "--evidence-json must encode an object"}))
+        return 2
+
+    if args.dry_run:
+        # Emit a stub proposal without invoking subagent — useful for tests
+        # and for human-in-the-loop fallbacks where the CLI is unavailable.
+        proposal = make_proposal(
+            gate_id=args.gate_id,
+            block_family=args.block_family,
+            evidence_in=evidence,
+            diagnosis=f"[dry-run] would diagnose: {args.gate_context[:120]}",
+            proposed_fix="[dry-run] would propose a fix; re-run without --dry-run for live diagnosis",
+            confidence=0.0,
+        )
+        write_proposal(phase_dir, proposal)
+        print(json.dumps({
+            "proposal_id": proposal.proposal_id,
+            "confidence": proposal.confidence,
+            "decision_pending": True,
+            "dry_run": True,
+        }))
+        return 0
+
+    prompt = PROMPT_TEMPLATE.format(
+        gate_id=args.gate_id,
+        block_family=args.block_family,
+        gate_context=args.gate_context or "(no context provided)",
+        evidence_json=json.dumps(evidence, indent=2, ensure_ascii=False),
+    )
+
+    cli_args = shlex.split(args.cli) if args.cli else None
+    try:
+        raw = invoke_subagent(prompt, cli_args=cli_args, timeout_s=args.timeout)
+        validated = validate_subagent_response(raw)
+    except RuntimeError as e:
+        print(json.dumps({"error": str(e)}))
+        return 1
+
+    proposal = make_proposal(
+        gate_id=args.gate_id,
+        block_family=args.block_family,
+        evidence_in=evidence,
+        diagnosis=validated["diagnosis"],
+        proposed_fix=validated["proposed_fix"],
+        confidence=validated["confidence"],
+    )
+    write_proposal(phase_dir, proposal)
+
+    print(json.dumps({
+        "proposal_id": proposal.proposal_id,
+        "confidence": proposal.confidence,
+        "decision_pending": True,
+        "diagnosis": proposal.diagnosis,
+        "proposed_fix": proposal.proposed_fix,
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spawn-diagnostic-l2.py
+++ b/scripts/spawn-diagnostic-l2.py
@@ -123,13 +123,46 @@ def _scrubbed_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k in allow}
 
 
+def _is_secret_name_string(value: object) -> bool:
+    """True if `value` is a string that looks like a secret-bearing field name.
+
+    Catches the {name: "Authorization", value: "Bearer …"} shape — the
+    name field's VALUE itself is a secret-related label, signaling that
+    sibling `value` is the actual secret.
+    """
+    if not isinstance(value, str):
+        return False
+    return bool(_REDACT_KEYS_RE.search(value))
+
+
 def _redact_secrets(value):
-    """Recursively redact values whose KEY name matches secret patterns."""
+    """Recursively redact values whose KEY name matches secret patterns.
+
+    Codex-R5-HIGH-1 fix: also handle adjacent-key shape. When a dict has
+    a `name` (or `key`/`field`) whose VALUE matches a secret pattern,
+    AND a sibling `value` (or `data`/`val`) field, redact the sibling.
+    Common scanner shape: {name: "Authorization", value: "Bearer …"}.
+    """
     if isinstance(value, dict):
-        return {
-            k: ("[REDACTED]" if _REDACT_KEYS_RE.search(str(k)) else _redact_secrets(v))
-            for k, v in value.items()
-        }
+        # Detect adjacent-key shape first
+        name_field = None
+        value_field = None
+        for k in value:
+            if str(k).lower() in {"name", "key", "field", "header"} and name_field is None:
+                if _is_secret_name_string(value[k]):
+                    name_field = k
+            if str(k).lower() in {"value", "val", "data", "content"} and value_field is None:
+                value_field = k
+        out = {}
+        for k, v in value.items():
+            if _REDACT_KEYS_RE.search(str(k)):
+                out[k] = "[REDACTED]"
+            elif name_field and value_field and k == value_field:
+                # Sibling-secret pattern: redact paired value
+                out[k] = "[REDACTED]"
+            else:
+                out[k] = _redact_secrets(v)
+        return out
     if isinstance(value, list):
         return [_redact_secrets(v) for v in value]
     return value

--- a/scripts/spawn-diagnostic-l2.py
+++ b/scripts/spawn-diagnostic-l2.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import os
 import shlex
 import subprocess
@@ -93,6 +94,47 @@ def _default_cli() -> list[str]:
     return ["claude", "--model", "haiku", "-p"]
 
 
+# Codex-R4-HIGH-4: scrub env so spawned CLI does NOT inherit secrets.
+# Allowlist + project-specific passthrough via VG_DIAGNOSTIC_L2_ENV_PASSTHROUGH.
+_DEFAULT_ENV_ALLOWLIST = (
+    "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL",
+    "TMPDIR", "PWD",
+    # CLI-specific tokens that the spawned CLI itself needs (NOT the parent's
+    # vendor secrets — claude/codex/gemini handle their own auth via OS keychain
+    # or per-CLI config files, NOT env vars by default).
+    "CLAUDE_HOME", "CODEX_HOME", "GEMINI_HOME",
+)
+
+# NB: no word boundaries — "auth_token", "api_key" must match too.
+_REDACT_KEYS_RE = re.compile(
+    r"(?i)(api[_-]?key|secret|token|password|passwd|authorization|"
+    r"bearer|access[_-]?key|private[_-]?key|cookie|credential)"
+)
+
+
+def _scrubbed_env() -> dict[str, str]:
+    """Return env dict with allowlist + opt-in passthrough."""
+    allow = set(_DEFAULT_ENV_ALLOWLIST)
+    passthrough = os.environ.get("VG_DIAGNOSTIC_L2_ENV_PASSTHROUGH", "")
+    for k in passthrough.split(","):
+        k = k.strip()
+        if k:
+            allow.add(k)
+    return {k: v for k, v in os.environ.items() if k in allow}
+
+
+def _redact_secrets(value):
+    """Recursively redact values whose KEY name matches secret patterns."""
+    if isinstance(value, dict):
+        return {
+            k: ("[REDACTED]" if _REDACT_KEYS_RE.search(str(k)) else _redact_secrets(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(v) for v in value]
+    return value
+
+
 def invoke_subagent(
     prompt: str,
     *,
@@ -110,6 +152,7 @@ def invoke_subagent(
             capture_output=True,
             text=True,
             timeout=timeout_s,
+            env=_scrubbed_env(),  # Codex-R4-HIGH-4: scrubbed env
         )
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(f"subagent timed out after {timeout_s}s") from e
@@ -219,11 +262,15 @@ def main() -> int:
         }))
         return 0
 
+    # Codex-R4-HIGH-4: redact secret-keyed evidence fields before sending
+    # to the subagent. Keeps the diagnostic context useful but blocks
+    # accidental token leaks.
+    redacted_evidence = _redact_secrets(evidence)
     prompt = PROMPT_TEMPLATE.format(
         gate_id=args.gate_id,
         block_family=args.block_family,
         gate_context=args.gate_context or "(no context provided)",
-        evidence_json=json.dumps(evidence, indent=2, ensure_ascii=False),
+        evidence_json=json.dumps(redacted_evidence, indent=2, ensure_ascii=False),
     )
 
     cli_args = shlex.split(args.cli) if args.cli else None

--- a/scripts/spawn-diagnostic-l2.py
+++ b/scripts/spawn-diagnostic-l2.py
@@ -145,20 +145,24 @@ def _redact_secrets(value):
     """
     if isinstance(value, dict):
         # Detect adjacent-key shape first
-        name_field = None
-        value_field = None
+        name_field_secret = False
+        value_fields: set = set()
         for k in value:
-            if str(k).lower() in {"name", "key", "field", "header"} and name_field is None:
+            kl = str(k).lower()
+            if kl in {"name", "key", "field", "header"}:
                 if _is_secret_name_string(value[k]):
-                    name_field = k
-            if str(k).lower() in {"value", "val", "data", "content"} and value_field is None:
-                value_field = k
+                    name_field_secret = True
+            if kl in {"value", "val", "data", "content"}:
+                value_fields.add(k)
         out = {}
         for k, v in value.items():
             if _REDACT_KEYS_RE.search(str(k)):
                 out[k] = "[REDACTED]"
-            elif name_field and value_field and k == value_field:
-                # Sibling-secret pattern: redact paired value
+            elif name_field_secret and k in value_fields:
+                # Codex-R6-HIGH-1 fix: redact ALL value-like siblings,
+                # not just the first one. Previous code only caught the
+                # first match — `{name: Authorization, content: public,
+                # value: Bearer SECRET}` would leak `value`.
                 out[k] = "[REDACTED]"
             else:
                 out[k] = _redact_secrets(v)

--- a/scripts/validators/registry.yaml
+++ b/scripts/validators/registry.yaml
@@ -957,9 +957,18 @@ validators:
 
   - id: evidence-provenance
     path: scripts/validators/verify-evidence-provenance.py
-    severity: warn
+    severity: block
     phases_active: [review]
     domain: evidence
     runtime_target_ms: 700
     added_in: v2.46
-    description: 'RFC v9 D10 — every mutation step claiming success (action + 2xx network) must carry structured evidence object {source, artifact_hash, captured_at, schema_version, scanner_run_id|layer2_proposal_id}. Default warn during migration; flip to block via review.provenance.enforcement once /vg:fixture-backfill has run.'
+    description: 'RFC v9 D10 — every mutation step claiming success (action + 2xx network) must carry structured evidence object {source, artifact_hash, captured_at, schema_version, scanner_run_id|layer2_proposal_id}. Codex-HIGH-4 fix: default block. Override via review.provenance.enforcement: warn in vg.config.md OR --allow-legacy-provenance for legacy phases.'
+
+  - id: codegen-fixture-ref
+    path: scripts/validators/verify-codegen-fixture-ref.py
+    severity: block
+    phases_active: [test]
+    domain: evidence
+    runtime_target_ms: 500
+    added_in: v2.46
+    description: 'Codex-HIGH-3 regression guard. When goal has FIXTURES-CACHE.captured but its generated .spec.ts does not reference FIXTURE.* identifiers, codegen-fixture-inject did not run. Override via --allow-no-fixture-ref (override-debt logged).'

--- a/scripts/validators/registry.yaml
+++ b/scripts/validators/registry.yaml
@@ -943,3 +943,23 @@ validators:
     runtime_target_ms: 800
     added_in: v2.35.0
     description: 'v2.35.0 closes #51 invariant 3. Every (resource × role) declared in CRUD-SURFACES.md kit:crud-roundtrip must have runs/{resource}-{role}.json with coverage.attempted >= 1 and evidence_ref populated per non-skipped step. Catches AI gaming via empty run artifacts.'
+
+  # ──── RFC v9 wave-3.2.3 — evidence provenance + matrix-staleness ────
+
+  - id: matrix-staleness
+    path: scripts/validators/verify-matrix-staleness.py
+    severity: block
+    phases_active: [review]
+    domain: evidence
+    runtime_target_ms: 600
+    added_in: v2.46
+    description: 'v2.46-wave3.2 — flag GOAL-COVERAGE-MATRIX rows with status=READY when goal_sequences[gid] has no submit click + 2xx mutation network. Wave-3.2.3 (RFC v9 D10): bidirectional sync (SUSPECTED → READY) only triggers on evidence.source ∈ {scanner, diagnostic_l2}.'
+
+  - id: evidence-provenance
+    path: scripts/validators/verify-evidence-provenance.py
+    severity: warn
+    phases_active: [review]
+    domain: evidence
+    runtime_target_ms: 700
+    added_in: v2.46
+    description: 'RFC v9 D10 — every mutation step claiming success (action + 2xx network) must carry structured evidence object {source, artifact_hash, captured_at, schema_version, scanner_run_id|layer2_proposal_id}. Default warn during migration; flip to block via review.provenance.enforcement once /vg:fixture-backfill has run.'

--- a/scripts/validators/verify-backend-mutation-evidence.py
+++ b/scripts/validators/verify-backend-mutation-evidence.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Validate backend mutation goals (surface=api|data|integration) carry
+replay-style evidence (RFC v9 PR-Z).
+
+Browser-only goals are covered by verify-mutation-actually-submitted.py +
+verify-evidence-provenance.py. Backend goals don't go through the scanner;
+they need a different evidence shape:
+
+Required fields per goal_sequence step (when goal.surface ∈ {api, data,
+integration}):
+  - replay.method
+  - replay.endpoint
+  - replay.status (must match expected_status_range from TEST-GOALS)
+  - replay.captured_at (ISO 8601)
+  - evidence.source ∈ {scanner, executor, diagnostic_l2} (D10 alignment)
+  - evidence.artifact_hash (sha256:...)
+
+When goal.surface = data: also require replay.side_effect_resource (e.g.,
+a `count_query` result confirming row insertion).
+
+Severity: BLOCK (default) | warn (legacy migration grace).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+BACKEND_SURFACES = {"api", "data", "integration"}
+ALLOWED_SOURCES = {"scanner", "executor", "diagnostic_l2"}
+
+
+def _read(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def parse_goals(text: str) -> list[dict]:
+    goals = []
+    for m in re.finditer(
+        r"^##\s+Goal\s+(G-[\w.-]+):?\s*(.*?)$"
+        r"(?P<body>(?:(?!^##\s+Goal\s+).)*)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    ):
+        gid = m.group(1)
+        body = m.group("body") or ""
+        surface_m = re.search(r"\*\*Surface:\*\*\s*(\w+)", body)
+        surface = surface_m.group(1).lower() if surface_m else "ui"
+        me_m = re.search(
+            r"\*\*Mutation evidence:\*\*\s*(.+?)(?=\*\*|\n##|\Z)",
+            body,
+            re.DOTALL,
+        )
+        mutation_evidence = me_m.group(1).strip() if me_m else ""
+        goals.append({
+            "id": gid,
+            "surface": surface,
+            "is_backend": surface in BACKEND_SURFACES,
+            "needs_replay": surface in BACKEND_SURFACES and bool(mutation_evidence),
+        })
+    return goals
+
+
+def validate_step(step: dict, gid: str, surface: str) -> list[dict]:
+    errors: list[dict] = []
+    replay = step.get("replay")
+    evidence = step.get("evidence")
+
+    if not isinstance(replay, dict):
+        errors.append({
+            "type": "replay_missing",
+            "gid": gid,
+            "issue": "backend mutation step missing `replay` block",
+        })
+        return errors
+
+    method = str(replay.get("method") or "").upper()
+    if method not in {"POST", "PUT", "PATCH", "DELETE"}:
+        errors.append({
+            "type": "replay_method_invalid",
+            "gid": gid,
+            "issue": f"replay.method='{method}' not a mutation verb",
+        })
+
+    endpoint = replay.get("endpoint") or ""
+    if not endpoint.startswith("/"):
+        errors.append({
+            "type": "replay_endpoint_invalid",
+            "gid": gid,
+            "issue": f"replay.endpoint must start with '/', got '{endpoint}'",
+        })
+
+    status = replay.get("status")
+    try:
+        code = int(status)
+        if not (200 <= code < 300):
+            errors.append({
+                "type": "replay_status_not_2xx",
+                "gid": gid,
+                "issue": f"replay.status={status} not in 200..299",
+            })
+    except (TypeError, ValueError):
+        errors.append({
+            "type": "replay_status_missing",
+            "gid": gid,
+            "issue": f"replay.status non-numeric: {status!r}",
+        })
+
+    if not replay.get("captured_at"):
+        errors.append({
+            "type": "replay_captured_at_missing",
+            "gid": gid,
+            "issue": "replay.captured_at required (ISO 8601)",
+        })
+
+    if surface == "data" and not replay.get("side_effect_resource"):
+        errors.append({
+            "type": "side_effect_resource_missing",
+            "gid": gid,
+            "issue": (
+                "surface=data step requires replay.side_effect_resource "
+                "(e.g., count query result proving row insertion)"
+            ),
+        })
+
+    # Evidence (RFC v9 D10) — same gate as UI goals
+    if not isinstance(evidence, dict):
+        errors.append({
+            "type": "evidence_missing",
+            "gid": gid,
+            "issue": "step missing structured evidence object",
+        })
+        return errors
+    source = evidence.get("source")
+    if source not in ALLOWED_SOURCES:
+        errors.append({
+            "type": "evidence_source_invalid_for_backend",
+            "gid": gid,
+            "issue": (
+                f"backend evidence.source='{source}' not in "
+                f"{sorted(ALLOWED_SOURCES)} (manual rejected for backend; "
+                f"replay must come from automated runner)"
+            ),
+        })
+    if not evidence.get("artifact_hash", "").startswith("sha256:"):
+        errors.append({
+            "type": "evidence_artifact_hash_invalid",
+            "gid": gid,
+            "issue": "evidence.artifact_hash missing or not sha256:...",
+        })
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify backend mutation evidence (surface=api|data|integration)",
+    )
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--severity", choices=["block", "warn"], default="block")
+    args = parser.parse_args()
+
+    out = Output(validator="backend-mutation-evidence")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"phase: {args.phase}"))
+            emit_and_exit(out)
+
+        goals_path = phase_dir / "TEST-GOALS.md"
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not (goals_path.exists() and runtime_path.exists()):
+            emit_and_exit(out)
+
+        goals = parse_goals(_read(goals_path))
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError:
+            out.add(Evidence(type="runtime_parse_error", message="parse failure"))
+            emit_and_exit(out)
+        sequences = runtime.get("goal_sequences") or {}
+
+        all_errors: list[dict] = []
+        backend_count = 0
+        for goal in goals:
+            if not goal["needs_replay"]:
+                continue
+            backend_count += 1
+            seq = sequences.get(goal["id"])
+            if not isinstance(seq, dict):
+                all_errors.append({
+                    "type": "goal_sequence_missing",
+                    "gid": goal["id"],
+                    "issue": (
+                        f"backend goal {goal['id']} has no goal_sequence entry — "
+                        f"runner did not record evidence"
+                    ),
+                })
+                continue
+            steps = seq.get("steps") or []
+            if not steps:
+                all_errors.append({
+                    "type": "steps_empty",
+                    "gid": goal["id"],
+                    "issue": "backend goal has empty steps[]",
+                })
+                continue
+            # Validate every mutation-claim step (assume all steps that have
+            # replay.method matter — usually 1 per backend goal).
+            mutation_steps_seen = 0
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                if "replay" not in step and "evidence" not in step:
+                    continue  # neutral step (e.g., setup GET)
+                mutation_steps_seen += 1
+                step_errors = validate_step(step, goal["id"], goal["surface"])
+                all_errors.extend(step_errors)
+            if mutation_steps_seen == 0:
+                all_errors.append({
+                    "type": "no_mutation_step",
+                    "gid": goal["id"],
+                    "issue": "no step carries replay/evidence — backend mutation never recorded",
+                })
+
+        out.add(
+            Evidence(
+                type="backend_summary",
+                message=f"{backend_count} backend mutation goals checked, {len(all_errors)} errors",
+            ),
+            escalate=False,
+        )
+        for err in all_errors:
+            out.add(
+                Evidence(
+                    type=err["type"],
+                    message=f"{err['gid']}: {err['issue']}",
+                    file=str(runtime_path),
+                    fix_hint=(
+                        "Add `replay` + `evidence` to the goal_sequence step. "
+                        "Use scripts/runtime/recipe_executor.py to record real "
+                        "POST/PUT/PATCH/DELETE traffic, then attach evidence."
+                    ),
+                ),
+                escalate=(args.severity == "block"),
+            )
+
+        if all_errors and args.severity == "warn":
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{len(all_errors)} backend mutation issues downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-codegen-fixture-ref.py
+++ b/scripts/validators/verify-codegen-fixture-ref.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate codegen specs reference FIXTURE.* when goal has captured store.
+
+Codex-HIGH-3 fix: Codex flagged that the codegen integration was a
+comment-only stub. This validator catches the regression — if a goal
+has FIXTURES-CACHE entry but its generated .spec.ts doesn't reference
+`FIXTURE.*` identifiers, the codegen-fixture-inject step was skipped
+or didn't run.
+
+Severity: BLOCK at /vg:test exit. Override via --allow-no-fixture-ref
+(logs override-debt; legitimate only when codegen intentionally
+ignored the fixture, e.g., goal is read-only).
+
+Usage:
+  scripts/validators/verify-codegen-fixture-ref.py \\
+    --phase 3.2 \\
+    --tests-dir apps/web/e2e
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from runtime.fixture_cache import load as cache_load
+except ImportError:
+    cache_load = None  # type: ignore[assignment]
+
+
+SPEC_PATTERN = re.compile(r"(G-[\w.-]+)\.spec\.ts$")
+FIXTURE_REF_RE = re.compile(r"\bFIXTURE\.[a-zA-Z_$][\w$]*\b")
+
+
+def find_specs(tests_dir: Path) -> dict[str, Path]:
+    if not tests_dir.exists():
+        return {}
+    out: dict[str, Path] = {}
+    for spec in sorted(tests_dir.rglob("*.spec.ts")):
+        m = SPEC_PATTERN.search(spec.name)
+        if m:
+            out[m.group(1)] = spec
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--phase", required=True)
+    ap.add_argument("--tests-dir", default="apps/web/e2e",
+                    help="Generated tests directory (relative to repo root)")
+    ap.add_argument("--severity", choices=["block", "warn"], default="block")
+    ap.add_argument("--allow-no-fixture-ref", action="store_true")
+    args = ap.parse_args()
+
+    out = Output(validator="codegen-fixture-ref")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"phase: {args.phase}"))
+            emit_and_exit(out)
+
+        if cache_load is None:
+            out.add(Evidence(
+                type="runtime_unavailable",
+                message="scripts/runtime not importable — install RFC v9 deps",
+            ))
+            emit_and_exit(out)
+
+        cache_data = cache_load(phase_dir)
+        entries = cache_data.get("entries") or {}
+        goals_with_captured = {
+            gid for gid, e in entries.items()
+            if isinstance(e, dict) and e.get("captured")
+        }
+
+        if not goals_with_captured:
+            out.add(Evidence(
+                type="no_captured_goals",
+                message="FIXTURES-CACHE.json has no captured stores — nothing to verify",
+            ), escalate=False)
+            emit_and_exit(out)
+
+        import os
+        repo = Path(os.environ.get("VG_REPO_ROOT") or os.getcwd()).resolve()
+        tests_dir = (repo / args.tests_dir).resolve()
+        specs = find_specs(tests_dir)
+
+        missing_refs: list[dict] = []
+        missing_specs: list[str] = []
+        ok_count = 0
+
+        for gid in sorted(goals_with_captured):
+            spec_path = specs.get(gid)
+            if spec_path is None:
+                missing_specs.append(gid)
+                continue
+            text = spec_path.read_text(encoding="utf-8")
+            if not FIXTURE_REF_RE.search(text):
+                missing_refs.append({
+                    "gid": gid,
+                    "spec": str(spec_path.relative_to(repo)) if spec_path.is_relative_to(repo) else str(spec_path),
+                })
+            else:
+                ok_count += 1
+
+        out.add(Evidence(
+            type="codegen_fixture_summary",
+            message=(
+                f"{len(goals_with_captured)} goal(s) have captured store; "
+                f"{ok_count} spec(s) reference FIXTURE; "
+                f"{len(missing_refs)} spec(s) missing FIXTURE ref; "
+                f"{len(missing_specs)} goal(s) have no spec at all"
+            ),
+        ), escalate=False)
+
+        if args.allow_no_fixture_ref and (missing_refs or missing_specs):
+            out.add(Evidence(
+                type="override_accepted",
+                message=f"--allow-no-fixture-ref override (debt logged)",
+            ), escalate=False)
+            emit_and_exit(out)
+
+        for entry in missing_refs:
+            out.add(
+                Evidence(
+                    type="fixture_ref_missing",
+                    message=(
+                        f"{entry['gid']} has FIXTURES-CACHE.captured but spec "
+                        f"{entry['spec']} does not reference FIXTURE.*. "
+                        f"codegen-fixture-inject did not run."
+                    ),
+                    file=entry["spec"],
+                    fix_hint=(
+                        f"Run: scripts/codegen-fixture-inject.py "
+                        f"--phase {args.phase} --goal {entry['gid']} "
+                        f"--spec {entry['spec']}"
+                    ),
+                ),
+                escalate=(args.severity == "block"),
+            )
+
+        for gid in missing_specs:
+            out.add(
+                Evidence(
+                    type="spec_missing_for_captured_goal",
+                    message=(
+                        f"{gid} has captured store but no .spec.ts found "
+                        f"under {args.tests_dir}. /vg:test codegen step "
+                        f"skipped this goal."
+                    ),
+                    fix_hint=(
+                        f"Re-run /vg:test {args.phase} (codegen step), or "
+                        f"verify the goal is in scope for codegen."
+                    ),
+                ),
+                escalate=(args.severity == "block"),
+            )
+
+        if (missing_refs or missing_specs) and args.severity == "warn":
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(Evidence(
+                type="severity_downgraded",
+                message=(
+                    f"{len(missing_refs) + len(missing_specs)} issues "
+                    f"downgraded to WARN."
+                ),
+            ), escalate=False)
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-codegen-fixture-ref.py
+++ b/scripts/validators/verify-codegen-fixture-ref.py
@@ -35,8 +35,13 @@ except ImportError:
     cache_load = None  # type: ignore[assignment]
 
 
-SPEC_PATTERN = re.compile(r"(G-[\w.-]+)\.spec\.ts$")
-FIXTURE_REF_RE = re.compile(r"\bFIXTURE\.[a-zA-Z_$][\w$]*\b")
+# Codex-MEDIUM-1 fix: support interactive (`.url-state.spec.ts`) and
+# lowercase goal IDs in spec filenames.
+SPEC_PATTERN = re.compile(r"(?i)\b(G-[\w.-]+?)(?:\.url-state)?\.spec\.ts$")
+# Codex-MEDIUM-2: also detect bracket-notation references (FIXTURE["x"])
+FIXTURE_REF_RE = re.compile(
+    r"\bFIXTURE(?:\.[a-zA-Z_$][\w$]*|\[(?:'[^']*'|\"[^\"]*\")\])"
+)
 
 
 def find_specs(tests_dir: Path) -> dict[str, Path]:
@@ -46,7 +51,11 @@ def find_specs(tests_dir: Path) -> dict[str, Path]:
     for spec in sorted(tests_dir.rglob("*.spec.ts")):
         m = SPEC_PATTERN.search(spec.name)
         if m:
-            out[m.group(1)] = spec
+            # Normalize to canonical uppercase G-XX
+            goal_id = m.group(1)
+            head, _, tail = goal_id.partition("-")
+            normalized = head.upper() + ("-" + tail if tail else "")
+            out[normalized] = spec
     return out
 
 

--- a/scripts/validators/verify-evidence-provenance.py
+++ b/scripts/validators/verify-evidence-provenance.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Verify evidence provenance in goal_sequences (RFC v9 D10).
+
+Closes wave-3.2.2 trust model hole: bidirectional sync (matrix-staleness
+SUSPECTED → READY) was triggering on hand-written `submit + 2xx` evidence.
+Executor agents could fabricate evidence without scanner ever running.
+
+This validator enforces:
+1. Every mutation step in goal_sequences[].steps[] has structured `evidence`
+2. evidence.source ∈ {scanner, executor, orchestrator, diagnostic_l2, manual}
+3. evidence.scanner_run_id (when source=scanner) matches an event in events.db
+4. evidence.artifact_hash present
+5. evidence.captured_at present and parseable
+6. evidence.schema_version matches expected
+
+Companion: matrix-staleness validator updated (RFC v9 D10) to promote
+SUSPECTED → READY ONLY when ALL submit + 2xx steps have
+`evidence.source: scanner` (or `diagnostic_l2` post-fix with audit trail).
+
+Migration: legacy goal_sequences pre-v9 missing evidence object are marked
+`legacy_pre_provenance` and treated informational-only (cannot trigger
+status promotion).
+
+Severity: BLOCK at /vg:review run-complete and /vg:test entry.
+
+Output: standard validator JSON contract (RFC v9 D11):
+  {"verdict": "PASS"|"BLOCK", "block_type": "B", "evidence": [...]}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
+
+EXPECTED_SCHEMA_VERSION = "1.0"
+ALLOWED_SOURCES = {"scanner", "executor", "orchestrator", "diagnostic_l2", "manual"}
+
+# Mutation step heuristic (overlap with mutation-actually-submitted validator):
+# a step is "mutation" if it has `do: click|submit|tap|press` AND target text
+# matches submit/approve/confirm intent.
+MUTATION_ACTIONS = {"click", "submit", "tap", "press"}
+
+
+def _read(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def is_mutation_step(step: dict) -> bool:
+    if not isinstance(step, dict):
+        return False
+    action = str(step.get("do") or step.get("action") or "").lower()
+    if action not in MUTATION_ACTIONS:
+        return False
+    # Heuristic: target/label/selector contains submit/approve/confirm verbs
+    target_text = " ".join(
+        str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+    ).lower()
+    submit_verbs = ("submit", "approve", "confirm", "save", "create",
+                    "update", "delete", "reject", "send", "duyệt", "xác nhận",
+                    "gửi", "tạo", "cập nhật", "xóa", "từ chối")
+    return any(v in target_text for v in submit_verbs)
+
+
+def has_2xx_network(step: dict) -> bool:
+    """Walk step for 2xx mutation network entry."""
+    def walk(value):
+        if isinstance(value, dict):
+            net = value.get("network")
+            entries = []
+            if isinstance(net, list):
+                entries = net
+            elif isinstance(net, dict):
+                entries = [net]
+            for e in entries:
+                if not isinstance(e, dict):
+                    continue
+                method = str(e.get("method") or "").upper()
+                status = e.get("status", e.get("status_code"))
+                try:
+                    code = int(status)
+                except (TypeError, ValueError):
+                    continue
+                if method in {"POST", "PUT", "PATCH", "DELETE"} and 200 <= code < 300:
+                    return True
+            for v in value.values():
+                if walk(v):
+                    return True
+        elif isinstance(value, list):
+            for v in value:
+                if walk(v):
+                    return True
+        return False
+    return walk(step)
+
+
+def validate_evidence(evidence: dict, gid: str, step_idx: int,
+                       events_db_path: Path | None) -> list[dict]:
+    """Validate structured evidence object. Returns list of error dicts."""
+    errors = []
+    if not isinstance(evidence, dict):
+        errors.append({
+            "type": "evidence_not_dict",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": "evidence must be object, got: " + type(evidence).__name__,
+        })
+        return errors
+
+    # Required: source
+    source = evidence.get("source")
+    if source is None:
+        errors.append({
+            "type": "evidence_source_missing",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": "evidence.source field required",
+        })
+    elif source not in ALLOWED_SOURCES:
+        errors.append({
+            "type": "evidence_source_invalid",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": f"evidence.source='{source}' not in {sorted(ALLOWED_SOURCES)}",
+        })
+
+    # Required: artifact_hash (sha256:... format)
+    artifact_hash = evidence.get("artifact_hash")
+    if not artifact_hash or not isinstance(artifact_hash, str):
+        errors.append({
+            "type": "artifact_hash_missing",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": "evidence.artifact_hash required (e.g., sha256:abc123...)",
+        })
+    elif not artifact_hash.startswith("sha256:"):
+        errors.append({
+            "type": "artifact_hash_format",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": f"evidence.artifact_hash must start with 'sha256:', got '{artifact_hash[:20]}'",
+        })
+
+    # Required: captured_at
+    captured_at = evidence.get("captured_at")
+    if not captured_at:
+        errors.append({
+            "type": "captured_at_missing",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": "evidence.captured_at required (ISO 8601)",
+        })
+
+    # Required: schema_version
+    schema_version = evidence.get("schema_version")
+    if not schema_version:
+        errors.append({
+            "type": "schema_version_missing",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": "evidence.schema_version required",
+        })
+    elif not str(schema_version).startswith("1."):
+        errors.append({
+            "type": "schema_version_unsupported",
+            "gid": gid,
+            "step_idx": step_idx,
+            "issue": f"evidence.schema_version='{schema_version}' major mismatch (expected 1.x)",
+        })
+
+    # When source=scanner: scanner_run_id must match events.db entry
+    if source == "scanner":
+        scanner_run_id = evidence.get("scanner_run_id")
+        if not scanner_run_id:
+            errors.append({
+                "type": "scanner_run_id_missing",
+                "gid": gid,
+                "step_idx": step_idx,
+                "issue": "evidence.source=scanner requires evidence.scanner_run_id",
+            })
+        elif events_db_path and events_db_path.exists():
+            # Check events.db has matching haiku_scanner_spawned event
+            try:
+                conn = sqlite3.connect(events_db_path)
+                row = conn.execute(
+                    "SELECT 1 FROM events WHERE event_type='review.haiku_scanner_spawned' "
+                    "AND payload LIKE ? LIMIT 1",
+                    (f"%{scanner_run_id}%",),
+                ).fetchone()
+                conn.close()
+                if not row:
+                    errors.append({
+                        "type": "scanner_run_id_orphan",
+                        "gid": gid,
+                        "step_idx": step_idx,
+                        "issue": (
+                            f"evidence.scanner_run_id='{scanner_run_id}' has no matching "
+                            f"review.haiku_scanner_spawned event in events.db. "
+                            f"Possible fabricated evidence."
+                        ),
+                    })
+            except sqlite3.Error:
+                pass  # events.db unavailable, skip cross-check
+
+    # When source=diagnostic_l2: layer2_proposal_id should be populated
+    if source == "diagnostic_l2":
+        proposal_id = evidence.get("layer2_proposal_id")
+        if not proposal_id:
+            errors.append({
+                "type": "layer2_proposal_id_missing",
+                "gid": gid,
+                "step_idx": step_idx,
+                "issue": "evidence.source=diagnostic_l2 requires evidence.layer2_proposal_id",
+            })
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify evidence provenance in goal_sequences")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument(
+        "--severity",
+        choices=["block", "warn"],
+        default="block",
+        help="block (default v9) or warn (legacy migration mode)",
+    )
+    parser.add_argument(
+        "--allow-legacy",
+        action="store_true",
+        help="Allow goal_sequences without evidence field (mark as legacy_pre_provenance, "
+             "informational only). Use during migration period.",
+    )
+    args = parser.parse_args()
+
+    out = Output(validator="evidence-provenance")
+    with timer(out):
+        phase_dir = find_phase_dir(args.phase)
+        if phase_dir is None:
+            out.add(Evidence(type="phase_not_found", message=f"Phase not found: {args.phase}"))
+            emit_and_exit(out)
+
+        runtime_path = phase_dir / "RUNTIME-MAP.json"
+        if not runtime_path.exists():
+            out.add(Evidence(type="runtime_map_missing", message=f"RUNTIME-MAP.json not found at {runtime_path}"))
+            emit_and_exit(out)
+
+        try:
+            runtime = json.loads(_read(runtime_path))
+        except json.JSONDecodeError as e:
+            out.add(Evidence(type="runtime_map_parse_error", message=str(e)))
+            emit_and_exit(out)
+
+        sequences = runtime.get("goal_sequences") or {}
+        events_db = phase_dir.parent.parent.parent / ".vg" / "events.db"
+        if not events_db.exists():
+            events_db = None
+
+        all_errors: list[dict] = []
+        legacy_count = 0
+        scanner_count = 0
+        non_scanner_count = 0
+        total_mutation_steps = 0
+
+        for gid, seq in sequences.items():
+            if not isinstance(seq, dict):
+                continue
+            steps = seq.get("steps") or []
+            for idx, step in enumerate(steps):
+                if not is_mutation_step(step):
+                    continue
+                # Only enforce on mutation steps that had 2xx (i.e., claim-of-success)
+                if not has_2xx_network(step):
+                    continue
+
+                total_mutation_steps += 1
+                evidence = step.get("evidence")
+                if evidence is None:
+                    if args.allow_legacy:
+                        legacy_count += 1
+                        continue
+                    all_errors.append({
+                        "type": "evidence_missing",
+                        "gid": gid,
+                        "step_idx": idx,
+                        "issue": (
+                            "Mutation step claims success (action + 2xx network) but "
+                            "lacks evidence object. RFC v9 D10 requires structured "
+                            "provenance. Use --allow-legacy during migration."
+                        ),
+                    })
+                    continue
+
+                step_errors = validate_evidence(evidence, gid, idx, events_db)
+                if step_errors:
+                    all_errors.extend(step_errors)
+                else:
+                    source = evidence.get("source")
+                    if source == "scanner":
+                        scanner_count += 1
+                    else:
+                        non_scanner_count += 1
+
+        # Emit summary evidence
+        out.add(
+            Evidence(
+                type="provenance_summary",
+                message=(
+                    f"{total_mutation_steps} mutation steps verified: "
+                    f"{scanner_count} scanner-sourced, "
+                    f"{non_scanner_count} other-sourced, "
+                    f"{legacy_count} legacy (pre-v9), "
+                    f"{len(all_errors)} errors"
+                ),
+            ),
+            escalate=False,
+        )
+
+        # Emit per-error evidence
+        for err in all_errors:
+            out.add(
+                Evidence(
+                    type=err["type"],
+                    message=f"{err['gid']} step[{err['step_idx']}]: {err['issue']}",
+                    file=str(runtime_path),
+                    fix_hint=(
+                        "Add structured evidence object to step in RUNTIME-MAP.json. "
+                        "Schema: { source, artifact_hash, captured_at, schema_version, "
+                        "scanner_run_id (when source=scanner), layer2_proposal_id "
+                        "(when source=diagnostic_l2) }. "
+                        "If migrating legacy phase, run with --allow-legacy."
+                    ),
+                ),
+                escalate=(args.severity == "block"),
+            )
+
+        # Severity downgrade for warn mode
+        if all_errors and args.severity == "warn":
+            if out.verdict == "BLOCK":
+                out.verdict = "WARN"
+            out.add(
+                Evidence(
+                    type="severity_downgraded",
+                    message=f"{len(all_errors)} provenance errors downgraded to WARN.",
+                ),
+                escalate=False,
+            )
+
+    emit_and_exit(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validators/verify-matrix-staleness.py
+++ b/scripts/validators/verify-matrix-staleness.py
@@ -21,6 +21,11 @@ Output:
 When this validator passes (zero SUSPECTED), --retry-failed can trust matrix.
 When BLOCKs, user MUST run --retry-failed (which will now include SUSPECTED)
 to refresh evidence.
+
+v2.46-wave3.2.3 (RFC v9 D10): bidirectional sync (SUSPECTED → READY) now
+requires trustworthy provenance — only `evidence.source: scanner` (with
+scanner_run_id) or `evidence.source: diagnostic_l2` (with audit trail)
+can promote. Hand-written `executor`/`manual` evidence keeps SUSPECTED.
 """
 from __future__ import annotations
 
@@ -34,6 +39,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 from _common import Evidence, Output, emit_and_exit, find_phase_dir, timer  # noqa: E402
 
 MUTATION_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+# v2.46-wave3.2.3 (RFC v9 D10): only these sources are trustworthy enough
+# to flip SUSPECTED → READY. `executor`/`orchestrator`/`manual` evidence can
+# be hand-fabricated; bidirectional sync used to ping-pong on those.
+TRUSTWORTHY_PROVENANCE_SOURCES = {"scanner", "diagnostic_l2"}
 SUBMIT_TARGET_RE = re.compile(
     r"\b(submit|approve|confirm|save|create|update|delete|reject|send|"
     r"d[uồ]ng\s*[yý]|duy[eệ]t|x[aá]c\s*nh[aậ]n|g[uử]i|t[aạ]o|c[aậ]p\s*nh[aậ]t|"
@@ -109,6 +118,61 @@ def has_submit_step(seq: dict) -> bool:
         if SUBMIT_TARGET_RE.search(target) and not CANCEL_TARGET_RE.search(target):
             return True
     return False
+
+
+def trustworthy_submit_evidence(seq: dict) -> tuple[bool, str | None]:
+    """Walk seq for a submit/mutation step bearing trustworthy provenance.
+
+    RFC v9 D10: only `evidence.source: scanner` (with scanner_run_id) or
+    `evidence.source: diagnostic_l2` (with layer2_proposal_id audit trail)
+    can promote SUSPECTED → READY. Hand-written `executor` / `manual`
+    evidence is rejected — that was the wave-3.2.2 trust hole.
+
+    Returns (trustworthy, reason). When False, reason explains why so the
+    validator can surface it.
+    """
+    steps = seq.get("steps") or []
+    if not isinstance(steps, list):
+        return False, "steps not list"
+
+    submit_actions = {"click", "tap", "press", "submit"}
+    found_any_submit_step = False
+    weak_source: str | None = None
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        action = str(step.get("do") or step.get("action") or "").lower()
+        if action not in submit_actions:
+            continue
+        target_text = " ".join(
+            str(step.get(k, "")) for k in ("target", "label", "selector", "name")
+        )
+        if not SUBMIT_TARGET_RE.search(target_text):
+            continue
+        if CANCEL_TARGET_RE.search(target_text):
+            continue
+        # This is a submit-intent step. Check provenance.
+        found_any_submit_step = True
+        evidence = step.get("evidence")
+        if not isinstance(evidence, dict):
+            continue
+        source = evidence.get("source")
+        if source not in TRUSTWORTHY_PROVENANCE_SOURCES:
+            if source:
+                weak_source = str(source)
+            continue
+        if source == "scanner" and not evidence.get("scanner_run_id"):
+            continue
+        if source == "diagnostic_l2" and not evidence.get("layer2_proposal_id"):
+            continue
+        return True, None
+
+    if not found_any_submit_step:
+        return False, "no submit step"
+    if weak_source:
+        return False, f"submit evidence.source={weak_source} not in {{scanner,diagnostic_l2}}"
+    return False, "submit step lacks structured evidence object"
 
 
 def has_mutation_network(seq: dict) -> bool:
@@ -226,14 +290,21 @@ def main() -> None:
             # to READY. Closes the workflow loop: retry-failed → re-record
             # evidence → matrix flips back. Without this, /vg:test sees
             # permanent SUSPECTED even after fix.
+            #
+            # v2.46-wave3.2.3 (RFC v9 D10): require trustworthy provenance.
+            # Without provenance check, an executor agent could hand-write a
+            # submit step + fake 2xx network entry to fabricate evidence.
+            # Only scanner (with scanner_run_id) or diagnostic_l2 (with
+            # layer2_proposal_id) can promote.
             if current_status == "SUSPECTED" and isinstance(seq, dict):
-                if has_submit_step(seq) and has_mutation_network(seq):
+                trustworthy, reason = trustworthy_submit_evidence(seq)
+                if has_submit_step(seq) and has_mutation_network(seq) and trustworthy:
                     out.add(
                         Evidence(
                             type="suspected_resolved",
                             message=(
                                 f"{gid} '{goal['title'][:60]}': SUSPECTED → READY "
-                                f"(real submit + 2xx evidence now present)"
+                                f"(scanner/diagnostic_l2 submit + 2xx evidence)"
                             ),
                         ),
                         escalate=False,
@@ -241,8 +312,23 @@ def main() -> None:
                     if args.apply_status_update:
                         matrix_text = update_matrix_status(
                             matrix_text, gid, "READY",
-                            note="resolved: submit+2xx evidence recorded",
+                            note="resolved: trustworthy submit+2xx evidence",
                         )
+                elif has_submit_step(seq) and has_mutation_network(seq) and not trustworthy:
+                    # Submit + 2xx exist but provenance is weak — surface so user
+                    # knows why SUSPECTED won't lift. Don't escalate; keep WARN.
+                    out.add(
+                        Evidence(
+                            type="suspected_kept_weak_provenance",
+                            message=(
+                                f"{gid} '{goal['title'][:60]}': has submit+2xx but "
+                                f"NOT promoted ({reason}). Re-run scanner via "
+                                f"/vg:review --re-scan-goals={gid}."
+                            ),
+                            file=str(matrix_path),
+                        ),
+                        escalate=False,
+                    )
                 continue  # Already SUSPECTED — don't re-flag, just resolve if applicable
 
             if current_status != "READY":

--- a/sync.sh
+++ b/sync.sh
@@ -197,6 +197,11 @@ sync_tree "$SCRIPT_DIR/skills" "$TARGET_ROOT/.claude/skills" "claude-skill"
 sync_tree "$SCRIPT_DIR/scripts" "$TARGET_ROOT/.claude/scripts" "claude-script"
 sync_tree "$SCRIPT_DIR/schemas" "$TARGET_ROOT/.claude/schemas" "claude-schema"
 sync_tree "$SCRIPT_DIR/templates/vg" "$TARGET_ROOT/.claude/templates/vg" "claude-template"
+# RFC v9 PR-research-augment: catalog/ holds the local edge-case pattern store
+# consumed by scripts/runtime/pattern_catalog.py. Skip silently when source
+# absent (older vgflow versions don't ship it).
+[ -d "$SCRIPT_DIR/catalog" ] && \
+  sync_tree "$SCRIPT_DIR/catalog" "$TARGET_ROOT/.claude/catalog" "claude-catalog"
 compare "$SCRIPT_DIR/VGFLOW-VERSION" "$TARGET_ROOT/.claude/VGFLOW-VERSION" "claude-version"
 if [ "$MODE_CHECK" = "false" ]; then
   chmod +x "$TARGET_ROOT/.claude/commands/vg/_shared/lib/"*.sh 2>/dev/null || true

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -1,0 +1,248 @@
+"""Tests for scripts/runtime/api_index.py — RFC v9 PR-C count_fn wiring."""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+requests = pytest.importorskip("requests")
+
+from runtime.api_index import (  # noqa: E402
+    ApiIndexError,
+    count_fn_factory,
+    parse_api_index,
+)
+from runtime.recipe_executor import RecipeRunner  # noqa: E402
+
+
+# ─── parse_api_index ──────────────────────────────────────────────────
+
+
+def test_parse_api_index_yaml_block(tmp_path):
+    pytest.importorskip("yaml")
+    md = """
+# ENV-CONTRACT
+
+```yaml
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+    count_query_keys: [tier, status]
+  withdraw:
+    count_endpoint: /api/admin/withdraw
+    count_jsonpath: $.data.length
+    count_role: admin
+```
+""".lstrip()
+    p = tmp_path / "ENV.md"
+    p.write_text(md, encoding="utf-8")
+    idx = parse_api_index(p)
+    assert "topup" in idx
+    assert idx["topup"].count_endpoint == "/api/admin/topup"
+    assert idx["topup"].count_query_keys == ["tier", "status"]
+    assert idx["withdraw"].count_jsonpath == "$.data.length"
+
+
+def test_parse_api_index_missing_required_raises(tmp_path):
+    pytest.importorskip("yaml")
+    md = """
+```yaml
+api_index:
+  topup:
+    count_endpoint: /api/x
+    # missing count_jsonpath
+    count_role: admin
+```
+""".lstrip()
+    p = tmp_path / "ENV.md"
+    p.write_text(md, encoding="utf-8")
+    with pytest.raises(ApiIndexError, match="count_jsonpath"):
+        parse_api_index(p)
+
+
+def test_parse_api_index_no_block_returns_empty(tmp_path):
+    p = tmp_path / "ENV.md"
+    p.write_text("No api_index here.\n", encoding="utf-8")
+    assert parse_api_index(p) == {}
+
+
+# ─── count_fn_factory — live HTTP ─────────────────────────────────────
+
+
+class _CountHandler(http.server.BaseHTTPRequestHandler):
+    routes: dict = {}
+    log: list = []
+    log_message = lambda *a, **k: None
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.log.append({"path": self.path, "headers": dict(self.headers)})
+        # Match by method + path-prefix (drop query string for routing)
+        path_only = self.path.split("?", 1)[0]
+        route = self.routes.get(("GET", path_only))
+        if route is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        # Allow per-request override based on full path (incl. query)
+        full_route = self.routes.get(("GET", self.path), route)
+        status = full_route.get("status", 200)
+        body = full_route.get("body", {})
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def do_POST(self) -> None:  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+
+@pytest.fixture
+def server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    routes: dict = {}
+    log: list = []
+
+    class _H(_CountHandler):
+        pass
+
+    _H.routes = routes
+    _H.log = log
+    srv = http.server.HTTPServer(("127.0.0.1", port), _H)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}", routes, log
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def test_count_fn_extracts_scalar(server):
+    base_url, routes, log = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"meta": {"total": 7}, "data": []},
+    }
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"admin": {"kind": "api_key", "key": "k"}},
+    )
+    from runtime.api_index import ResourceCounter
+    idx = {"topup": ResourceCounter(
+        resource="topup",
+        count_endpoint="/api/admin/topup",
+        count_jsonpath="$.meta.total",
+        count_role="admin",
+        count_query_keys=["tier", "status"],
+    )}
+    count = count_fn_factory(idx, runner)
+    n = count("topup", {"tier": 2, "status": "pending"})
+    assert n == 7
+    # Query string only includes count_query_keys
+    paths = [e["path"] for e in log]
+    assert any("tier=2" in p and "status=pending" in p for p in paths)
+
+
+def test_count_fn_filters_unknown_query_keys(server):
+    base_url, routes, log = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"data": [1, 2, 3]},
+    }
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"admin": {"kind": "api_key", "key": "k"}},
+    )
+    from runtime.api_index import ResourceCounter
+    idx = {"topup": ResourceCounter(
+        resource="topup",
+        count_endpoint="/api/admin/topup",
+        count_jsonpath="$.data",  # array → length
+        count_role="admin",
+        count_query_keys=["tier"],  # ONLY tier passes through
+    )}
+    count = count_fn_factory(idx, runner)
+    n = count("topup", {"tier": 2, "internal_flag": "secret"})
+    assert n == 3
+    assert all("internal_flag" not in e["path"] for e in log)
+
+
+def test_count_fn_array_jsonpath_returns_len(server):
+    base_url, routes, _ = server
+    routes[("GET", "/api/admin/withdraw")] = {
+        "status": 200, "body": {"data": [{"id": 1}, {"id": 2}]},
+    }
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"admin": {"kind": "api_key", "key": "k"}},
+    )
+    from runtime.api_index import ResourceCounter
+    idx = {"withdraw": ResourceCounter(
+        resource="withdraw",
+        count_endpoint="/api/admin/withdraw",
+        count_jsonpath="$.data[*]",
+        count_role="admin",
+    )}
+    count = count_fn_factory(idx, runner)
+    assert count("withdraw", {}) == 2
+
+
+def test_count_fn_string_int_coerced(server):
+    base_url, routes, _ = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"meta": {"total": "42"}},
+    }
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"admin": {"kind": "api_key", "key": "k"}},
+    )
+    from runtime.api_index import ResourceCounter
+    idx = {"topup": ResourceCounter(
+        resource="topup",
+        count_endpoint="/api/admin/topup",
+        count_jsonpath="$.meta.total",
+        count_role="admin",
+    )}
+    count = count_fn_factory(idx, runner)
+    assert count("topup", {}) == 42
+
+
+def test_count_fn_unknown_resource_raises(server):
+    base_url, _, _ = server
+    runner = RecipeRunner(base_url=base_url, env="sandbox", credentials_map={})
+    count = count_fn_factory({}, runner)
+    with pytest.raises(ApiIndexError, match="no entry for resource"):
+        count("missing", {})
+
+
+def test_count_fn_500_raises(server):
+    base_url, routes, _ = server
+    routes[("GET", "/api/admin/topup")] = {"status": 500, "body": {"err": "oops"}}
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"admin": {"kind": "api_key", "key": "k"}},
+    )
+    from runtime.api_index import ResourceCounter
+    idx = {"topup": ResourceCounter(
+        resource="topup",
+        count_endpoint="/api/admin/topup",
+        count_jsonpath="$.meta.total",
+        count_role="admin",
+    )}
+    count = count_fn_factory(idx, runner)
+    with pytest.raises(ApiIndexError, match="500"):
+        count("topup", {})

--- a/tests/test_backend_mutation_evidence.py
+++ b/tests/test_backend_mutation_evidence.py
@@ -1,0 +1,174 @@
+"""Tests for verify-backend-mutation-evidence.py — RFC v9 PR-Z."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "validators" / "verify-backend-mutation-evidence.py"
+
+
+def _run(repo: Path, phase: str, *flags: str) -> tuple[int, dict]:
+    cmd = [sys.executable, str(VALIDATOR), "--phase", phase, *flags]
+    proc = subprocess.run(
+        cmd,
+        env={"VG_REPO_ROOT": str(repo), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    try:
+        out = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        out = {"verdict": "PARSE_ERROR", "stdout": proc.stdout, "stderr": proc.stderr}
+    return proc.returncode, out
+
+
+def _phase(tmp_path: Path, surface: str, sequences: dict) -> Path:
+    phases_dir = tmp_path / ".vg" / "phases"
+    phase_dir = phases_dir / "99.9-backend"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "TEST-GOALS.md").write_text(
+        f"## Goal G-01: Backend goal\n"
+        f"**Surface:** {surface}\n"
+        f"**Mutation evidence:** POST /api/x → 200\n",
+        encoding="utf-8",
+    )
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps({"goal_sequences": sequences}), encoding="utf-8",
+    )
+    return phase_dir
+
+
+def _good_step(surface: str = "api") -> dict:
+    step = {
+        "replay": {
+            "method": "POST",
+            "endpoint": "/api/x",
+            "status": 200,
+            "captured_at": "2026-05-02T10:00:00Z",
+        },
+        "evidence": {
+            "source": "scanner",
+            "artifact_hash": "sha256:abcdef",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "scanner_run_id": "haiku-r1",
+            "schema_version": "1.0",
+        },
+    }
+    if surface == "data":
+        step["replay"]["side_effect_resource"] = {"count_query": "SELECT COUNT(*)", "count": 1}
+    return step
+
+
+def test_complete_api_evidence_passes(tmp_path):
+    repo = tmp_path
+    _phase(repo, "api", {"G-01": {"steps": [_good_step("api")]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 0, out
+    assert out["verdict"] in ("PASS", "WARN")
+
+
+def test_data_surface_requires_side_effect_resource(tmp_path):
+    repo = tmp_path
+    step = _good_step("api")  # missing side_effect_resource
+    _phase(repo, "data", {"G-01": {"steps": [step]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "side_effect_resource_missing" in types
+
+
+def test_missing_replay_blocks(tmp_path):
+    repo = tmp_path
+    _phase(repo, "api", {"G-01": {"steps": [{"evidence": {"source": "scanner"}}]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "replay_missing" in types
+
+
+def test_missing_evidence_blocks(tmp_path):
+    repo = tmp_path
+    step = _good_step("api")
+    del step["evidence"]
+    _phase(repo, "api", {"G-01": {"steps": [step]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "evidence_missing" in types
+
+
+def test_manual_source_rejected_for_backend(tmp_path):
+    repo = tmp_path
+    step = _good_step("api")
+    step["evidence"]["source"] = "manual"
+    _phase(repo, "api", {"G-01": {"steps": [step]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "evidence_source_invalid_for_backend" in types
+
+
+def test_status_4xx_blocks(tmp_path):
+    repo = tmp_path
+    step = _good_step("api")
+    step["replay"]["status"] = 422
+    _phase(repo, "api", {"G-01": {"steps": [step]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "replay_status_not_2xx" in types
+
+
+def test_ui_surface_skipped(tmp_path):
+    """UI goals are not the responsibility of this validator."""
+    repo = tmp_path
+    phases_dir = repo / ".vg" / "phases"
+    phase_dir = phases_dir / "99.9-ui"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "TEST-GOALS.md").write_text(
+        "## Goal G-01: UI\n**Surface:** ui\n**Mutation evidence:** click submit\n",
+        encoding="utf-8",
+    )
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps({"goal_sequences": {"G-01": {"steps": []}}}),
+        encoding="utf-8",
+    )
+    rc, out = _run(repo, "99.9")
+    assert rc == 0  # UI not flagged here
+    msg = " ".join(e.get("message", "") for e in out["evidence"])
+    assert "0 backend mutation goals" in msg
+
+
+def test_warn_severity_downgrades(tmp_path):
+    repo = tmp_path
+    _phase(repo, "api", {"G-01": {"steps": [{"evidence": {"source": "scanner"}}]}})
+    rc, out = _run(repo, "99.9", "--severity", "warn")
+    assert rc == 0
+    assert out["verdict"] in ("WARN", "PASS")
+    types = [e["type"] for e in out["evidence"]]
+    assert "severity_downgraded" in types
+
+
+def test_missing_goal_sequence_blocks(tmp_path):
+    repo = tmp_path
+    _phase(repo, "api", {})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "goal_sequence_missing" in types
+
+
+def test_no_mutation_step_blocks(tmp_path):
+    repo = tmp_path
+    # Step without replay or evidence — neutral; produces no_mutation_step error
+    _phase(repo, "api", {"G-01": {"steps": [{"do": "nothing"}]}})
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out["evidence"]]
+    assert "no_mutation_step" in types

--- a/tests/test_block_aggregator.py
+++ b/tests/test_block_aggregator.py
@@ -42,12 +42,14 @@ def test_three_same_gate_aggregated():
 
 
 def test_below_threshold_not_aggregated():
+    """Codex MEDIUM fix: is_aggregated now respects threshold (was True
+    for any count > 1 — inconsistent with should_aggregate)."""
     instances = [_instance("missing-artifact", artifact=f"X{i}.md") for i in range(2)]
     out = aggregate(instances, threshold=3)
-    # Returns 1 group of 2 (still grouped by gate_id, but treated as singleton path)
     assert len(out) == 1
-    assert out[0].instance_count == 2  # is_aggregated property: True
-    assert out[0].is_aggregated is True  # > 1 — but caller decides routing
+    assert out[0].instance_count == 2
+    assert out[0].is_aggregated is False  # 2 < threshold 3 → not aggregated
+    assert out[0].threshold_used == 3
 
 
 def test_mixed_families_grouped_separately():
@@ -131,3 +133,11 @@ def test_sample_evidence_truncated_to_5():
 def test_invalid_input_raises():
     with pytest.raises(TypeError):
         aggregate(["not a BlockInstance"], threshold=3)
+
+
+def test_threshold_2_makes_count_2_aggregated():
+    """is_aggregated semantics depend on the threshold the aggregator was built with."""
+    instances = [_instance("g") for _ in range(2)]
+    out = aggregate(instances, threshold=2)
+    assert out[0].is_aggregated is True
+    assert out[0].threshold_used == 2

--- a/tests/test_block_aggregator.py
+++ b/tests/test_block_aggregator.py
@@ -1,0 +1,133 @@
+"""Tests for scripts/runtime/block_aggregator.py — RFC v9 D28."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.block_aggregator import (  # noqa: E402
+    AggregatedBlock,
+    BlockInstance,
+    aggregate,
+    should_aggregate,
+)
+
+
+def _instance(gate_id: str, family: str = "missing-artifact",
+              severity: str = "block", **evidence) -> BlockInstance:
+    return BlockInstance(
+        gate_id=gate_id, family=family, severity=severity,
+        evidence=evidence,
+    )
+
+
+def test_single_instance_passes_through_as_singleton():
+    out = aggregate([_instance("g1", artifact="X.md")], threshold=3)
+    assert len(out) == 1
+    assert out[0].instance_count == 1
+    assert not out[0].is_aggregated
+
+
+def test_three_same_gate_aggregated():
+    instances = [_instance("missing-artifact", artifact=f"X{i}.md") for i in range(3)]
+    out = aggregate(instances, threshold=3)
+    assert len(out) == 1
+    assert out[0].instance_count == 3
+    assert out[0].is_aggregated
+    assert out[0].gate_id == "missing-artifact"
+
+
+def test_below_threshold_not_aggregated():
+    instances = [_instance("missing-artifact", artifact=f"X{i}.md") for i in range(2)]
+    out = aggregate(instances, threshold=3)
+    # Returns 1 group of 2 (still grouped by gate_id, but treated as singleton path)
+    assert len(out) == 1
+    assert out[0].instance_count == 2  # is_aggregated property: True
+    assert out[0].is_aggregated is True  # > 1 — but caller decides routing
+
+
+def test_mixed_families_grouped_separately():
+    instances = [
+        _instance("missing-artifact", artifact="A.md"),
+        _instance("missing-artifact", artifact="B.md"),
+        _instance("missing-artifact", artifact="C.md"),
+        _instance("traceability-orphan", goal="G-1"),
+    ]
+    out = aggregate(instances, threshold=3)
+    assert len(out) == 2
+    counts = {a.gate_id: a.instance_count for a in out}
+    assert counts == {"missing-artifact": 3, "traceability-orphan": 1}
+
+
+def test_severity_max_propagates():
+    instances = [
+        _instance("g", severity="warn"),
+        _instance("g", severity="block"),
+        _instance("g", severity="advisory"),
+    ]
+    out = aggregate(instances, threshold=2)
+    assert out[0].severity == "block"
+
+
+def test_capped_at_max_merged_evidence():
+    instances = [_instance("g", n=i) for i in range(100)]
+    out = aggregate(instances, threshold=3, max_merged_evidence=10)
+    assert out[0].instance_count == 100  # total reported
+    assert len(out[0].instances) == 10  # but capped
+    assert "Capped to first 10" in out[0].merged_context
+
+
+def test_sort_aggregated_before_singletons():
+    instances = [
+        _instance("g-singleton-1", n=1),
+        *[_instance("g-aggregated", n=i) for i in range(5)],
+        _instance("g-singleton-2", n=2),
+    ]
+    out = aggregate(instances, threshold=3)
+    # Aggregated first
+    assert out[0].instance_count == 5
+    assert out[0].gate_id == "g-aggregated"
+    assert out[1].instance_count == 1
+    assert out[2].instance_count == 1
+
+
+def test_merged_context_includes_evidence_details():
+    instances = [_instance("g", artifact=f"file{i}.md") for i in range(3)]
+    out = aggregate(instances, threshold=3)
+    ctx = out[0].merged_context
+    assert "Total instances: 3" in ctx
+    assert "file0.md" in ctx
+    assert "severity=block" in ctx
+
+
+def test_should_aggregate_helper_above_threshold():
+    instances = [_instance("g") for _ in range(4)]
+    assert should_aggregate(instances, threshold=3)
+
+
+def test_should_aggregate_helper_below_threshold():
+    instances = [_instance("g") for _ in range(2)]
+    assert not should_aggregate(instances, threshold=3)
+
+
+def test_should_aggregate_helper_mixed_one_meets_threshold():
+    instances = [
+        *[_instance("g1") for _ in range(4)],
+        *[_instance("g2") for _ in range(1)],
+    ]
+    assert should_aggregate(instances, threshold=3)
+
+
+def test_sample_evidence_truncated_to_5():
+    instances = [_instance("g", n=i) for i in range(10)]
+    out = aggregate(instances, threshold=3)
+    assert len(out[0].sample_evidence) == 5
+
+
+def test_invalid_input_raises():
+    with pytest.raises(TypeError):
+        aggregate(["not a BlockInstance"], threshold=3)

--- a/tests/test_block_resolver_l2_handoff.sh
+++ b/tests/test_block_resolver_l2_handoff.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tests for block_resolve_l2_handoff (Codex-R7 fix).
+# Validates: handoff brief extracts recommendations from BOTH legacy
+# `proposal.suggested_actions` shape AND diagnostic-L2
+# `proposal.decision_questions[0].recommendation` shape.
+
+set -euo pipefail
+
+REPO_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${REPO_ROOT_DIR}/commands/vg/_shared/lib/block-resolver.sh"
+
+# shellcheck disable=SC1090
+REPO_ROOT="$REPO_ROOT_DIR" source "$LIB"
+export REPO_ROOT="$REPO_ROOT_DIR"
+
+PASSED=0
+FAILED=0
+fail() { echo "  ✗ $1" >&2; FAILED=$((FAILED + 1)); }
+pass() { echo "  ✓ $1"; PASSED=$((PASSED + 1)); }
+
+# ─── Test 1: legacy shape — suggested_actions list ──────────────────
+TMP=$(mktemp -d)
+PHASE_DIR="$TMP"
+LEGACY_RESULT=$(cat <<'JSON'
+{"level":"L2","action":"proposal","proposal":{
+  "type":"refactor","summary":"split into sub-phases",
+  "confidence":0.85,
+  "rationale":"too many tasks in one phase",
+  "suggested_actions":["create sub-phase 7.1.1","move task A","move task B"]
+}}
+JSON
+)
+
+block_resolve_l2_handoff "test-gate" "$LEGACY_RESULT" "$PHASE_DIR" >/dev/null 2>&1 || true
+
+BRIEF="$PHASE_DIR/.block-resolver-l2-brief.md"
+if [ -f "$BRIEF" ]; then
+  pass "brief written"
+else
+  fail "brief not written"
+fi
+
+if grep -q 'create sub-phase 7.1.1' "$BRIEF"; then
+  pass "legacy suggested_actions appear in brief"
+else
+  fail "legacy suggested_actions missing from brief: $(cat "$BRIEF")"
+fi
+
+if grep -q 'too many tasks' "$BRIEF"; then
+  pass "rationale present"
+else
+  fail "rationale missing"
+fi
+
+# ─── Test 2: diagnostic-L2 shape — decision_questions[0].recommendation ─
+TMP2=$(mktemp -d)
+PHASE_DIR="$TMP2"
+DL2_RESULT=$(cat <<'JSON'
+{"level":"L2","action":"proposal","proposal":{
+  "type":"diagnostic-l2",
+  "summary":"G-10 step 2 missing evidence.source",
+  "confidence":0.9,
+  "decision_questions":[{
+    "q":"Apply proposed fix?",
+    "recommendation":"Re-run scanner: /vg:review --re-scan-goals=G-10",
+    "rationale":"L2 audit trail: l2-12345-abc; confidence 0.90"
+  }],
+  "proposal_id":"l2-12345-abc"
+}}
+JSON
+)
+
+block_resolve_l2_handoff "missing-evidence" "$DL2_RESULT" "$PHASE_DIR" >/dev/null 2>&1 || true
+BRIEF2="$PHASE_DIR/.block-resolver-l2-brief.md"
+
+if grep -q 'Re-run scanner' "$BRIEF2"; then
+  pass "diagnostic-L2 recommendation appears in brief"
+else
+  fail "diagnostic-L2 recommendation missing — Codex-R7 regression. Brief: $(cat "$BRIEF2")"
+fi
+
+if grep -q 'L2 audit trail' "$BRIEF2"; then
+  pass "diagnostic-L2 rationale appears in brief"
+else
+  fail "diagnostic-L2 rationale missing"
+fi
+
+# Should NOT show the "did not provide explicit actions" placeholder
+if grep -q 'did not provide explicit actions' "$BRIEF2"; then
+  fail "brief says 'did not provide actions' — extraction broken"
+else
+  pass "brief does not show the no-actions placeholder"
+fi
+
+# ─── Cleanup ────────────────────────────────────────────────────────
+rm -rf "$TMP" "$TMP2"
+
+echo ""
+echo "PASSED: $PASSED"
+echo "FAILED: $FAILED"
+[ "$FAILED" -eq 0 ]

--- a/tests/test_block_resolver_l2_spawn.sh
+++ b/tests/test_block_resolver_l2_spawn.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for block-resolver L2 architect → spawn-diagnostic-l2 wiring (stub-3 fix).
+# Validates: spawn invoked when script available, fallback to placeholder when
+# disabled, JSON shape preserved, dry-run mode plumbing.
+
+set -euo pipefail
+
+REPO_ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${REPO_ROOT_DIR}/commands/vg/_shared/lib/block-resolver.sh"
+
+# shellcheck disable=SC1090
+REPO_ROOT="$REPO_ROOT_DIR" source "$LIB"
+export REPO_ROOT="$REPO_ROOT_DIR"
+
+PASSED=0
+FAILED=0
+fail() { echo "  ✗ $1" >&2; FAILED=$((FAILED + 1)); }
+pass() { echo "  ✓ $1"; PASSED=$((PASSED + 1)); }
+
+# ─── Test 1: dry-run path emits diagnostic-l2 proposal type ─────────
+TMP=$(mktemp -d)
+PHASE_DIR="$TMP/phase"
+mkdir -p "$PHASE_DIR"
+
+VG_DIAGNOSTIC_L2_DRY_RUN=1 OUT=$(_block_resolve_l2_architect \
+  "missing-evidence" \
+  "G-10 step 2 missing evidence.source" \
+  '{"goal":"G-10","step_idx":2}' \
+  "$PHASE_DIR" 2>/dev/null)
+
+TYPE=$(echo "$OUT" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('type',''))" 2>/dev/null)
+if [ "$TYPE" = "diagnostic-l2" ]; then
+  pass "dry-run path emits type=diagnostic-l2"
+else
+  fail "expected type=diagnostic-l2, got '$TYPE' (output: $OUT)"
+fi
+
+# Should include proposal_id
+PID=$(echo "$OUT" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('proposal_id',''))" 2>/dev/null)
+if [[ "$PID" =~ ^l2- ]]; then
+  pass "proposal_id in response"
+else
+  fail "proposal_id missing or malformed: $PID"
+fi
+
+# Proposal should be persisted on disk
+if [ -f "$PHASE_DIR/.l2-proposals/$PID.json" ]; then
+  pass "proposal persisted to .l2-proposals/$PID.json"
+else
+  fail "proposal file missing"
+fi
+
+# ─── Test 2: VG_DIAGNOSTIC_L2_DISABLE=1 falls back to placeholder ───
+VG_DIAGNOSTIC_L2_DISABLE=1 OUT2=$(_block_resolve_l2_architect \
+  "g" "ctx" '{}' "$PHASE_DIR" 2>/dev/null)
+
+TYPE2=$(echo "$OUT2" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('type',''))" 2>/dev/null)
+if [ "$TYPE2" = "config-change" ]; then
+  pass "VG_DIAGNOSTIC_L2_DISABLE=1 returns placeholder"
+else
+  fail "DISABLE=1 should fall back, got type='$TYPE2'"
+fi
+
+# ─── Test 3: missing phase_dir falls back to placeholder ────────────
+OUT3=$(_block_resolve_l2_architect "g" "ctx" '{}' "" 2>/dev/null)
+TYPE3=$(echo "$OUT3" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('type',''))" 2>/dev/null)
+if [ "$TYPE3" = "config-change" ]; then
+  pass "missing phase_dir returns placeholder"
+else
+  fail "no phase_dir should fall back, got '$TYPE3'"
+fi
+
+# ─── Cleanup ────────────────────────────────────────────────────────
+rm -rf "$TMP"
+
+echo ""
+echo "PASSED: $PASSED"
+echo "FAILED: $FAILED"
+[ "$FAILED" -eq 0 ]

--- a/tests/test_block_resolver_l3_single_advisory.sh
+++ b/tests/test_block_resolver_l3_single_advisory.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for block_resolve_l3_single_advisory (RFC v9 D26).
+# Validates: confidence-gated single-advisory rendering, fallback to
+# 3-option flow on low confidence, JSON shape.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="${REPO_ROOT}/commands/vg/_shared/lib/block-resolver.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+PASSED=0
+FAILED=0
+fail() { echo "  ✗ $1" >&2; FAILED=$((FAILED + 1)); }
+pass() { echo "  ✓ $1"; PASSED=$((PASSED + 1)); }
+
+# ─── Test 1: high-confidence emits single-advisory ──────────────────
+TMP=$(mktemp -d)
+PHASE_DIR="$TMP"
+cat > "$PHASE_DIR/.block-resolver-l2-brief.md" <<EOF
+- **Type:** missing-evidence
+- **Summary:** Re-run scanner for G-10
+- **Rationale:** Restores trustworthy provenance per D10
+EOF
+
+OUT=$(block_resolve_l3_single_advisory "test-gate" "$PHASE_DIR" "0.9" 2>/dev/null)
+if echo "$OUT" | grep -q "BLOCK_RESOLVER_L3_PROMPT_SINGLE_ADVISORY"; then
+  pass "high-confidence emits single-advisory marker"
+else
+  fail "high-confidence did not emit single-advisory marker. Got: $OUT"
+fi
+
+if echo "$OUT" | grep -q '"confidence": 0.9'; then
+  pass "confidence preserved in JSON"
+else
+  fail "confidence not preserved in JSON output"
+fi
+
+# Should have exactly 2 options (Yes / No-show-details), NOT 3
+OPT_COUNT=$(echo "$OUT" | grep -c '"label":')
+if [ "$OPT_COUNT" -eq 2 ]; then
+  pass "single-advisory has exactly 2 options (Yes + details)"
+else
+  fail "single-advisory has $OPT_COUNT options, expected 2"
+fi
+
+# ─── Test 2: low-confidence falls back to 3-option ──────────────────
+OUT_LOW=$(block_resolve_l3_single_advisory "test-gate" "$PHASE_DIR" "0.3" 2>/dev/null)
+if echo "$OUT_LOW" | grep -q "BLOCK_RESOLVER_L3_PROMPT_SINGLE_ADVISORY"; then
+  fail "low-confidence wrongly emitted single-advisory marker"
+else
+  pass "low-confidence does NOT emit single-advisory (falls through)"
+fi
+
+# Fallback should produce 3-option output (Apply / Override / Abort)
+if echo "$OUT_LOW" | grep -q "BLOCK_RESOLVER_L3_PROMPT"; then
+  pass "low-confidence falls back to 3-option L3 output"
+else
+  fail "low-confidence did not fall back to 3-option output"
+fi
+
+# ─── Test 3: missing brief → graceful error ─────────────────────────
+EMPTY=$(mktemp -d)
+if block_resolve_l3_single_advisory "test-gate" "$EMPTY" "0.9" 2>/dev/null; then
+  fail "missing brief should return non-zero"
+else
+  pass "missing brief returns non-zero exit"
+fi
+
+# ─── Test 4: threshold env override ─────────────────────────────────
+CONFIG_REVIEW_L3_SINGLE_ADVISORY_MIN_CONFIDENCE="0.99"
+OUT_HIGH_THR=$(block_resolve_l3_single_advisory "test-gate" "$PHASE_DIR" "0.85" 2>/dev/null)
+unset CONFIG_REVIEW_L3_SINGLE_ADVISORY_MIN_CONFIDENCE
+if echo "$OUT_HIGH_THR" | grep -q "BLOCK_RESOLVER_L3_PROMPT_SINGLE_ADVISORY"; then
+  fail "threshold override 0.99 should reject confidence=0.85 → fallback expected"
+else
+  pass "threshold override gates single-advisory correctly"
+fi
+
+# ─── Cleanup ────────────────────────────────────────────────────────
+rm -rf "$TMP" "$EMPTY"
+
+echo ""
+echo "PASSED: $PASSED"
+echo "FAILED: $FAILED"
+[ "$FAILED" -eq 0 ]

--- a/tests/test_codegen_fixture_inject.py
+++ b/tests/test_codegen_fixture_inject.py
@@ -338,6 +338,88 @@ def test_substitute_disabled_by_default(tmp_path):
     assert "'p7e9-distinct-uuid-value'" in body  # NOT substituted
 
 
+def test_sweep_finds_url_state_interactive_specs(tmp_path):
+    """Codex-MEDIUM-1: interactive codegen emits g-10.url-state.spec.ts.
+    Sweep must detect those (lowercase + .url-state suffix)."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "e2e"
+    e2e.mkdir()
+    (e2e / "g-10.url-state.spec.ts").write_text(
+        "import { test } from '@playwright/test';\n", encoding="utf-8",
+    )
+    result = _run(tmp_path, "--phase", "1.0", "--sweep", str(e2e))
+    out = json.loads(result.stdout)
+    assert len(out["injected"]) == 1
+    assert "VGFLOW_FIXTURE_INJECTED" in (e2e / "g-10.url-state.spec.ts").read_text()
+
+
+def test_sweep_finds_lowercase_goal_id_in_filename(tmp_path):
+    """Codex-MEDIUM-1: goal_id may appear lowercase in filename."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "e2e"
+    e2e.mkdir()
+    (e2e / "auto-g-10.spec.ts").write_text("test('x');\n", encoding="utf-8")
+    result = _run(tmp_path, "--phase", "1.0", "--sweep", str(e2e))
+    out = json.loads(result.stdout)
+    assert len(out["injected"]) == 1
+
+
+def test_substitute_uses_bracket_notation_for_non_identifier_keys(tmp_path):
+    """Codex-MEDIUM-2: 'pending-id' is not a valid TS identifier (hyphen).
+    Substitution must emit FIXTURE['pending-id'], not FIXTURE.pending-id."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {
+            "pending-id": "p7e9-distinct-uuid-value",
+            "valid_id": "another-distinct-value",
+        }},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => {\n"
+        "  use('p7e9-distinct-uuid-value');\n"
+        "  use('another-distinct-value');\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+          "--spec", str(spec), "--substitute")
+    text = spec.read_text()
+    body = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    # Non-identifier → bracket notation
+    assert 'FIXTURE["pending-id"]' in body
+    # Identifier → dot notation
+    assert "FIXTURE.valid_id" in body
+    # Invalid TS does NOT appear
+    assert "FIXTURE.pending-id" not in body
+
+
+def test_substitute_handles_keys_with_special_chars(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {
+            "with space": "long-distinctive-string-value",
+            "1leading-digit": "another-long-string-value",
+        }},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => {\n"
+        "  use('long-distinctive-string-value');\n"
+        "  use('another-long-string-value');\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+          "--spec", str(spec), "--substitute")
+    text = spec.read_text()
+    body = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    assert 'FIXTURE["with space"]' in body
+    assert 'FIXTURE["1leading-digit"]' in body
+
+
 def test_arg_validation(tmp_path):
     # Missing --goal/--spec/--sweep
     r1 = _run(tmp_path, "--phase", "1.0")

--- a/tests/test_codegen_fixture_inject.py
+++ b/tests/test_codegen_fixture_inject.py
@@ -208,6 +208,136 @@ def test_phase_not_found_returns_1(tmp_path):
     assert result.returncode == 1
 
 
+# ─── Codex-HIGH-3-bis: --substitute literal-replacement pass ─────────
+
+
+def test_substitute_replaces_quoted_string_with_fixture_ref(tmp_path):
+    """Codex-HIGH-3-bis: codegen often emits hard-coded captured values
+    as exact-string equality checks. --substitute swaps WHOLE-STRING
+    quoted occurrences for FIXTURE.x references. (Substring/template
+    literal substitution is out of scope — too brittle without AST.)"""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {
+            "pending_id": "p7e9-2026-05-02-abc-uuid",
+            "amount": 0.01,
+        }},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "import { test } from '@playwright/test';\n\n"
+        "test('approve', async ({ page }) => {\n"
+        "  const id = 'p7e9-2026-05-02-abc-uuid';\n"
+        "  expect(received).toBe('p7e9-2026-05-02-abc-uuid');\n"
+        '  expect(other).toBe("p7e9-2026-05-02-abc-uuid");\n'
+        "});\n",
+        encoding="utf-8",
+    )
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+                   "--spec", str(spec), "--substitute")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    # 3 whole-string quoted matches: 'X', 'X', "X"
+    assert out["injected"][0]["substitutions"] == 3, out
+
+    text = spec.read_text()
+    assert "FIXTURE.pending_id" in text
+    assert "p7e9-2026-05-02-abc-uuid" in text  # still in FIXTURE block
+    # Body no longer has the bare quoted literal outside the const block
+    body_after_block = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    assert "'p7e9-2026-05-02-abc-uuid'" not in body_after_block
+    assert '"p7e9-2026-05-02-abc-uuid"' not in body_after_block
+
+
+def test_substitute_skips_short_values(tmp_path):
+    """Conservative guard: 'ok' is too short — risk of coincidental match."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"status": "ok"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => { expect(result).toBe('ok'); });\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+          "--spec", str(spec), "--substitute")
+    text = spec.read_text()
+    # 'ok' should NOT be substituted (too short, ambiguous)
+    assert "expect(result).toBe('ok')" in text
+    assert "FIXTURE.status" not in text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+
+
+def test_substitute_picks_up_sentinel_prefixed_short_strings(tmp_path):
+    """VG_FIXTURE_M1 is short but sentinel-prefixed — always safe."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"merchant": "VG_FIXTURE_M1"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        'test("x", async () => { mockApi("VG_FIXTURE_M1"); });\n',
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+          "--spec", str(spec), "--substitute")
+    text = spec.read_text()
+    assert "FIXTURE.merchant" in text
+    body = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    assert '"VG_FIXTURE_M1"' not in body  # substituted
+
+
+def test_substitute_does_not_modify_inside_fixture_block(tmp_path):
+    """Substitution must NOT recurse into the FIXTURE const block itself
+    (would create `FIXTURE.x: FIXTURE.x` infinite loop)."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"pending_id": "p7e9-uuid-with-hyphens-here"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => { use('p7e9-uuid-with-hyphens-here'); });\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+          "--spec", str(spec), "--substitute")
+    text = spec.read_text()
+    # FIXTURE block content unchanged (still has the literal)
+    fixture_block = text.split("VGFLOW_FIXTURE_INJECTED")[1].split(
+        "VGFLOW_FIXTURE_INJECTED_END")[0]
+    assert "p7e9-uuid-with-hyphens-here" in fixture_block
+    # Body got substitution
+    body = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    assert "FIXTURE.pending_id" in body
+
+
+def test_substitute_handles_uuid_values(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "12345678-1234-1234-1234-123456789abc"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => { use('12345678-1234-1234-1234-123456789abc'); });\n",
+        encoding="utf-8",
+    )
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+                   "--spec", str(spec), "--substitute")
+    out = json.loads(result.stdout)
+    assert out["injected"][0]["substitutions"] >= 1
+
+
+def test_substitute_disabled_by_default(tmp_path):
+    """Without --substitute flag, no body changes happen."""
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"pending_id": "p7e9-distinct-uuid-value"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "test('x', async () => { use('p7e9-distinct-uuid-value'); });\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    text = spec.read_text()
+    body = text.split("VGFLOW_FIXTURE_INJECTED_END", 1)[1]
+    assert "'p7e9-distinct-uuid-value'" in body  # NOT substituted
+
+
 def test_arg_validation(tmp_path):
     # Missing --goal/--spec/--sweep
     r1 = _run(tmp_path, "--phase", "1.0")

--- a/tests/test_codegen_fixture_inject.py
+++ b/tests/test_codegen_fixture_inject.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/codegen-fixture-inject.py — Codex-HIGH-3 fix."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "codegen-fixture-inject.py"
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo), *args],
+        env={"VG_REPO_ROOT": str(repo), "PATH": "/usr/bin:/bin",
+             "PYTHONPATH": str(REPO_ROOT / "scripts")},
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def _phase_with_cache(tmp_path: Path, name: str, entries: dict) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / name
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "FIXTURES-CACHE.json").write_text(
+        json.dumps({"schema_version": "1.0", "entries": entries}, indent=2),
+        encoding="utf-8",
+    )
+    return phase_dir
+
+
+def test_injects_fixture_into_simple_spec(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"pending_id": "p7", "amount": 0.01,
+                                "tags": ["alpha", "beta"]}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "import { test, expect } from '@playwright/test';\n\n"
+        "test('approve topup', async ({ page }) => {\n"
+        "  await page.goto('/admin/topup');\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+                   "--spec", str(spec))
+    assert result.returncode == 0, result.stderr
+    out = json.loads(result.stdout)
+    assert len(out["injected"]) == 1
+    assert out["injected"][0]["action"] == "injected"
+
+    text = spec.read_text()
+    assert "VGFLOW_FIXTURE_INJECTED" in text
+    assert 'pending_id: "p7"' in text
+    assert "amount: 0.01" in text
+    assert '["alpha", "beta"]' in text
+    assert "as const;" in text
+
+
+def test_idempotent_replace_existing_block(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"pending_id": "p1"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "import { test } from '@playwright/test';\n\n"
+        "test('x', async () => {});\n",
+        encoding="utf-8",
+    )
+    # First inject
+    r1 = _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    assert r1.returncode == 0
+    text1 = spec.read_text()
+
+    # Update cache, second inject — should REPLACE not stack
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"pending_id": "p2"}},  # different value
+    })
+    r2 = _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    out2 = json.loads(r2.stdout)
+    assert out2["injected"][0]["action"] == "replaced"
+
+    text2 = spec.read_text()
+    # Only one block (count sentinels)
+    assert text2.count("VGFLOW_FIXTURE_INJECTED — DO NOT EDIT") == 1
+    assert 'pending_id: "p2"' in text2
+    assert 'pending_id: "p1"' not in text2
+
+
+def test_inject_after_imports_not_at_very_top(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "x"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text(
+        "// header comment\n"
+        "import { test } from '@playwright/test';\n"
+        "import { other } from './helpers';\n"
+        "\n"
+        "test('x', async () => {});\n",
+        encoding="utf-8",
+    )
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    text = spec.read_text()
+    # The fixture block should appear AFTER the imports
+    sentinel_pos = text.index("VGFLOW_FIXTURE_INJECTED")
+    last_import_pos = text.rindex("import")
+    assert sentinel_pos > last_import_pos
+
+
+def test_skip_when_no_captured_store(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"lease": {"owner_session": "x"}},  # no `captured` key
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text("test('x', async () => {});\n", encoding="utf-8")
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    out = json.loads(result.stdout)
+    assert out["injected"] == []
+    assert len(out["skipped"]) == 1
+    assert "no captured store" in out["skipped"][0]["reason"]
+    assert "VGFLOW_FIXTURE_INJECTED" not in spec.read_text()
+
+
+def test_dry_run_does_not_modify_file(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "x"}},
+    })
+    spec = tmp_path / "test.spec.ts"
+    original = "test('x', async () => {});\n"
+    spec.write_text(original, encoding="utf-8")
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+                   "--spec", str(spec), "--dry-run")
+    assert result.returncode == 0
+    assert spec.read_text() == original
+
+
+def test_sweep_mode_finds_specs(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "p1"}},
+        "G-11": {"captured": {"id": "p2"}},
+    })
+    e2e = tmp_path / "e2e"
+    e2e.mkdir()
+    (e2e / "1.0-G-10.spec.ts").write_text(
+        "import { test } from '@playwright/test';\n", encoding="utf-8",
+    )
+    (e2e / "1.0-G-11.spec.ts").write_text(
+        "import { test } from '@playwright/test';\n", encoding="utf-8",
+    )
+    result = _run(tmp_path, "--phase", "1.0", "--sweep", str(e2e))
+    out = json.loads(result.stdout)
+    assert len(out["injected"]) == 2
+    for spec in (e2e / "1.0-G-10.spec.ts", e2e / "1.0-G-11.spec.ts"):
+        assert "VGFLOW_FIXTURE_INJECTED" in spec.read_text()
+
+
+def test_sweep_skips_unrelated_specs(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "e2e"
+    e2e.mkdir()
+    spec_other = e2e / "smoke.spec.ts"  # no goal id in name
+    spec_other.write_text("test('x', async () => {});\n", encoding="utf-8")
+    result = _run(tmp_path, "--phase", "1.0", "--sweep", str(e2e))
+    out = json.loads(result.stdout)
+    assert out["injected"] == []
+    assert "VGFLOW_FIXTURE_INJECTED" not in spec_other.read_text()
+
+
+def test_typescript_safe_key_quoting(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {
+            "valid_id": "x",
+            "kebab-key": "y",     # invalid TS identifier → must quote
+            "with space": "z",
+        }},
+    })
+    spec = tmp_path / "test.spec.ts"
+    spec.write_text("test('x', async () => {});\n", encoding="utf-8")
+    _run(tmp_path, "--phase", "1.0", "--goal", "G-10", "--spec", str(spec))
+    text = spec.read_text()
+    assert "valid_id:" in text  # unquoted valid identifier
+    assert '"kebab-key":' in text  # quoted invalid identifier
+    assert '"with space":' in text
+
+
+def test_missing_spec_raises_error(tmp_path):
+    _phase_with_cache(tmp_path, "01.0-x", {
+        "G-10": {"captured": {"id": "x"}},
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--goal", "G-10",
+                   "--spec", str(tmp_path / "missing.spec.ts"))
+    out = json.loads(result.stdout)
+    assert len(out["errors"]) == 1
+    assert "not found" in out["errors"][0]["error"]
+
+
+def test_phase_not_found_returns_1(tmp_path):
+    (tmp_path / ".vg" / "phases").mkdir(parents=True)
+    spec = tmp_path / "x.spec.ts"
+    spec.write_text("", encoding="utf-8")
+    result = _run(tmp_path, "--phase", "99.99", "--goal", "G-1",
+                   "--spec", str(spec))
+    assert result.returncode == 1
+
+
+def test_arg_validation(tmp_path):
+    # Missing --goal/--spec/--sweep
+    r1 = _run(tmp_path, "--phase", "1.0")
+    assert r1.returncode != 0
+    # --spec without --goal
+    r2 = _run(tmp_path, "--phase", "1.0", "--spec", "x.spec.ts")
+    assert r2.returncode != 0
+    # --sweep + --goal mutually exclusive
+    r3 = _run(tmp_path, "--phase", "1.0", "--sweep", "/tmp",
+              "--goal", "G-1", "--spec", "x.spec.ts")
+    assert r3.returncode != 0

--- a/tests/test_content_depth.py
+++ b/tests/test_content_depth.py
@@ -1,0 +1,189 @@
+"""Tests for scripts/runtime/content_depth.py — RFC v9 D27."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.content_depth import (  # noqa: E402
+    aggregate_failures,
+    cross_reference,
+    edge_case_substance,
+    instruction_repetition,
+    llm_judge_sample,
+    word_count,
+)
+
+
+# ─── word_count ───────────────────────────────────────────────────────
+
+
+def test_word_count_passes():
+    ok, msg = word_count("alpha beta gamma delta epsilon zeta", min_words=5)
+    assert ok and msg is None
+
+
+def test_word_count_fails():
+    ok, msg = word_count("only three words now", min_words=10)
+    assert not ok
+    assert "word_count=4" in msg
+
+
+def test_word_count_handles_unicode():
+    ok, _ = word_count("một hai ba bốn năm", min_words=5)
+    assert ok
+
+
+# ─── cross_reference ─────────────────────────────────────────────────
+
+
+def test_cross_reference_all_present():
+    text = "We discuss D-01, D-02, D-03, and decision G-10."
+    ok, msg = cross_reference(text, required_anchors=["D-01", "D-02", "G-10"])
+    assert ok and msg is None
+
+
+def test_cross_reference_missing():
+    text = "Only D-01 here."
+    ok, msg = cross_reference(text, required_anchors=["D-01", "D-02", "G-10"])
+    assert not ok
+    assert "D-02" in msg
+
+
+def test_cross_reference_min_unique_enforced():
+    text = "D-01 D-01 D-01"
+    ok, msg = cross_reference(
+        text, required_anchors=["D-01"], min_unique=2,
+    )
+    assert not ok
+    assert "1 unique" in msg
+
+
+# ─── edge_case_substance ─────────────────────────────────────────────
+
+
+def test_edge_case_substance_passes_when_substantive():
+    text = """
+- API rejects with 422 when amount exceeds tier limit; client must show
+- Rate limiter trips after 5 requests in 10 seconds and surfaces 429
+- Concurrent admin clicks cause race; idempotency-key prevents double charge
+- Network timeout after 30s rolls back transaction; user sees retry option
+""".strip()
+    ok, msg = edge_case_substance(text)
+    assert ok, msg
+
+
+def test_edge_case_substance_fails_on_tbd():
+    text = """
+- TBD
+- TODO: think about this
+- N/A
+""".strip()
+    ok, msg = edge_case_substance(text)
+    assert not ok
+    assert "placeholder" in msg
+
+
+def test_edge_case_substance_fails_on_thin_bullets():
+    text = """
+- Short
+- Tiny one
+- Brief
+- Yes
+""".strip()
+    ok, msg = edge_case_substance(text, bullet_min_words=10)
+    assert not ok
+    assert "substantive bullets" in msg
+
+
+def test_edge_case_substance_fails_on_too_few_bullets():
+    text = """
+- This is a substantive edge case with sufficient detail to satisfy threshold
+""".strip()
+    ok, msg = edge_case_substance(text, min_bullets_with_body=3)
+    assert not ok
+
+
+def test_edge_case_substance_vietnamese_placeholder():
+    text = "- chưa\n- cần bổ sung\n- TBD\n"
+    ok, msg = edge_case_substance(text)
+    assert not ok
+    assert "placeholder" in msg
+
+
+# ─── instruction_repetition ──────────────────────────────────────────
+
+
+def test_instruction_repetition_passes():
+    text = "STEP 1: do X. Later: REMEMBER, do X. Final: do X again."
+    ok, msg = instruction_repetition(text, key_phrase="do X", min_occurrences=3)
+    assert ok
+
+
+def test_instruction_repetition_fails():
+    text = "Do X once at the top. Then never again."
+    ok, msg = instruction_repetition(text, key_phrase="do X", min_occurrences=3)
+    assert not ok
+    assert "1×" in msg
+
+
+def test_instruction_repetition_case_insensitive_default():
+    text = "Do X. DO X. do x."
+    ok, _ = instruction_repetition(text, key_phrase="do x", min_occurrences=3)
+    assert ok
+
+
+def test_instruction_repetition_case_sensitive():
+    text = "Do X. DO X."
+    ok, msg = instruction_repetition(
+        text, key_phrase="do X", min_occurrences=2, case_insensitive=False,
+    )
+    assert not ok
+
+
+# ─── llm_judge_sample ────────────────────────────────────────────────
+
+
+def test_llm_judge_sample_returns_all_when_few_sections():
+    sections = {"a": "X", "b": "Y"}
+    out = llm_judge_sample(sections, sample_size=3)
+    assert out == sections
+
+
+def test_llm_judge_sample_deterministic():
+    sections = {f"s{i}": f"text-{i}" for i in range(10)}
+    out_a = llm_judge_sample(sections, sample_size=3, rng_seed=42)
+    out_b = llm_judge_sample(sections, sample_size=3, rng_seed=42)
+    assert out_a == out_b
+    assert len(out_a) == 3
+
+
+def test_llm_judge_sample_different_seed_different_picks():
+    sections = {f"s{i}": f"text-{i}" for i in range(20)}
+    out_a = llm_judge_sample(sections, sample_size=5, rng_seed=1)
+    out_b = llm_judge_sample(sections, sample_size=5, rng_seed=2)
+    assert out_a != out_b
+
+
+# ─── aggregate_failures ──────────────────────────────────────────────
+
+
+def test_aggregate_passes_when_all_ok():
+    results = [(True, None), (True, None)]
+    out = aggregate_failures(results, name="test-validator")
+    assert out["verdict"] == "PASS"
+    assert out["failures"] == []
+    assert out["checks_run"] == 2
+    assert out["checks_passed"] == 2
+
+
+def test_aggregate_blocks_with_partial_failures():
+    results = [(True, None), (False, "issue-A"), (False, "issue-B")]
+    out = aggregate_failures(results, name="test")
+    assert out["verdict"] == "BLOCK"
+    assert "issue-A" in out["failures"]
+    assert out["checks_passed"] == 1

--- a/tests/test_diagnostic_l2.py
+++ b/tests/test_diagnostic_l2.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/runtime/diagnostic_l2.py — RFC v9 PR-D3."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.diagnostic_l2 import (  # noqa: E402
+    L2Proposal,
+    list_open_proposals,
+    load_proposal,
+    make_proposal,
+    new_proposal_id,
+    proposal_dir,
+    record_decision,
+    render_single_advisory,
+    write_proposal,
+)
+
+
+def _stub_proposal(**overrides) -> L2Proposal:
+    base = dict(
+        gate_id="missing-evidence",
+        block_family="provenance",
+        evidence_in={"goal": "G-10"},
+        diagnosis="Mutation step at G-10/step[2] missing evidence.source",
+        proposed_fix="Re-run scanner: /vg:review {phase} --re-scan-goals=G-10",
+        confidence=0.85,
+    )
+    base.update(overrides)
+    return make_proposal(**base)
+
+
+def test_new_proposal_id_format():
+    pid = new_proposal_id()
+    assert pid.startswith("l2-")
+    parts = pid.split("-")
+    assert len(parts) == 3
+    int(parts[1])  # epoch is numeric
+    assert len(parts[2]) == 6  # rand6
+
+
+def test_make_proposal_clamps_confidence():
+    p = _stub_proposal(confidence=1.5)
+    assert p.confidence == 1.0
+    p = _stub_proposal(confidence=-0.2)
+    assert p.confidence == 0.0
+
+
+def test_write_then_load_roundtrip(tmp_path):
+    p = _stub_proposal()
+    write_proposal(tmp_path, p)
+    loaded = load_proposal(tmp_path, p.proposal_id)
+    assert loaded.proposal_id == p.proposal_id
+    assert loaded.diagnosis == p.diagnosis
+    assert loaded.evidence_in == p.evidence_in
+
+
+def test_render_single_advisory_vietnamese():
+    p = _stub_proposal()
+    text = render_single_advisory(p, locale="vi")
+    assert "Chẩn đoán" in text
+    assert "Áp dụng đề xuất này?" in text
+    assert "85%" in text  # confidence
+
+
+def test_render_single_advisory_english():
+    p = _stub_proposal()
+    text = render_single_advisory(p, locale="en")
+    assert "Diagnosis:" in text
+    assert "Apply?" in text
+
+
+def test_render_single_advisory_no_3_options_anti_pattern():
+    """D26: do NOT show A/B/C menu — single advisory only."""
+    p = _stub_proposal()
+    text = render_single_advisory(p, locale="vi")
+    # Must not have "Option A:" / "(a)" / "1." / etc.
+    assert "Option A" not in text
+    assert "Lựa chọn 1" not in text
+    assert "(a)" not in text
+    # Must have the single decision: Y/n/d
+    assert "[Y]" in text
+
+
+def test_record_decision_accepted(tmp_path):
+    p = _stub_proposal()
+    write_proposal(tmp_path, p)
+    updated = record_decision(tmp_path, p.proposal_id, "accepted")
+    assert updated.decision == "accepted"
+    assert updated.decided_at is not None
+
+
+def test_record_decision_applied_with_artifacts(tmp_path):
+    p = _stub_proposal()
+    write_proposal(tmp_path, p)
+    updated = record_decision(
+        tmp_path, p.proposal_id, "applied",
+        applied_artifacts=["RUNTIME-MAP.json", "GOAL-COVERAGE-MATRIX.md"],
+    )
+    assert updated.decision == "applied"
+    assert "RUNTIME-MAP.json" in updated.applied_artifacts
+
+
+def test_record_decision_rejected(tmp_path):
+    p = _stub_proposal()
+    write_proposal(tmp_path, p)
+    updated = record_decision(tmp_path, p.proposal_id, "rejected")
+    assert updated.decision == "rejected"
+
+
+def test_record_decision_invalid_raises(tmp_path):
+    p = _stub_proposal()
+    write_proposal(tmp_path, p)
+    with pytest.raises(ValueError, match="unknown decision"):
+        record_decision(tmp_path, p.proposal_id, "maybe-later")
+
+
+def test_list_open_proposals_returns_only_undecided(tmp_path):
+    p1 = _stub_proposal()
+    p2 = _stub_proposal()
+    p3 = _stub_proposal()
+    write_proposal(tmp_path, p1)
+    write_proposal(tmp_path, p2)
+    write_proposal(tmp_path, p3)
+    record_decision(tmp_path, p1.proposal_id, "applied")
+    record_decision(tmp_path, p2.proposal_id, "rejected")
+    open_props = list_open_proposals(tmp_path)
+    assert len(open_props) == 1
+    assert open_props[0].proposal_id == p3.proposal_id
+
+
+def test_list_open_proposals_handles_missing_dir(tmp_path):
+    assert list_open_proposals(tmp_path / "missing") == []
+
+
+def test_persisted_file_includes_layer2_proposal_id(tmp_path):
+    """Audit trail: matrix-staleness/evidence-provenance check this ID exists."""
+    p = _stub_proposal()
+    target = write_proposal(tmp_path, p)
+    data = json.loads(target.read_text())
+    assert data["proposal_id"] == p.proposal_id
+    assert data["schema_version"] == "1.0"
+
+
+def test_proposal_dir_path(tmp_path):
+    assert proposal_dir(tmp_path).name == ".l2-proposals"
+
+
+def test_two_proposals_have_unique_ids():
+    p1 = _stub_proposal()
+    p2 = _stub_proposal()
+    assert p1.proposal_id != p2.proposal_id

--- a/tests/test_evidence_provenance.py
+++ b/tests/test_evidence_provenance.py
@@ -1,0 +1,267 @@
+"""Tests for verify-evidence-provenance.py (RFC v9 D10).
+
+Closes wave-3.2.2 trust hole: structured provenance is mandatory on all
+mutation steps that claim success (action + 2xx network), so executor
+agents cannot fabricate evidence to flip matrix status.
+
+Covers:
+- evidence missing → BLOCK (default) / informational (--allow-legacy)
+- evidence.source missing / invalid
+- artifact_hash absent / wrong format
+- captured_at / schema_version absent / unsupported version
+- scanner without scanner_run_id
+- diagnostic_l2 without layer2_proposal_id
+- non-mutation step ignored
+- mutation step without 2xx ignored (no claim of success)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "validators" / "verify-evidence-provenance.py"
+
+
+def _run(repo_root: Path, phase: str, *flags: str) -> tuple[int, dict]:
+    cmd = [sys.executable, str(VALIDATOR), "--phase", phase, *flags]
+    proc = subprocess.run(
+        cmd,
+        env={"VG_REPO_ROOT": str(repo_root), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    try:
+        out = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        out = {"verdict": "PARSE_ERROR", "stdout": proc.stdout, "stderr": proc.stderr}
+    return proc.returncode, out
+
+
+def _make_phase(tmp_path: Path, sequences: dict) -> tuple[Path, Path]:
+    phases_dir = tmp_path / ".vg" / "phases"
+    phase_dir = phases_dir / "99.9-prov"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps({"goal_sequences": sequences}, indent=2),
+        encoding="utf-8",
+    )
+    return tmp_path, phase_dir
+
+
+def _mutation_step(evidence: dict | None = None, with_2xx: bool = True) -> dict:
+    step = {"do": "click", "target": "Submit topup"}
+    if with_2xx:
+        step["network"] = [{"method": "POST", "endpoint": "/api/topup", "status": 200}]
+    if evidence is not None:
+        step["evidence"] = evidence
+    return step
+
+
+# ─── BLOCK cases ──────────────────────────────────────────────────────────
+
+
+def test_missing_evidence_blocks_in_default_mode(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step(None)]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1, out
+    assert out["verdict"] == "BLOCK"
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "evidence_missing" in types
+
+
+def test_invalid_source_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({"source": "ai_hallucination"})]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "evidence_source_invalid" in types
+
+
+def test_artifact_hash_wrong_format_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "scanner",
+            "scanner_run_id": "haiku-1",
+            "artifact_hash": "md5:0123abc",  # wrong algorithm
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "artifact_hash_format" in types
+
+
+def test_schema_version_major_mismatch_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "scanner",
+            "scanner_run_id": "haiku-1",
+            "artifact_hash": "sha256:xyz",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "2.0",  # major bump unsupported
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "schema_version_unsupported" in types
+
+
+def test_scanner_source_without_run_id_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "scanner",
+            # NO scanner_run_id
+            "artifact_hash": "sha256:xyz",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "scanner_run_id_missing" in types
+
+
+def test_diagnostic_l2_without_proposal_id_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "diagnostic_l2",
+            "artifact_hash": "sha256:abc",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+            # NO layer2_proposal_id
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "layer2_proposal_id_missing" in types
+
+
+def test_missing_required_subfields_blocks(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({"source": "manual"})]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 1
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "artifact_hash_missing" in types
+    assert "captured_at_missing" in types
+    assert "schema_version_missing" in types
+
+
+# ─── PASS cases ──────────────────────────────────────────────────────────
+
+
+def test_complete_scanner_evidence_passes(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "scanner",
+            "scanner_run_id": "haiku-r-1",
+            "artifact_hash": "sha256:cafebabe1234",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 0, out
+    assert out["verdict"] in ("PASS", "WARN")
+
+
+def test_complete_diagnostic_l2_evidence_passes(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "diagnostic_l2",
+            "layer2_proposal_id": "l2-prop-7e9",
+            "artifact_hash": "sha256:cafe",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.1",  # minor bump OK
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 0
+
+
+def test_executor_with_full_metadata_passes_validator(tmp_path):
+    """The provenance validator only checks structure, not whether source
+    is trustworthy enough for matrix promotion. matrix-staleness D10 is the
+    second gate that rejects executor for promotion. This validator passes
+    structurally-complete executor evidence — that is intentional."""
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({
+            "source": "executor",
+            "artifact_hash": "sha256:e",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        })]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 0
+
+
+# ─── Skip cases ──────────────────────────────────────────────────────────
+
+
+def test_non_mutation_step_skipped(tmp_path):
+    """GET-only step (no submit verb, no 2xx mutation) → no evidence required."""
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [{
+            "do": "click",
+            "target": "Open detail panel",  # not submit/approve/etc.
+            "network": [{"method": "GET", "endpoint": "/api/x", "status": 200}],
+        }]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 0
+
+
+def test_mutation_step_without_2xx_skipped(tmp_path):
+    """Submit attempted but 4xx — claim-of-success not made → no evidence required."""
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [{
+            "do": "click",
+            "target": "Submit topup",
+            "network": [{"method": "POST", "endpoint": "/api/topup", "status": 422}],
+        }]},
+    })
+    rc, out = _run(repo, "99.9")
+    assert rc == 0
+
+
+# ─── --allow-legacy migration grace ─────────────────────────────────────
+
+
+def test_allow_legacy_skips_missing_evidence(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step(None)]},  # no evidence
+    })
+    rc, out = _run(repo, "99.9", "--allow-legacy")
+    assert rc == 0
+    # Summary should still report
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "provenance_summary" in types
+
+
+def test_warn_severity_downgrades_block(tmp_path):
+    repo, _ = _make_phase(tmp_path, {
+        "G-01": {"steps": [_mutation_step({"source": "manual"})]},  # incomplete
+    })
+    rc, out = _run(repo, "99.9", "--severity", "warn")
+    # warn mode → not BLOCK; rc=0
+    assert rc == 0
+    assert out["verdict"] in ("WARN", "PASS")
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "severity_downgraded" in types

--- a/tests/test_fixture_backfill.py
+++ b/tests/test_fixture_backfill.py
@@ -1,0 +1,189 @@
+"""Tests for scripts/fixture-backfill.py — RFC v9 PR-A.5 migration tool."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "fixture-backfill.py"
+
+
+def _run(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _phase_with_runtime(tmp_path: Path, name: str, runtime: dict) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / name
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps(runtime, indent=2), encoding="utf-8",
+    )
+    return phase_dir
+
+
+def _mutation_seq_with_body() -> dict:
+    return {
+        "G-10": {
+            "title": "Approve tier2 topup",
+            "steps": [{
+                "do": "click",
+                "target": "Submit topup",
+                "network": [{
+                    "method": "POST",
+                    "endpoint": "/api/topup/approve",
+                    "status": 200,
+                    "body": {"id": "p7", "approver_note": "ok"},
+                }],
+            }],
+        },
+    }
+
+
+def test_high_confidence_when_body_captured(tmp_path):
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", {
+        "goal_sequences": _mutation_seq_with_body(),
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0, result.stderr
+    fixture = phase_dir / "FIXTURES" / "G-10.yaml"
+    assert fixture.exists()
+    content = fixture.read_text()
+    assert "confidence: HIGH" in content
+    assert "approver_note: ok" in content
+    assert "method: POST" in content
+    assert "/api/topup/approve" in content
+
+
+def test_medium_confidence_when_body_missing(tmp_path):
+    runtime = {
+        "goal_sequences": {
+            "G-10": {
+                "title": "Approve",
+                "steps": [{
+                    "do": "click",
+                    "target": "Submit",
+                    "network": [{
+                        "method": "POST",
+                        "endpoint": "/api/x",
+                        "status": 200,
+                    }],
+                }],
+            },
+        },
+    }
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", runtime)
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0, result.stderr
+    content = (phase_dir / "FIXTURES" / "G-10.yaml").read_text()
+    assert "confidence: MEDIUM" in content
+    # Body skeleton with TODO sentinel
+    assert "TODO" in content
+
+
+def test_skips_non_mutation_goals(tmp_path):
+    runtime = {
+        "goal_sequences": {
+            "G-read": {
+                "title": "Read only",
+                "steps": [{
+                    "do": "click",
+                    "target": "Open detail",
+                    "network": [{"method": "GET", "endpoint": "/x", "status": 200}],
+                }],
+            },
+        },
+    }
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", runtime)
+    result = _run(tmp_path, "--phase", "1.0", "--dry-run")
+    assert result.returncode == 0
+    assert "No mutation goals" in result.stdout
+
+
+def test_dry_run_does_not_write(tmp_path):
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", {
+        "goal_sequences": _mutation_seq_with_body(),
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--dry-run")
+    assert result.returncode == 0
+    assert not (phase_dir / "FIXTURES").exists()
+
+
+def test_only_filter_targets_specific_goals(tmp_path):
+    runtime = {
+        "goal_sequences": {
+            "G-10": _mutation_seq_with_body()["G-10"],
+            "G-11": {
+                "title": "Other",
+                "steps": [{
+                    "do": "click",
+                    "target": "Save merchant",
+                    "network": [{"method": "PUT", "endpoint": "/api/m",
+                                  "status": 200, "body": {"x": 1}}],
+                }],
+            },
+        },
+    }
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", runtime)
+    result = _run(tmp_path, "--phase", "1.0", "--apply", "--only", "G-11")
+    assert result.returncode == 0
+    assert (phase_dir / "FIXTURES" / "G-11.yaml").exists()
+    assert not (phase_dir / "FIXTURES" / "G-10.yaml").exists()
+
+
+def test_existing_yaml_not_clobbered(tmp_path):
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", {
+        "goal_sequences": _mutation_seq_with_body(),
+    })
+    fixtures = phase_dir / "FIXTURES"
+    fixtures.mkdir()
+    (fixtures / "G-10.yaml").write_text("# user-authored content — keep me\n",
+                                           encoding="utf-8")
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0
+    # Original file unchanged
+    assert "# user-authored content — keep me\n" == (
+        (fixtures / "G-10.yaml").read_text()
+    )
+    # Backfill goes to .backfill-draft
+    assert (fixtures / "G-10.yaml.backfill-draft").exists()
+
+
+def test_writes_backfill_report(tmp_path):
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", {
+        "goal_sequences": _mutation_seq_with_body(),
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0
+    report = phase_dir / "FIXTURES" / ".backfill-report.json"
+    data = json.loads(report.read_text())
+    assert data["phase"] == "1.0"
+    assert len(data["goals"]) == 1
+    assert data["goals"][0]["goal_id"] == "G-10"
+    assert data["goals"][0]["confidence"] == "HIGH"
+
+
+def test_post_step_has_idempotency_key(tmp_path):
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", {
+        "goal_sequences": _mutation_seq_with_body(),
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    content = (phase_dir / "FIXTURES" / "G-10.yaml").read_text()
+    assert "idempotency_key:" in content
+
+
+def test_phase_not_found_returns_nonzero(tmp_path):
+    (tmp_path / ".vg" / "phases").mkdir(parents=True)
+    result = _run(tmp_path, "--phase", "99.99", "--dry-run")
+    assert result.returncode != 0
+
+
+def test_dry_run_or_apply_required(tmp_path):
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode != 0

--- a/tests/test_fixture_backfill.py
+++ b/tests/test_fixture_backfill.py
@@ -187,3 +187,42 @@ def test_phase_not_found_returns_nonzero(tmp_path):
 def test_dry_run_or_apply_required(tmp_path):
     result = _run(tmp_path, "--phase", "1.0")
     assert result.returncode != 0
+
+
+def test_path_traversal_goal_id_rejected(tmp_path):
+    """Codex-R4-HIGH-3: RUNTIME-MAP is untrusted. goal_id with path
+    traversal must be rejected, not used as filename."""
+    runtime = {
+        "goal_sequences": {
+            "../../etc/passwd": _mutation_seq_with_body()["G-10"],
+            "G-10": _mutation_seq_with_body()["G-10"],  # legit one for control
+        },
+    }
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", runtime)
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0
+    # Only the legit G-10 should be backfilled
+    assert (phase_dir / "FIXTURES" / "G-10.yaml").exists()
+    # No file written outside FIXTURES dir
+    assert not (tmp_path / ".." / ".." / "etc" / "passwd.yaml").exists()
+    # Stderr should mention skipping
+    assert "path-traversal" in result.stderr or "invalid goal_id" in result.stderr
+
+
+def test_invalid_goal_id_format_rejected(tmp_path):
+    """goal_id not matching G-XX pattern rejected."""
+    runtime = {
+        "goal_sequences": {
+            "not-a-goal": _mutation_seq_with_body()["G-10"],
+            "G_underscore": _mutation_seq_with_body()["G-10"],
+            "G-10": _mutation_seq_with_body()["G-10"],
+        },
+    }
+    phase_dir = _phase_with_runtime(tmp_path, "01.0-foo", runtime)
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0
+    fixtures = list((phase_dir / "FIXTURES").iterdir()) if (phase_dir / "FIXTURES").exists() else []
+    fixture_names = {f.name for f in fixtures}
+    assert "G-10.yaml" in fixture_names
+    assert "not-a-goal.yaml" not in fixture_names
+    assert "G_underscore.yaml" not in fixture_names

--- a/tests/test_fixture_cache.py
+++ b/tests/test_fixture_cache.py
@@ -1,0 +1,191 @@
+"""Tests for scripts/runtime/fixture_cache.py — RFC v9 PR-A3."""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime import fixture_cache as fc  # noqa: E402
+
+
+def test_recipe_hash_stable():
+    h1 = fc.recipe_hash("schema_version: 1.0\n")
+    h2 = fc.recipe_hash("schema_version: 1.0\n")
+    h3 = fc.recipe_hash("schema_version: 1.1\n")
+    assert h1 == h2
+    assert h1 != h3
+    assert h1.startswith("sha256:")
+
+
+def test_load_returns_empty_when_missing(tmp_path):
+    data = fc.load(tmp_path)
+    assert data["entries"] == {}
+    assert data["schema_version"] == fc.SCHEMA_VERSION
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    fc.save(tmp_path, {"schema_version": "1.0", "entries": {"G-1": {"foo": "bar"}}})
+    data = fc.load(tmp_path)
+    assert data["entries"]["G-1"] == {"foo": "bar"}
+
+
+def test_acquire_lease_destructive_first_session_succeeds(tmp_path):
+    lease = fc.acquire_lease(
+        tmp_path, "G-10",
+        owner_session="sess-A",
+        consume_semantics="destructive",
+        ttl_seconds=60,
+    )
+    assert lease["owner_session"] == "sess-A"
+    assert lease["consume_semantics"] == "destructive"
+
+
+def test_acquire_lease_destructive_second_session_fails(tmp_path):
+    fc.acquire_lease(tmp_path, "G-10", owner_session="sess-A",
+                       consume_semantics="destructive", ttl_seconds=60)
+    with pytest.raises(fc.LeaseError, match="sess-A"):
+        fc.acquire_lease(tmp_path, "G-10", owner_session="sess-B",
+                           consume_semantics="destructive", ttl_seconds=60)
+
+
+def test_acquire_lease_read_only_shared(tmp_path):
+    fc.acquire_lease(tmp_path, "G-10", owner_session="sess-A",
+                       consume_semantics="read_only", ttl_seconds=60)
+    # Second read_only co-tenancy: should NOT raise
+    fc.acquire_lease(tmp_path, "G-10", owner_session="sess-B",
+                       consume_semantics="read_only", ttl_seconds=60)
+
+
+def test_acquire_lease_read_only_blocks_destructive(tmp_path):
+    fc.acquire_lease(tmp_path, "G-10", owner_session="sess-A",
+                       consume_semantics="read_only", ttl_seconds=60)
+    with pytest.raises(fc.LeaseError):
+        fc.acquire_lease(tmp_path, "G-10", owner_session="sess-B",
+                           consume_semantics="destructive", ttl_seconds=60)
+
+
+def test_expired_lease_is_reapable(tmp_path):
+    # Manually plant an expired lease
+    expired_iso = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat(timespec="seconds")
+    fc.save(tmp_path, {"schema_version": "1.0", "entries": {"G-1": {
+        "lease": {
+            "owner_session": "stale-sess",
+            "expires_at": expired_iso,
+            "consume_semantics": "destructive",
+        },
+    }}})
+    # New session should take over
+    lease = fc.acquire_lease(tmp_path, "G-1", owner_session="fresh",
+                                consume_semantics="destructive", ttl_seconds=60)
+    assert lease["owner_session"] == "fresh"
+
+
+def test_release_lease_only_by_owner(tmp_path):
+    fc.acquire_lease(tmp_path, "G-1", owner_session="sess-A",
+                       consume_semantics="destructive", ttl_seconds=60)
+    assert fc.release_lease(tmp_path, "G-1", "sess-B") is False  # foreign
+    assert fc.release_lease(tmp_path, "G-1", "sess-A") is True
+    # After release: another session can take it
+    fc.acquire_lease(tmp_path, "G-1", owner_session="sess-C",
+                       consume_semantics="destructive", ttl_seconds=60)
+
+
+def test_recipe_hash_drift_invalidates_captured(tmp_path):
+    # Acquire lease + write captured under hash-A
+    fc.acquire_lease(tmp_path, "G-1", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60,
+                       recipe_hash_value="sha256:hash-A")
+    fc.write_captured(tmp_path, "G-1", {"pid": "p1"}, owner_session="s",
+                        recipe_hash_value="sha256:hash-A")
+    assert fc.get_captured(tmp_path, "G-1") == {"pid": "p1"}
+    # Release + re-acquire with new hash → captured dropped
+    fc.release_lease(tmp_path, "G-1", "s")
+    fc.acquire_lease(tmp_path, "G-1", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60,
+                       recipe_hash_value="sha256:hash-B")
+    assert fc.get_captured(tmp_path, "G-1") is None
+
+
+def test_write_captured_requires_lease(tmp_path):
+    with pytest.raises(fc.LeaseError, match="not owned"):
+        fc.write_captured(tmp_path, "G-1", {"x": 1}, owner_session="s")
+
+
+def test_find_orphans(tmp_path):
+    fc.acquire_lease(tmp_path, "G-1", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60)
+    fc.acquire_lease(tmp_path, "G-orphan", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60)
+    orphans = fc.find_orphans(tmp_path, known_goals={"G-1", "G-2"})
+    assert orphans == ["G-orphan"]
+
+
+def test_reap_orphans_removes_them(tmp_path):
+    fc.acquire_lease(tmp_path, "G-keep", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60)
+    fc.acquire_lease(tmp_path, "G-drop", owner_session="s",
+                       consume_semantics="destructive", ttl_seconds=60)
+    n = fc.reap_orphans(tmp_path, known_goals={"G-keep"})
+    assert n == 1
+    data = fc.load(tmp_path)
+    assert "G-drop" not in data["entries"]
+    assert "G-keep" in data["entries"]
+
+
+def test_reap_expired_leases(tmp_path):
+    expired = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat(timespec="seconds")
+    fresh = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat(timespec="seconds")
+    fc.save(tmp_path, {"schema_version": "1.0", "entries": {
+        "G-old": {"lease": {"owner_session": "x", "expires_at": expired,
+                            "consume_semantics": "destructive"}},
+        "G-new": {"lease": {"owner_session": "x", "expires_at": fresh,
+                            "consume_semantics": "destructive"}},
+    }})
+    n = fc.reap_expired_leases(tmp_path)
+    assert n == 1
+    data = fc.load(tmp_path)
+    assert "lease" not in data["entries"]["G-old"]
+    assert data["entries"]["G-new"]["lease"]["owner_session"] == "x"
+
+
+def test_concurrent_acquire_destructive_serializes(tmp_path):
+    """Many threads racing on the same destructive goal → exactly one wins."""
+    winners: list[str] = []
+    losers: list[str] = []
+    barrier = threading.Barrier(8)
+
+    def race(name: str) -> None:
+        barrier.wait()
+        try:
+            fc.acquire_lease(tmp_path, "G-race", owner_session=name,
+                               consume_semantics="destructive", ttl_seconds=60)
+            winners.append(name)
+        except fc.LeaseError:
+            losers.append(name)
+
+    threads = [threading.Thread(target=race, args=(f"sess-{i}",)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(winners) == 1, f"Expected 1 winner, got {len(winners)}: {winners}"
+    assert len(losers) == 7
+    assert len(winners) + len(losers) == 8
+
+
+def test_lease_extension_same_session_succeeds(tmp_path):
+    fc.acquire_lease(tmp_path, "G-1", owner_session="sess",
+                       consume_semantics="destructive", ttl_seconds=60)
+    # Same session re-acquires (renewal)
+    lease2 = fc.acquire_lease(tmp_path, "G-1", owner_session="sess",
+                                 consume_semantics="destructive", ttl_seconds=120)
+    assert lease2["owner_session"] == "sess"

--- a/tests/test_fixture_prune.py
+++ b/tests/test_fixture_prune.py
@@ -1,0 +1,150 @@
+"""Tests for scripts/fixture-prune.py — RFC v9 PR-F."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "fixture-prune.py"
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo), *args],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def _phase(tmp_path: Path, name: str, cache: dict, goals_md: str = "") -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / name
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "FIXTURES-CACHE.json").write_text(
+        json.dumps(cache, indent=2), encoding="utf-8",
+    )
+    if goals_md:
+        (phase_dir / "TEST-GOALS.md").write_text(goals_md, encoding="utf-8")
+    return phase_dir
+
+
+def _expired_iso() -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat(timespec="seconds")
+
+
+def _fresh_iso() -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=600)).isoformat(timespec="seconds")
+
+
+def test_dry_run_does_not_mutate(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {
+            "G-1": {"lease": {"owner_session": "s", "expires_at": _expired_iso(),
+                              "consume_semantics": "destructive"}},
+        },
+    }, goals_md="## Goal G-1: x\n")
+    result = _run(tmp_path, "--phase", "1.0", "--dry-run")
+    assert result.returncode == 0, result.stderr
+    after = json.loads((phase_dir / "FIXTURES-CACHE.json").read_text())
+    assert "lease" in after["entries"]["G-1"]
+
+
+def test_apply_reaps_expired_leases(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {
+            "G-1": {"lease": {"owner_session": "s", "expires_at": _expired_iso(),
+                              "consume_semantics": "destructive"}},
+            "G-2": {"lease": {"owner_session": "s", "expires_at": _fresh_iso(),
+                              "consume_semantics": "destructive"}},
+        },
+    }, goals_md="## Goal G-1: x\n## Goal G-2: y\n")
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0, result.stderr
+    after = json.loads((phase_dir / "FIXTURES-CACHE.json").read_text())
+    assert "lease" not in after["entries"]["G-1"]  # expired → reaped
+    assert "lease" in after["entries"]["G-2"]  # fresh → kept
+
+
+def test_apply_reaps_orphans(tmp_path):
+    """Cache has G-orphan but TEST-GOALS only declares G-keep."""
+    phase_dir = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {
+            "G-keep": {"captured": {"x": 1}},
+            "G-orphan": {"captured": {"y": 2}},
+        },
+    }, goals_md="## Goal G-keep: keep me\n")
+    result = _run(tmp_path, "--phase", "1.0", "--apply")
+    assert result.returncode == 0, result.stderr
+    after = json.loads((phase_dir / "FIXTURES-CACHE.json").read_text())
+    assert "G-orphan" not in after["entries"]
+    assert "G-keep" in after["entries"]
+
+
+def test_skip_orphans_only_reaps_leases(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {
+            "G-orphan": {"lease": {"owner_session": "s",
+                                    "expires_at": _expired_iso(),
+                                    "consume_semantics": "destructive"}},
+        },
+    }, goals_md="")  # no TEST-GOALS → orphan
+    result = _run(tmp_path, "--phase", "1.0", "--apply", "--skip-orphans")
+    assert result.returncode == 0
+    # Lease reaped; entry kept
+    after = json.loads((phase_dir / "FIXTURES-CACHE.json").read_text())
+    assert "G-orphan" in after["entries"]
+    assert "lease" not in after["entries"]["G-orphan"]
+
+
+def test_skip_leases_only_reaps_orphans(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {
+            "G-orphan": {"lease": {"owner_session": "s",
+                                    "expires_at": _expired_iso(),
+                                    "consume_semantics": "destructive"}},
+        },
+    }, goals_md="## Goal G-keep: keep me\n")
+    result = _run(tmp_path, "--phase", "1.0", "--apply", "--skip-leases")
+    assert result.returncode == 0
+    after = json.loads((phase_dir / "FIXTURES-CACHE.json").read_text())
+    assert "G-orphan" not in after["entries"]
+
+
+def test_all_phases_processes_each(tmp_path):
+    p1 = _phase(tmp_path, "01.0-x", {
+        "schema_version": "1.0",
+        "entries": {"G-1": {"captured": {}}},
+    }, goals_md="")
+    p2 = _phase(tmp_path, "02.0-y", {
+        "schema_version": "1.0",
+        "entries": {"G-2": {"captured": {}}},
+    }, goals_md="## Goal G-2: y\n")
+    result = _run(tmp_path, "--all-phases", "--apply")
+    assert result.returncode == 0
+    after_p1 = json.loads((p1 / "FIXTURES-CACHE.json").read_text())
+    after_p2 = json.loads((p2 / "FIXTURES-CACHE.json").read_text())
+    # Phase 1 has no TEST-GOALS → no orphan list available, so entries kept.
+    # Phase 2 has G-2 declared, so G-2 is kept.
+    assert "G-2" in after_p2["entries"]
+
+
+def test_phase_or_all_required(tmp_path):
+    result = _run(tmp_path, "--apply")
+    assert result.returncode != 0
+
+
+def test_skip_both_rejected(tmp_path):
+    result = _run(tmp_path, "--phase", "1.0", "--apply",
+                  "--skip-leases", "--skip-orphans")
+    assert result.returncode != 0
+
+
+def test_dry_run_or_apply_required(tmp_path):
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode != 0

--- a/tests/test_matrix_staleness_d10_provenance.py
+++ b/tests/test_matrix_staleness_d10_provenance.py
@@ -1,0 +1,304 @@
+"""Tests for verify-matrix-staleness.py D10 trustworthy-provenance gate.
+
+Wave-3.2.3 (RFC v9 D10): bidirectional sync (SUSPECTED → READY) must only
+trigger when the submit step bears `evidence.source: scanner` (with
+`scanner_run_id`) or `evidence.source: diagnostic_l2` (with
+`layer2_proposal_id`). Hand-written `executor`/`manual` evidence keeps
+SUSPECTED — closes the trust hole where executor agents could fabricate
+submit + 2xx evidence to flip the matrix back.
+
+Exercises the `trustworthy_submit_evidence()` helper directly + verifies
+end-to-end behavior via subprocess invocation against a fixture phase.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATORS_DIR = REPO_ROOT / "scripts" / "validators"
+sys.path.insert(0, str(VALIDATORS_DIR))
+
+# Module imported as a hyphen-named file — load via importlib
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "verify_matrix_staleness",
+    VALIDATORS_DIR / "verify-matrix-staleness.py",
+)
+matrix_staleness = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(matrix_staleness)
+
+
+# ─── Unit tests for trustworthy_submit_evidence() ─────────────────────────────
+
+
+def _seq_with_step(step: dict) -> dict:
+    return {"steps": [step]}
+
+
+def test_scanner_with_run_id_is_trustworthy():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Submit topup",
+        "evidence": {
+            "source": "scanner",
+            "scanner_run_id": "haiku-2026-05-02-abc123",
+            "artifact_hash": "sha256:deadbeef",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        },
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is True
+    assert reason is None
+
+
+def test_scanner_without_run_id_is_not_trustworthy():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Submit topup",
+        "evidence": {"source": "scanner"},  # missing scanner_run_id
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    # Falls through to "submit step lacks structured evidence" because the
+    # only submit step's evidence is rejected (no scanner_run_id) and no
+    # weak_source was captured (since 'scanner' is in trustworthy set).
+    # Either reason is acceptable — what matters is ok=False.
+
+
+def test_diagnostic_l2_with_proposal_id_is_trustworthy():
+    seq = _seq_with_step({
+        "do": "submit",
+        "target": "Confirm withdraw",
+        "evidence": {
+            "source": "diagnostic_l2",
+            "layer2_proposal_id": "l2-proposal-7e9f",
+            "artifact_hash": "sha256:cafebabe",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        },
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is True
+    assert reason is None
+
+
+def test_diagnostic_l2_without_proposal_id_is_not_trustworthy():
+    seq = _seq_with_step({
+        "do": "submit",
+        "target": "Confirm withdraw",
+        "evidence": {"source": "diagnostic_l2"},  # missing layer2_proposal_id
+    })
+    ok, _ = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+
+
+def test_executor_evidence_is_rejected():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Approve transaction",
+        "evidence": {
+            "source": "executor",  # hand-written by executor agent — DENY
+            "artifact_hash": "sha256:fake",
+            "captured_at": "2026-05-02T10:00:00Z",
+            "schema_version": "1.0",
+        },
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    assert "executor" in reason
+
+
+def test_manual_evidence_is_rejected():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Submit",
+        "evidence": {"source": "manual"},
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    assert "manual" in reason
+
+
+def test_orchestrator_evidence_is_rejected():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Confirm",
+        "evidence": {"source": "orchestrator"},
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    assert "orchestrator" in reason
+
+
+def test_missing_evidence_object_is_rejected():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Submit topup",
+        # NO evidence key — pre-v9 / legacy
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    # Either "no submit step" if SUBMIT_TARGET_RE didn't catch, or the
+    # "lacks structured evidence" path; both are acceptable refusals.
+    assert reason is not None
+
+
+def test_cancel_step_does_not_count_as_submit():
+    seq = _seq_with_step({
+        "do": "click",
+        "target": "Cancel",
+        "evidence": {
+            "source": "scanner",
+            "scanner_run_id": "x",
+        },
+    })
+    ok, reason = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is False
+    # The submit-target regex should reject "Cancel" (cancel verb wins),
+    # so we never see this as a submit step.
+    assert reason == "no submit step"
+
+
+def test_multiple_steps_one_trustworthy_passes():
+    seq = {
+        "steps": [
+            {  # Earlier weak step (executor)
+                "do": "click",
+                "target": "Submit topup",
+                "evidence": {"source": "executor"},
+            },
+            {  # Later trustworthy step (scanner)
+                "do": "click",
+                "target": "Submit topup",
+                "evidence": {
+                    "source": "scanner",
+                    "scanner_run_id": "haiku-r2",
+                },
+            },
+        ],
+    }
+    ok, _ = matrix_staleness.trustworthy_submit_evidence(seq)
+    assert ok is True  # any trustworthy submit step is enough
+
+
+def test_non_dict_seq_is_safe():
+    ok, reason = matrix_staleness.trustworthy_submit_evidence({"steps": "not-a-list"})
+    assert ok is False
+    assert reason == "steps not list"
+
+
+# ─── End-to-end test: invoke validator binary against synthetic phase ──────
+
+
+@pytest.fixture
+def synthetic_phase(tmp_path: Path):
+    """Build a minimal phase tree with TEST-GOALS, RUNTIME-MAP, MATRIX."""
+    phases_dir = tmp_path / ".vg" / "phases"
+    phase_dir = phases_dir / "99.9-d10-test"
+    phase_dir.mkdir(parents=True)
+
+    (phase_dir / "TEST-GOALS.md").write_text(
+        "## Goal G-01: Submit topup\n"
+        "**Surface:** ui\n"
+        "**Mutation evidence:** POST /api/topup returns 200 with id\n",
+        encoding="utf-8",
+    )
+
+    (phase_dir / "GOAL-COVERAGE-MATRIX.md").write_text(
+        "| Goal | Type | Evidence | Status |\n"
+        "|------|------|----------|--------|\n"
+        "| G-01 | mutation | trace-x | SUSPECTED |\n",
+        encoding="utf-8",
+    )
+
+    yield tmp_path, phase_dir
+
+
+def _run_validator(repo_root: Path, phase: str, *flags: str) -> tuple[int, dict]:
+    """Invoke validator with VG_REPO_ROOT pointed at synthetic tree."""
+    cmd = [
+        sys.executable,
+        str(VALIDATORS_DIR / "verify-matrix-staleness.py"),
+        "--phase", phase,
+        *flags,
+    ]
+    proc = subprocess.run(
+        cmd,
+        env={"VG_REPO_ROOT": str(repo_root), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    try:
+        out = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        out = {"verdict": "PARSE_ERROR", "stdout": proc.stdout, "stderr": proc.stderr}
+    return proc.returncode, out
+
+
+def _write_runtime_map(phase_dir: Path, evidence_block: dict | None) -> None:
+    step = {
+        "do": "click",
+        "target": "Submit topup",
+        "network": [{"method": "POST", "endpoint": "/api/topup", "status": 200}],
+    }
+    if evidence_block is not None:
+        step["evidence"] = evidence_block
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps({
+            "goal_sequences": {
+                "G-01": {"steps": [step], "result": "passed"},
+            },
+        }, indent=2),
+        encoding="utf-8",
+    )
+
+
+def test_e2e_scanner_evidence_promotes_suspected_to_ready(synthetic_phase):
+    repo, phase_dir = synthetic_phase
+    _write_runtime_map(phase_dir, {
+        "source": "scanner",
+        "scanner_run_id": "haiku-r-1",
+        "artifact_hash": "sha256:abc",
+        "captured_at": "2026-05-02T10:00:00Z",
+        "schema_version": "1.0",
+    })
+    rc, out = _run_validator(repo, "99.9", "--apply-status-update")
+    assert rc == 0, f"Expected PASS, got rc={rc}, output={out}"
+    assert out["verdict"] in ("PASS", "WARN")
+    matrix_text = (phase_dir / "GOAL-COVERAGE-MATRIX.md").read_text()
+    assert "READY" in matrix_text
+    # Suspected_resolved evidence emitted
+    types = [e["type"] for e in out.get("evidence", [])]
+    assert "suspected_resolved" in types
+
+
+def test_e2e_executor_evidence_keeps_suspected(synthetic_phase):
+    repo, phase_dir = synthetic_phase
+    _write_runtime_map(phase_dir, {"source": "executor"})  # untrustworthy
+    rc, out = _run_validator(repo, "99.9", "--apply-status-update")
+    matrix_text = (phase_dir / "GOAL-COVERAGE-MATRIX.md").read_text()
+    # Should still be SUSPECTED — promotion blocked
+    assert "SUSPECTED" in matrix_text
+    types = [e["type"] for e in out.get("evidence", [])]
+    # Surface the kept-with-weak-provenance signal
+    assert "suspected_kept_weak_provenance" in types
+    # Validator itself still passes (kept-weak is non-escalating signal)
+    assert rc == 0
+
+
+def test_e2e_no_evidence_keeps_suspected_silently(synthetic_phase):
+    """Pre-v9 legacy: missing evidence object — keep SUSPECTED, no error."""
+    repo, phase_dir = synthetic_phase
+    _write_runtime_map(phase_dir, None)
+    rc, out = _run_validator(repo, "99.9", "--apply-status-update")
+    matrix_text = (phase_dir / "GOAL-COVERAGE-MATRIX.md").read_text()
+    assert "SUSPECTED" in matrix_text
+    assert rc == 0

--- a/tests/test_migrate_legacy_provenance.py
+++ b/tests/test_migrate_legacy_provenance.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/migrate-legacy-provenance.py.
+
+RFC v9 D10 migration tool — tags pre-v9 mutation steps lacking
+`evidence` with `provenance_status: legacy_pre_provenance` so the
+provenance validator skips them while still allowing future re-scans
+to record real scanner-source evidence.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "migrate-legacy-provenance.py"
+
+
+def _run(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _phase(tmp_path: Path, name: str, runtime: dict) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / name
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "RUNTIME-MAP.json").write_text(
+        json.dumps(runtime, indent=2), encoding="utf-8",
+    )
+    return phase_dir
+
+
+def _mutation_step(evidence: dict | None = None,
+                   already_tagged: bool = False) -> dict:
+    step = {
+        "do": "click",
+        "target": "Submit topup",
+        "network": [{"method": "POST", "endpoint": "/api/topup", "status": 200}],
+    }
+    if evidence is not None:
+        step["evidence"] = evidence
+    if already_tagged:
+        step["provenance_status"] = "legacy_pre_provenance"
+    return step
+
+
+def test_dry_run_reports_without_writing(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step()]}}
+    })
+    result = _run(tmp_path, "--dry-run")
+    assert result.returncode == 0, result.stderr
+    assert "newly-tagged=  1" in result.stdout
+    # File NOT modified
+    rt = json.loads((phase_dir / "RUNTIME-MAP.json").read_text())
+    assert "provenance_status" not in rt["goal_sequences"]["G-01"]["steps"][0]
+
+
+def test_apply_tags_legacy_steps(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step()]}}
+    })
+    result = _run(tmp_path, "--apply", "--no-backup")
+    assert result.returncode == 0, result.stderr
+    rt = json.loads((phase_dir / "RUNTIME-MAP.json").read_text())
+    step = rt["goal_sequences"]["G-01"]["steps"][0]
+    assert step["provenance_status"] == "legacy_pre_provenance"
+    assert "provenance_migrated_at" in step
+
+
+def test_apply_writes_backup_by_default(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step()]}}
+    })
+    result = _run(tmp_path, "--apply")
+    assert result.returncode == 0
+    bak = phase_dir / "RUNTIME-MAP.json.bak"
+    assert bak.exists()
+    # Backup is the ORIGINAL (no provenance_status tag)
+    bak_data = json.loads(bak.read_text())
+    assert "provenance_status" not in bak_data["goal_sequences"]["G-01"]["steps"][0]
+
+
+def test_skips_steps_with_existing_evidence(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step(
+            evidence={"source": "scanner", "scanner_run_id": "haiku-1"}
+        )]}}
+    })
+    result = _run(tmp_path, "--apply", "--no-backup")
+    assert result.returncode == 0
+    rt = json.loads((phase_dir / "RUNTIME-MAP.json").read_text())
+    step = rt["goal_sequences"]["G-01"]["steps"][0]
+    # Untouched
+    assert "provenance_status" not in step
+    assert "evidence" in step
+
+
+def test_skips_already_tagged_legacy(tmp_path):
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step(already_tagged=True)]}}
+    })
+    result = _run(tmp_path, "--apply", "--no-backup")
+    assert result.returncode == 0
+    assert "already-legacy=  1" in result.stdout
+    assert "newly-tagged=  0" in result.stdout
+
+
+def test_skips_steps_without_2xx_network(tmp_path):
+    """No claim-of-success → no evidence required → no migration tag."""
+    step = {
+        "do": "click",
+        "target": "Submit topup",
+        "network": [{"method": "POST", "endpoint": "/api/topup", "status": 422}],
+    }
+    phase_dir = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [step]}}
+    })
+    result = _run(tmp_path, "--apply", "--no-backup")
+    assert result.returncode == 0
+    rt = json.loads((phase_dir / "RUNTIME-MAP.json").read_text())
+    assert "provenance_status" not in rt["goal_sequences"]["G-01"]["steps"][0]
+
+
+def test_phase_filter_targets_single_phase(tmp_path):
+    p1 = _phase(tmp_path, "01.0-foo", {
+        "goal_sequences": {"G-01": {"steps": [_mutation_step()]}}
+    })
+    p2 = _phase(tmp_path, "02.0-bar", {
+        "goal_sequences": {"G-02": {"steps": [_mutation_step()]}}
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--apply", "--no-backup")
+    assert result.returncode == 0, result.stderr
+    rt1 = json.loads((p1 / "RUNTIME-MAP.json").read_text())
+    rt2 = json.loads((p2 / "RUNTIME-MAP.json").read_text())
+    assert "provenance_status" in rt1["goal_sequences"]["G-01"]["steps"][0]
+    assert "provenance_status" not in rt2["goal_sequences"]["G-02"]["steps"][0]
+
+
+def test_requires_dry_run_or_apply(tmp_path):
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "must specify" in result.stderr.lower() or "must specify" in result.stdout.lower()
+
+
+def test_dry_run_and_apply_mutually_exclusive(tmp_path):
+    result = _run(tmp_path, "--dry-run", "--apply")
+    assert result.returncode != 0

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/runtime/pattern_catalog.py — RFC v9 D25."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.pattern_catalog import (  # noqa: E402
+    Pattern,
+    load_catalog,
+    load_pattern,
+    match_patterns,
+    needs_web_augment,
+)
+
+CATALOG_DIR = REPO_ROOT / "catalog" / "edge-cases"
+
+
+def test_seed_catalog_loads():
+    """The 5 seed patterns must load without errors."""
+    patterns = load_catalog(CATALOG_DIR)
+    assert len(patterns) >= 5
+    ids = {p.id for p in patterns}
+    assert "payments-idempotency-collision" in ids
+    assert "auth-session-fixation" in ids
+    assert "ui-double-submit" in ids
+
+
+def test_match_by_surface(tmp_path):
+    catalog = load_catalog(CATALOG_DIR)
+    api_only = match_patterns(catalog, surface="api")
+    assert all(p.surface == "api" for p in api_only)
+    assert any(p.id == "payments-idempotency-collision" for p in api_only)
+
+    ui_only = match_patterns(catalog, surface="ui")
+    assert all(p.surface == "ui" for p in ui_only)
+
+
+def test_match_by_tags_overlap():
+    catalog = load_catalog(CATALOG_DIR)
+    payments = match_patterns(catalog, tags=["payments"])
+    assert any(p.id == "payments-idempotency-collision" for p in payments)
+    assert all("payments" in p.tags for p in payments)
+
+
+def test_match_require_all_tags():
+    catalog = load_catalog(CATALOG_DIR)
+    # idempotency AND payments — payments-idempotency-collision is the seed
+    # pattern carrying both tags
+    matches = match_patterns(
+        catalog, tags=["payments", "idempotency"], require_all_tags=True,
+    )
+    assert any(p.id == "payments-idempotency-collision" for p in matches)
+    # something with only payments would miss when require_all_tags=True
+    only_payments_match = match_patterns(
+        catalog, tags=["payments", "no_such_tag"], require_all_tags=True,
+    )
+    assert only_payments_match == []
+
+
+def test_severity_floor():
+    catalog = load_catalog(CATALOG_DIR)
+    high_only = match_patterns(catalog, severity_min="high")
+    assert all(p.severity in ("high", "critical") for p in high_only)
+    crit_only = match_patterns(catalog, severity_min="critical")
+    assert all(p.severity == "critical" for p in crit_only)
+
+
+def test_results_sorted_by_severity_desc():
+    catalog = load_catalog(CATALOG_DIR)
+    out = match_patterns(catalog)
+    sev_rank = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+    ranks = [sev_rank.get(p.severity, 2) for p in out]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_load_pattern_missing_id_raises(tmp_path):
+    bad = tmp_path / "bad.md"
+    bad.write_text("---\nsurface: api\n---\nbody\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing id"):
+        load_pattern(bad)
+
+
+def test_load_pattern_missing_surface_raises(tmp_path):
+    bad = tmp_path / "bad.md"
+    bad.write_text("---\nid: x\n---\nbody\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing surface"):
+        load_pattern(bad)
+
+
+def test_needs_web_augment_threshold():
+    assert needs_web_augment([], min_matches=1)
+    assert needs_web_augment([Pattern("x", "api")], min_matches=2)
+    assert not needs_web_augment(
+        [Pattern("a", "api"), Pattern("b", "api")], min_matches=2,
+    )
+
+
+def test_load_catalog_empty_dir(tmp_path):
+    assert load_catalog(tmp_path) == []
+
+
+def test_load_catalog_nonexistent_dir(tmp_path):
+    assert load_catalog(tmp_path / "missing") == []
+
+
+def test_load_catalog_skips_malformed(tmp_path):
+    (tmp_path / "good.md").write_text(
+        "---\nid: g\nsurface: api\n---\nbody\n", encoding="utf-8",
+    )
+    (tmp_path / "bad.md").write_text(
+        "---\nid: b\n---\nno surface\n", encoding="utf-8",
+    )
+    out = load_catalog(tmp_path)
+    assert len(out) == 1
+    assert out[0].id == "g"

--- a/tests/test_preflight_invariants.py
+++ b/tests/test_preflight_invariants.py
@@ -1,0 +1,269 @@
+"""Tests for scripts/runtime/preflight.py — RFC v9 PR-C N-consumer algorithm."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.preflight import (  # noqa: E402
+    PreflightError,
+    parse_env_contract,
+    required_count,
+    verify_invariants,
+    fix_hint,
+)
+
+
+# ─── required_count algorithm (D5) ────────────────────────────────────
+
+
+def test_per_consumer_one_destructive():
+    inv = {
+        "id": "i1",
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+        ],
+    }
+    assert required_count(inv) == 1
+
+
+def test_per_consumer_three_destructive():
+    inv = {
+        "id": "i1",
+        "consumers": [
+            {"goal": f"G-{i}", "recipe": f"G-{i}", "consume_semantics": "destructive"}
+            for i in range(1, 4)
+        ],
+    }
+    assert required_count(inv) == 3
+
+
+def test_per_consumer_destructive_plus_read_only_adds_one():
+    """3 destructive + 2 read_only with isolation=per_consumer → 4 (3 destructive + 1 shared)."""
+    inv = {
+        "id": "i1",
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+            {"goal": "G-2", "recipe": "G-2", "consume_semantics": "destructive"},
+            {"goal": "G-3", "recipe": "G-3", "consume_semantics": "destructive"},
+            {"goal": "G-4", "recipe": "G-4", "consume_semantics": "read_only"},
+            {"goal": "G-5", "recipe": "G-5", "consume_semantics": "read_only"},
+        ],
+    }
+    assert required_count(inv) == 4
+
+
+def test_shared_when_read_only_all_read_only():
+    inv = {
+        "id": "i1",
+        "isolation": "shared_when_read_only",
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "read_only"},
+            {"goal": "G-2", "recipe": "G-2", "consume_semantics": "read_only"},
+        ],
+    }
+    assert required_count(inv) == 1
+
+
+def test_shared_when_read_only_with_destructive_falls_back():
+    """isolation=shared_when_read_only but a destructive consumer present →
+    fall back to per_consumer count (destructive_n)."""
+    inv = {
+        "id": "i1",
+        "isolation": "shared_when_read_only",
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+            {"goal": "G-2", "recipe": "G-2", "consume_semantics": "read_only"},
+        ],
+    }
+    assert required_count(inv) == 1  # destructive_n=1; can't share with destructive
+
+
+def test_no_consumers_raises():
+    with pytest.raises(PreflightError, match="no consumers"):
+        required_count({"id": "i1", "consumers": []})
+
+
+def test_unknown_isolation_raises():
+    inv = {
+        "id": "i1",
+        "isolation": "weird",
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+        ],
+    }
+    with pytest.raises(PreflightError, match="unknown isolation"):
+        required_count(inv)
+
+
+# ─── verify_invariants ───────────────────────────────────────────────
+
+
+def _stub_count_fn(returns: dict[str, int]):
+    """Returns a count_fn that maps resource → fixed count."""
+    def count_fn(resource: str, where: dict) -> int:
+        return returns.get(resource, 0)
+    return count_fn
+
+
+def test_verify_invariants_no_gap():
+    invariants = [{
+        "id": "tier2_topup",
+        "resource": "topup",
+        "where": {"tier": 2},
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+            {"goal": "G-2", "recipe": "G-2", "consume_semantics": "destructive"},
+        ],
+    }]
+    gaps = verify_invariants(invariants, _stub_count_fn({"topup": 5}))
+    assert gaps == []
+
+
+def test_verify_invariants_gap_destructive_short():
+    invariants = [{
+        "id": "tier2_topup",
+        "resource": "topup",
+        "where": {"tier": 2},
+        "consumers": [
+            {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+            {"goal": "G-2", "recipe": "G-2", "consume_semantics": "destructive"},
+            {"goal": "G-3", "recipe": "G-3", "consume_semantics": "destructive"},
+        ],
+    }]
+    gaps = verify_invariants(invariants, _stub_count_fn({"topup": 1}))
+    assert len(gaps) == 1
+    g = gaps[0]
+    assert g.required == 3
+    assert g.actual == 1
+    assert "G-1" in g.consumers and "G-3" in g.consumers
+
+
+def test_verify_invariants_multiple_resources():
+    invariants = [
+        {
+            "id": "i1",
+            "resource": "topup",
+            "where": {"tier": 2},
+            "consumers": [{"goal": "G-1", "recipe": "G-1",
+                           "consume_semantics": "destructive"}],
+        },
+        {
+            "id": "i2",
+            "resource": "withdraw",
+            "where": {"status": "pending"},
+            "consumers": [{"goal": "G-2", "recipe": "G-2",
+                           "consume_semantics": "destructive"}],
+        },
+    ]
+    # topup OK (1), withdraw short (0)
+    gaps = verify_invariants(invariants, _stub_count_fn({"topup": 1, "withdraw": 0}))
+    assert len(gaps) == 1
+    assert gaps[0].invariant_id == "i2"
+    assert gaps[0].resource == "withdraw"
+
+
+def test_count_fn_receives_correct_where():
+    captured: list = []
+
+    def count_fn(resource: str, where: dict) -> int:
+        captured.append((resource, where))
+        return 99
+
+    invariants = [{
+        "id": "i1",
+        "resource": "topup",
+        "where": {"tier": 2, "status": "pending"},
+        "consumers": [{"goal": "G-1", "recipe": "G-1",
+                       "consume_semantics": "destructive"}],
+    }]
+    verify_invariants(invariants, count_fn)
+    assert captured == [("topup", {"tier": 2, "status": "pending"})]
+
+
+def test_invariant_missing_id_raises():
+    with pytest.raises(PreflightError, match="missing id"):
+        verify_invariants(
+            [{"resource": "x", "consumers": [
+                {"goal": "G-1", "recipe": "G-1", "consume_semantics": "destructive"},
+            ]}],
+            _stub_count_fn({}),
+        )
+
+
+# ─── fix_hint ─────────────────────────────────────────────────────────
+
+
+def test_fix_hint_includes_actionable_data():
+    from runtime.preflight import InvariantGap
+    g = InvariantGap(
+        invariant_id="tier2_topup",
+        resource="topup",
+        required=3,
+        actual=1,
+        consumers=["G-10", "G-11", "G-12"],
+        where={"tier": 2, "status": "pending"},
+    )
+    hint = fix_hint(g)
+    assert "create 2 more" in hint
+    assert "G-10" in hint
+    assert "tier2_topup" in hint
+    assert "shared_when_read_only" in hint  # offer alternative
+
+
+# ─── parse_env_contract ──────────────────────────────────────────────
+
+
+def test_parses_yaml_block_in_markdown(tmp_path):
+    md = """
+# ENV-CONTRACT
+
+Some prose…
+
+```yaml
+data_invariants:
+  - id: tier2_topup
+    resource: topup
+    where:
+      tier: 2
+    consumers:
+      - goal: G-10
+        recipe: G-10
+        consume_semantics: destructive
+```
+
+More prose.
+""".lstrip()
+    path = tmp_path / "ENV-CONTRACT.md"
+    path.write_text(md, encoding="utf-8")
+    pytest.importorskip("yaml")
+    invs = parse_env_contract(path)
+    assert len(invs) == 1
+    assert invs[0]["id"] == "tier2_topup"
+
+
+def test_parses_pure_yaml(tmp_path):
+    pytest.importorskip("yaml")
+    yaml_text = """
+data_invariants:
+  - id: x
+    resource: r
+    where: {a: 1}
+    consumers:
+      - {goal: G-1, recipe: G-1, consume_semantics: read_only}
+""".lstrip()
+    path = tmp_path / "ENV.yaml"
+    path.write_text(yaml_text, encoding="utf-8")
+    invs = parse_env_contract(path)
+    assert invs[0]["id"] == "x"
+
+
+def test_returns_empty_when_no_block(tmp_path):
+    path = tmp_path / "no.md"
+    path.write_text("No invariants here.\n", encoding="utf-8")
+    pytest.importorskip("yaml")
+    assert parse_env_contract(path) == []

--- a/tests/test_preflight_invariants_runner.py
+++ b/tests/test_preflight_invariants_runner.py
@@ -1,0 +1,271 @@
+"""Tests for scripts/preflight-invariants.py — standalone runner."""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "preflight-invariants.py"
+
+requests = pytest.importorskip("requests")
+
+
+def _run(repo: Path, *args: str, env_extra: dict | None = None
+         ) -> subprocess.CompletedProcess:
+    env = {
+        "VG_REPO_ROOT": str(repo),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": str(REPO_ROOT / "scripts"),
+    }
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    routes: dict = {}
+    log_message = lambda *a, **k: None
+
+    def do_GET(self) -> None:
+        path_only = self.path.split("?", 1)[0]
+        route = self.routes.get(("GET", path_only))
+        if route is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(route.get("status", 200))
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(route.get("body", {})).encode())
+
+
+@pytest.fixture
+def server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    routes: dict = {}
+
+    class _H(_Handler):
+        pass
+    _H.routes = routes
+    srv = http.server.HTTPServer(("127.0.0.1", port), _H)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}", routes
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _phase(tmp_path: Path, env_contract_md: str) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / "01.0-preflight"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "ENV-CONTRACT.md").write_text(env_contract_md, encoding="utf-8")
+    return phase_dir
+
+
+def test_no_env_contract_passes(tmp_path):
+    """No ENV-CONTRACT.md — preflight is opt-in, so trivial PASS."""
+    phase_dir = tmp_path / ".vg" / "phases" / "01.0-x"
+    phase_dir.mkdir(parents=True)
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "PASS"
+
+
+def test_no_invariants_passes(tmp_path):
+    _phase(tmp_path, "# ENV-CONTRACT\n\nNo invariants here.\n")
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "PASS"
+
+
+def test_dry_run_emits_planned_checks(tmp_path):
+    pytest.importorskip("yaml")
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: tier2_topup
+    resource: topup
+    where: {tier: 2}
+    consumers:
+      - {goal: G-10, recipe: G-10, consume_semantics: destructive}
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+```
+""".strip())
+    result = _run(tmp_path, "--phase", "1.0", "--dry-run")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "DRY_RUN"
+    assert out["invariants"] == 1
+    assert "topup" in out["api_index_resources"]
+
+
+def test_live_run_pass_when_count_meets_required(tmp_path, server):
+    pytest.importorskip("yaml")
+    base_url, routes = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"meta": {"total": 5}},
+    }
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: tier2_topup
+    resource: topup
+    where: {tier: 2}
+    consumers:
+      - {goal: G-10, recipe: G-10, consume_semantics: destructive}
+      - {goal: G-11, recipe: G-11, consume_semantics: destructive}
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+    count_query_keys: [tier]
+```
+""".strip())
+    creds = json.dumps({"admin": {"kind": "api_key", "key": "test"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "PASS"
+
+
+def test_live_run_blocks_when_count_short(tmp_path, server):
+    pytest.importorskip("yaml")
+    base_url, routes = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"meta": {"total": 1}},  # need 3, have 1
+    }
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: tier2_topup
+    resource: topup
+    where: {tier: 2}
+    consumers:
+      - {goal: G-10, recipe: G-10, consume_semantics: destructive}
+      - {goal: G-11, recipe: G-11, consume_semantics: destructive}
+      - {goal: G-12, recipe: G-12, consume_semantics: destructive}
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+    count_query_keys: [tier]
+```
+""".strip())
+    creds = json.dumps({"admin": {"kind": "api_key", "key": "test"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 1
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "BLOCK"
+    assert len(out["gaps"]) == 1
+    assert out["gaps"][0]["required"] == 3
+    assert out["gaps"][0]["actual"] == 1
+    assert "fix_hint" in out["gaps"][0]
+
+
+def test_severity_warn_does_not_block(tmp_path, server):
+    pytest.importorskip("yaml")
+    base_url, routes = server
+    routes[("GET", "/api/admin/topup")] = {
+        "status": 200, "body": {"meta": {"total": 0}},
+    }
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: tier2_topup
+    resource: topup
+    where: {tier: 2}
+    consumers:
+      - {goal: G-10, recipe: G-10, consume_semantics: destructive}
+api_index:
+  topup:
+    count_endpoint: /api/admin/topup
+    count_jsonpath: $.meta.total
+    count_role: admin
+```
+""".strip())
+    creds = json.dumps({"admin": {"kind": "api_key", "key": "test"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--severity", "warn",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "WARN"
+
+
+def test_missing_credentials_errors(tmp_path):
+    pytest.importorskip("yaml")
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: i
+    resource: r
+    where: {x: 1}
+    consumers:
+      - {goal: G-1, recipe: G-1, consume_semantics: destructive}
+api_index:
+  r:
+    count_endpoint: /api/r
+    count_jsonpath: $.n
+    count_role: admin
+```
+""".strip())
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", "http://localhost")
+    assert result.returncode == 2
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "ERROR"
+    assert "credentials" in out["error"].lower()
+
+
+def test_missing_base_url_errors(tmp_path):
+    pytest.importorskip("yaml")
+    _phase(tmp_path, """
+```yaml
+data_invariants:
+  - id: i
+    resource: r
+    where: {x: 1}
+    consumers:
+      - {goal: G-1, recipe: G-1, consume_semantics: destructive}
+api_index:
+  r:
+    count_endpoint: /api/r
+    count_jsonpath: $.n
+    count_role: admin
+```
+""".strip())
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode == 2
+    out = json.loads(result.stdout)
+    assert "base-url" in out["error"].lower() or "base_url" in out["error"].lower()
+
+
+def test_phase_not_found_errors(tmp_path):
+    (tmp_path / ".vg" / "phases").mkdir(parents=True)
+    result = _run(tmp_path, "--phase", "99.99")
+    assert result.returncode == 2

--- a/tests/test_rcrurd_gate.py
+++ b/tests/test_rcrurd_gate.py
@@ -144,6 +144,61 @@ def test_post_state_increased_by_at_least():
     assert res.post_state_passed
 
 
+def test_post_state_decreased_by_at_least_passes():
+    """Codex-R4-HIGH-1: decreased_by_at_least was schema-declared but not
+    evaluated. Now must enforce drop ≥ threshold."""
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/balance",
+            "assert_jsonpath": [{"path": "$.balance", "decreased_by_at_least": 100}],
+        },
+    }
+    res = run_post_state_with_retry(
+        "G-1",
+        lifecycle,
+        _stub_get({("u", "/api/balance"): {"balance": 800}}),
+        pre_payload={"balance": 1000},
+    )
+    assert res.post_state_passed
+
+
+def test_post_state_decreased_below_threshold_fails():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/balance",
+            "assert_jsonpath": [{"path": "$.balance", "decreased_by_at_least": 100}],
+        },
+    }
+    res = run_post_state_with_retry(
+        "G-1",
+        lifecycle,
+        _stub_get({("u", "/api/balance"): {"balance": 950}}),  # drop=50 < 100
+        pre_payload={"balance": 1000},
+    )
+    assert not res.post_state_passed
+    assert any("drop=50" in f or "decreased_by_at_least" in f for f in res.post_state_failures)
+
+
+def test_post_state_value_increased_when_decrease_expected_fails():
+    """Critical regression: balance went UP when assertion says DOWN."""
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/balance",
+            "assert_jsonpath": [{"path": "$.balance", "decreased_by_at_least": 100}],
+        },
+    }
+    res = run_post_state_with_retry(
+        "G-1",
+        lifecycle,
+        _stub_get({("u", "/api/balance"): {"balance": 1200}}),  # INCREASED
+        pre_payload={"balance": 1000},
+    )
+    assert not res.post_state_passed
+
+
 def test_post_state_increased_by_at_least_below_threshold():
     lifecycle = {
         "post_state": {

--- a/tests/test_rcrurd_gate.py
+++ b/tests/test_rcrurd_gate.py
@@ -1,0 +1,209 @@
+"""Tests for scripts/runtime/rcrurd_gate.py — RFC v9 PR-D2 Layer 0 lifecycle gate."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.rcrurd_gate import (  # noqa: E402
+    LifecycleGateError,
+    run_post_state_with_retry,
+    run_pre_state,
+)
+
+
+def _stub_get(responses: dict[tuple[str, str], dict | Exception]):
+    """Returns a get_fn over a (role, endpoint) → response mapping."""
+    def get_fn(role: str, endpoint: str):
+        r = responses.get((role, endpoint))
+        if isinstance(r, Exception):
+            raise r
+        if r is None:
+            raise KeyError(f"no stub for ({role}, {endpoint})")
+        return r
+    return get_fn
+
+
+def test_pre_state_passes_when_assertion_matches():
+    lifecycle = {
+        "pre_state": {
+            "role": "u",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 0}],
+        },
+    }
+    res = run_pre_state("G-1", lifecycle, _stub_get({
+        ("u", "/api/topup/pending"): {"count": 0},
+    }))
+    assert res.pre_state_passed
+    assert not res.pre_state_failures
+
+
+def test_pre_state_fails_when_assertion_does_not_match():
+    lifecycle = {
+        "pre_state": {
+            "role": "u",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 0}],
+        },
+    }
+    res = run_pre_state("G-1", lifecycle, _stub_get({
+        ("u", "/api/topup/pending"): {"count": 5},  # WRONG
+    }))
+    assert not res.pre_state_passed
+    assert any("count" in f for f in res.pre_state_failures)
+
+
+def test_pre_state_no_lifecycle_skips():
+    res = run_pre_state("G-1", {}, _stub_get({}))
+    assert res.skipped_reason
+
+
+def test_pre_state_get_raises_recorded():
+    lifecycle = {
+        "pre_state": {
+            "role": "u", "endpoint": "/api/x",
+            "assert_jsonpath": [{"path": "$", "not_null": True}],
+        },
+    }
+    res = run_pre_state("G-1", lifecycle, _stub_get({
+        ("u", "/api/x"): RuntimeError("network"),
+    }))
+    assert any("raised" in f for f in res.pre_state_failures)
+
+
+def test_post_state_passes_first_attempt():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 1}],
+        },
+    }
+    res = run_post_state_with_retry("G-1", lifecycle, _stub_get({
+        ("u", "/api/topup/pending"): {"count": 1},
+    }))
+    assert res.post_state_passed
+
+
+def test_post_state_eventually_passes_with_retry():
+    """Eventual consistency: first attempt sees count=0, second sees count=1."""
+    attempt_state = {"n": 0}
+
+    def get_fn(role: str, endpoint: str):
+        attempt_state["n"] += 1
+        return {"count": 0 if attempt_state["n"] < 3 else 1}
+
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 1}],
+            "retry": {"max_attempts": 5, "delay_ms": 1, "until_assertion_pass": True},
+        },
+    }
+    res = run_post_state_with_retry("G-1", lifecycle, get_fn)
+    assert res.post_state_passed
+    assert attempt_state["n"] == 3
+
+
+def test_post_state_max_attempts_exhausted():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 1}],
+            "retry": {"max_attempts": 3, "delay_ms": 1, "until_assertion_pass": True},
+        },
+    }
+    res = run_post_state_with_retry("G-1", lifecycle, _stub_get({
+        ("u", "/api/topup/pending"): {"count": 0},
+    }))
+    assert not res.post_state_passed
+    assert any("attempt 3" in f for f in res.post_state_failures)
+
+
+def test_post_state_increased_by_at_least():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/balance",
+            "assert_jsonpath": [{"path": "$.balance", "increased_by_at_least": 100}],
+        },
+    }
+    res = run_post_state_with_retry(
+        "G-1",
+        lifecycle,
+        _stub_get({("u", "/api/balance"): {"balance": 1100}}),
+        pre_payload={"balance": 1000},
+    )
+    assert res.post_state_passed
+
+
+def test_post_state_increased_by_at_least_below_threshold():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/balance",
+            "assert_jsonpath": [{"path": "$.balance", "increased_by_at_least": 100}],
+        },
+    }
+    res = run_post_state_with_retry(
+        "G-1",
+        lifecycle,
+        _stub_get({("u", "/api/balance"): {"balance": 1050}}),
+        pre_payload={"balance": 1000},
+    )
+    assert not res.post_state_passed
+    assert any("delta=50.0" in f or "threshold=100" in f for f in res.post_state_failures)
+
+
+def test_post_state_cardinality_assertion():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/items",
+            "assert_jsonpath": [{"path": "$.items[*]", "cardinality": ">=3"}],
+        },
+    }
+    payload = {"items": [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]}
+    res = run_post_state_with_retry("G-1", lifecycle, _stub_get({
+        ("u", "/api/items"): payload,
+    }))
+    assert res.post_state_passed
+
+
+def test_post_state_not_null():
+    lifecycle = {
+        "post_state": {
+            "role": "u",
+            "endpoint": "/api/last",
+            "assert_jsonpath": [{"path": "$.confirmed_at", "not_null": True}],
+        },
+    }
+    res = run_post_state_with_retry("G-1", lifecycle, _stub_get({
+        ("u", "/api/last"): {"confirmed_at": "2026-05-02T10:00:00Z"},
+    }))
+    assert res.post_state_passed
+
+
+def test_post_state_no_retry_block_runs_once():
+    """retry omitted → max_attempts=1, no until_pass loop."""
+    attempts = {"n": 0}
+
+    def get_fn(role: str, endpoint: str):
+        attempts["n"] += 1
+        return {"count": 0}  # always fails
+
+    lifecycle = {
+        "post_state": {
+            "role": "u", "endpoint": "/api/x",
+            "assert_jsonpath": [{"path": "$.count", "equals": 1}],
+        },
+    }
+    run_post_state_with_retry("G-1", lifecycle, get_fn)
+    assert attempts["n"] == 1

--- a/tests/test_rcrurd_preflight_runner.py
+++ b/tests/test_rcrurd_preflight_runner.py
@@ -1,0 +1,314 @@
+"""Tests for scripts/rcrurd-preflight.py — RCRURD live runner."""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "rcrurd-preflight.py"
+
+requests = pytest.importorskip("requests")
+yaml = pytest.importorskip("yaml")
+
+
+def _run(repo: Path, *args: str, env_extra: dict | None = None
+         ) -> subprocess.CompletedProcess:
+    env = {"VG_REPO_ROOT": str(repo), "PATH": "/usr/bin:/bin",
+           "PYTHONPATH": str(REPO_ROOT / "scripts")}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    routes: dict = {}
+    log_message = lambda *a, **k: None
+
+    def do_GET(self) -> None:
+        path_only = self.path.split("?", 1)[0]
+        route = self.routes.get(("GET", path_only))
+        if route is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(route.get("status", 200))
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(route.get("body", {})).encode())
+
+
+@pytest.fixture
+def server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    routes: dict = {}
+
+    class _H(_Handler):
+        pass
+    _H.routes = routes
+    srv = http.server.HTTPServer(("127.0.0.1", port), _H)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}", routes
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _phase(tmp_path: Path, fixtures: dict[str, dict]) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / "01.0-rcrurd"
+    fixtures_dir = phase_dir / "FIXTURES"
+    fixtures_dir.mkdir(parents=True)
+    for gid, recipe in fixtures.items():
+        (fixtures_dir / f"{gid}.yaml").write_text(
+            yaml.safe_dump(recipe, sort_keys=False), encoding="utf-8",
+        )
+    return phase_dir
+
+
+def test_no_fixtures_dir_passes(tmp_path):
+    phase_dir = tmp_path / ".vg" / "phases" / "01.0-x"
+    phase_dir.mkdir(parents=True)
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["verdict"] == "PASS"
+
+
+def test_no_lifecycle_blocks_passes(tmp_path):
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50, "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+        },
+    })
+    result = _run(tmp_path, "--phase", "1.0")
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["verdict"] == "PASS"
+
+
+def test_dry_run_lists_planned_checks(tmp_path):
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/topup/pending",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/topup/pending",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--dry-run")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "DRY_RUN"
+    assert any("/api/topup/pending" in p["endpoint"] for p in out["would_check"])
+
+
+def test_live_pre_state_passes(tmp_path, server):
+    base_url, routes = server
+    routes[("GET", "/api/topup/pending")] = {
+        "status": 200, "body": {"count": 0},  # matches expected
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/topup/pending",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/topup/pending",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "PASS"
+
+
+def test_live_pre_state_block_when_count_wrong(tmp_path, server):
+    base_url, routes = server
+    routes[("GET", "/api/topup/pending")] = {
+        "status": 200, "body": {"count": 5},  # WRONG (expected 0)
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/topup/pending",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/topup/pending",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--severity", "block",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 1
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "BLOCK"
+    assert out["failed"] == 1
+    assert any("count" in str(r.get("errors", "")) for r in out["results"])
+
+
+def test_only_filter_targets_specific_goal(tmp_path, server):
+    base_url, routes = server
+    routes[("GET", "/api/x/0")] = {"status": 200, "body": {"count": 0}}
+    routes[("GET", "/api/y/0")] = {"status": 200, "body": {"count": 0}}
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/x/0",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/x/0",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+        "G-11": {
+            "schema_version": "1.0", "goal": "G-11",
+            "description": "y" * 50,
+            "fixture_intent": {"declared_in": "y", "validates": "y" * 25},
+            "steps": [{"id": "y", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/y"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/y/0",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/y",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/y/0",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--only", "G-10",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["checked"] == 1
+
+
+def test_warn_severity_does_not_block(tmp_path, server):
+    base_url, routes = server
+    routes[("GET", "/api/x")] = {
+        "status": 200, "body": {"count": 99},  # wrong
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/x",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/x",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--severity", "warn",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "WARN"
+
+
+def test_missing_credentials_errors(tmp_path):
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET", "endpoint": "/x",
+                              "assert_jsonpath": [{"path": "$.x", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET", "endpoint": "/x",
+                               "assert_jsonpath": [{"path": "$.x", "equals": 1}]},
+            },
+        },
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", "http://localhost")
+    assert result.returncode == 2
+    assert "credentials" in json.loads(result.stdout)["error"].lower()

--- a/tests/test_rcrurd_preflight_runner.py
+++ b/tests/test_rcrurd_preflight_runner.py
@@ -397,6 +397,107 @@ def test_mode_post_dry_run_lists_post_state_endpoints(tmp_path):
     assert not any("/api/pre" in p["endpoint"] for p in out["would_check"])
 
 
+def test_capture_and_reuse_snapshot_for_increased_by_delta(tmp_path, server):
+    """Codex-HIGH-1-bis: post_state must use REAL pre-action snapshot for
+    increased_by_at_least, not a fresh post-action GET."""
+    base_url, routes = server
+    # Stage 1: pre_state runs against count=0
+    routes[("GET", "/api/balance")] = {
+        "status": 200, "body": {"balance": 100},
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {
+                    "role": "u", "method": "GET",
+                    "endpoint": "/api/balance",
+                    "assert_jsonpath": [{"path": "$.balance", "not_null": True}],
+                },
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/topup",
+                                                  "status_range": [200, 299]}},
+                "post_state": {
+                    "role": "u", "method": "GET",
+                    "endpoint": "/api/balance",
+                    "assert_jsonpath": [
+                        {"path": "$.balance", "increased_by_at_least": 50},
+                    ],
+                },
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    snap = tmp_path / "pre-snapshot.json"
+
+    # Stage 1: --mode pre with --capture-snapshot
+    r1 = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+               "--mode", "pre", "--capture-snapshot", str(snap),
+               env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert r1.returncode == 0, f"stdout={r1.stdout}\nstderr={r1.stderr}"
+    assert snap.exists()
+    snap_data = json.loads(snap.read_text())
+    assert snap_data["G-10"] == {"balance": 100}
+
+    # Stage 2: simulate action — balance increases to 200
+    routes[("GET", "/api/balance")] = {
+        "status": 200, "body": {"balance": 200},
+    }
+
+    # Stage 3: --mode post with --pre-snapshot — delta = 200-100 = 100 >= 50 → PASS
+    r2 = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+               "--mode", "post", "--pre-snapshot", str(snap),
+               env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert r2.returncode == 0, f"stdout={r2.stdout}\nstderr={r2.stderr}"
+    out2 = json.loads(r2.stdout)
+    assert out2["verdict"] == "PASS"
+    assert out2.get("pre_snapshot_loaded") is True
+
+
+def test_post_without_snapshot_fails_delta_assertions(tmp_path, server):
+    """Without snapshot, post mode samples pre + post post-action — delta=0."""
+    base_url, routes = server
+    routes[("GET", "/api/balance")] = {
+        "status": 200, "body": {"balance": 200},
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/balance",
+                              "assert_jsonpath": [{"path": "$.balance", "not_null": True}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/topup",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/balance",
+                               "assert_jsonpath": [
+                                   {"path": "$.balance", "increased_by_at_least": 50},
+                               ]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    # No --pre-snapshot → fallback fetch reads same payload → delta=0
+    r = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+              "--mode", "post",
+              env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert r.returncode == 1
+    out = json.loads(r.stdout)
+    assert out["verdict"] == "BLOCK"
+
+
 def test_default_severity_is_now_block(tmp_path, server):
     """Codex-HIGH-4: default severity changed from warn to block."""
     base_url, routes = server

--- a/tests/test_rcrurd_preflight_runner.py
+++ b/tests/test_rcrurd_preflight_runner.py
@@ -289,6 +289,145 @@ def test_warn_severity_does_not_block(tmp_path, server):
     assert out["verdict"] == "WARN"
 
 
+# ─── Codex-HIGH-1: --mode post wires post_state into workflow ────────
+
+
+def test_mode_post_runs_post_state_assertions(tmp_path, server):
+    """Codex-HIGH-1: post-state must actually execute, not just be defined."""
+    base_url, routes = server
+    routes[("GET", "/api/topup/pending")] = {
+        "status": 200, "body": {"count": 1},  # post-state expects 1
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/topup/pending",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/topup/pending",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--mode", "post",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "PASS"
+    assert out["mode"] == "post"
+
+
+def test_mode_post_blocks_when_post_state_wrong(tmp_path, server):
+    """Action did not produce expected post-state — must BLOCK."""
+    base_url, routes = server
+    # Both endpoints return count=0 — pre-state OK, post-state WRONG
+    routes[("GET", "/api/topup/pending")] = {
+        "status": 200, "body": {"count": 0},
+    }
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/topup/pending",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/topup/pending",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   "--mode", "post", "--severity", "block",
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 1
+    out = json.loads(result.stdout)
+    assert out["verdict"] == "BLOCK"
+    assert out["mode"] == "post"
+
+
+def test_mode_post_dry_run_lists_post_state_endpoints(tmp_path):
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET",
+                              "endpoint": "/api/pre",
+                              "assert_jsonpath": [{"path": "$.x", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET",
+                               "endpoint": "/api/post",
+                               "assert_jsonpath": [{"path": "$.x", "equals": 1}]},
+            },
+        },
+    })
+    result = _run(tmp_path, "--phase", "1.0", "--mode", "post", "--dry-run")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    # Should list /api/post (post_state endpoint), not /api/pre
+    assert any("/api/post" in p["endpoint"] for p in out["would_check"])
+    assert not any("/api/pre" in p["endpoint"] for p in out["would_check"])
+
+
+def test_default_severity_is_now_block(tmp_path, server):
+    """Codex-HIGH-4: default severity changed from warn to block."""
+    base_url, routes = server
+    routes[("GET", "/api/x")] = {"status": 200, "body": {"count": 99}}  # wrong
+    _phase(tmp_path, {
+        "G-10": {
+            "schema_version": "1.0", "goal": "G-10",
+            "description": "x" * 50,
+            "fixture_intent": {"declared_in": "x", "validates": "x" * 25},
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/x"}],
+            "lifecycle": {
+                "pre_state": {"role": "u", "method": "GET", "endpoint": "/api/x",
+                              "assert_jsonpath": [{"path": "$.count", "equals": 0}]},
+                "action": {"surface": "ui_click",
+                           "expected_network": {"method": "POST",
+                                                  "endpoint": "/api/x",
+                                                  "status_range": [200, 299]}},
+                "post_state": {"role": "u", "method": "GET", "endpoint": "/api/x",
+                               "assert_jsonpath": [{"path": "$.count", "equals": 1}]},
+            },
+        },
+    })
+    creds = json.dumps({"u": {"kind": "api_key", "key": "k"}})
+    # NO --severity flag → should default to block, exit 1
+    result = _run(tmp_path, "--phase", "1.0", "--base-url", base_url,
+                   env_extra={"VG_CREDENTIALS_JSON": creds})
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["verdict"] == "BLOCK"
+
+
 def test_missing_credentials_errors(tmp_path):
     _phase(tmp_path, {
         "G-10": {

--- a/tests/test_recipe_auth.py
+++ b/tests/test_recipe_auth.py
@@ -1,0 +1,278 @@
+"""Tests for scripts/runtime/recipe_auth.py — RFC v9 PR-A2 4 auth handlers."""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+requests = pytest.importorskip("requests")
+
+from runtime.recipe_auth import (  # noqa: E402
+    AuthError,
+    auth_api_key,
+    auth_bearer_jwt,
+    auth_command,
+    auth_cookie_login,
+    authenticate,
+)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    routes: dict = {}
+    log: list = []
+    log_message = lambda *a, **k: None
+
+    def _serve(self, method: str) -> None:
+        body_len = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(body_len) if body_len else b""
+        try:
+            parsed = json.loads(body) if body else None
+        except (json.JSONDecodeError, ValueError):
+            parsed = body
+        self.log.append({"method": method, "path": self.path, "body": parsed})
+        route = self.routes.get((method, self.path))
+        if not route:
+            self.send_response(404)
+            self.end_headers()
+            return
+        cookies = route.get("set_cookies")
+        status = route.get("status", 200)
+        payload = route.get("body", {})
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        if cookies:
+            for name, val in cookies.items():
+                self.send_header("Set-Cookie", f"{name}={val}; Path=/")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+    def do_GET(self): self._serve("GET")
+    def do_POST(self): self._serve("POST")
+
+
+@pytest.fixture
+def server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    routes: dict = {}
+    log: list = []
+
+    class _H(_Handler):
+        pass
+    _H.routes = routes
+    _H.log = log
+    srv = http.server.HTTPServer(("127.0.0.1", port), _H)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}", routes, log
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# ─── api_key ──────────────────────────────────────────────────────────
+
+
+def test_api_key_default_header():
+    ctx = auth_api_key("http://x", {"key": "secret-1"}, sandbox=True)
+    assert ctx.session.headers["Authorization"] == "ApiKey secret-1"
+    assert ctx.session.headers["X-VGFlow-Sandbox"] == "true"
+
+
+def test_api_key_custom_header_and_scheme():
+    ctx = auth_api_key("http://x", {
+        "key": "k",
+        "header_name": "X-Api-Token",
+        "scheme": "",
+    }, sandbox=False)
+    assert ctx.session.headers["X-Api-Token"] == "k"
+    assert "X-VGFlow-Sandbox" not in ctx.session.headers
+
+
+def test_api_key_missing_key_raises():
+    with pytest.raises(AuthError, match="creds.key"):
+        auth_api_key("http://x", {}, sandbox=True)
+
+
+# ─── cookie_login ─────────────────────────────────────────────────────
+
+
+def test_cookie_login_attaches_session_cookie(server):
+    base_url, routes, log = server
+    routes[("POST", "/login")] = {
+        "status": 200,
+        "set_cookies": {"session_id": "sess-123"},
+        "body": {"ok": True},
+    }
+    ctx = auth_cookie_login(
+        base_url,
+        {"endpoint": "/login", "body": {"u": "alice", "p": "pw"}},
+        sandbox=True,
+    )
+    assert ctx.session.cookies.get("session_id") == "sess-123"
+    assert log[0]["body"] == {"u": "alice", "p": "pw"}
+
+
+def test_cookie_login_4xx_raises(server):
+    base_url, routes, _ = server
+    routes[("POST", "/login")] = {"status": 401, "body": {"err": "bad"}}
+    with pytest.raises(AuthError, match="401"):
+        auth_cookie_login(base_url, {"endpoint": "/login", "body": {}}, sandbox=True)
+
+
+def test_cookie_login_no_set_cookie_raises(server):
+    base_url, routes, _ = server
+    routes[("POST", "/login")] = {"status": 200, "body": {"ok": True}}  # no Set-Cookie
+    with pytest.raises(AuthError, match="Set-Cookie"):
+        auth_cookie_login(base_url, {"endpoint": "/login", "body": {}}, sandbox=True)
+
+
+# ─── bearer_jwt ───────────────────────────────────────────────────────
+
+
+def test_bearer_jwt_captures_token(server):
+    base_url, routes, log = server
+    routes[("POST", "/auth/token")] = {
+        "status": 200,
+        "body": {"access_token": "jwt-xyz", "expires_in": 3600},
+    }
+    ctx = auth_bearer_jwt(
+        base_url,
+        {"endpoint": "/auth/token", "body": {"u": "alice"}},
+        sandbox=True,
+    )
+    assert ctx.session.headers["Authorization"] == "Bearer jwt-xyz"
+    assert ctx.refresh_callable is not None
+
+
+def test_bearer_jwt_custom_token_path(server):
+    base_url, routes, _ = server
+    routes[("POST", "/auth/token")] = {
+        "status": 200,
+        "body": {"data": {"token": {"value": "deep-jwt"}}},
+    }
+    ctx = auth_bearer_jwt(
+        base_url,
+        {
+            "endpoint": "/auth/token",
+            "body": {},
+            "token_path": "data.token.value",
+        },
+        sandbox=True,
+    )
+    assert ctx.session.headers["Authorization"] == "Bearer deep-jwt"
+
+
+def test_bearer_jwt_refresh_re_calls_login(server):
+    base_url, routes, log = server
+    routes[("POST", "/auth/token")] = {
+        "status": 200,
+        "body": {"access_token": "jwt-1"},
+    }
+    ctx = auth_bearer_jwt(base_url, {"endpoint": "/auth/token", "body": {}}, sandbox=True)
+    assert ctx.session.headers["Authorization"] == "Bearer jwt-1"
+    # Swap response → refresh should pick up new token
+    routes[("POST", "/auth/token")] = {
+        "status": 200,
+        "body": {"access_token": "jwt-2"},
+    }
+    ctx.refresh_callable()
+    assert ctx.session.headers["Authorization"] == "Bearer jwt-2"
+
+
+def test_bearer_jwt_token_path_not_found_raises(server):
+    base_url, routes, _ = server
+    routes[("POST", "/auth/token")] = {
+        "status": 200,
+        "body": {"foo": "bar"},  # no access_token
+    }
+    with pytest.raises(AuthError, match="token_path"):
+        auth_bearer_jwt(base_url, {"endpoint": "/auth/token", "body": {}}, sandbox=True)
+
+
+def test_bearer_jwt_login_4xx_raises(server):
+    base_url, routes, _ = server
+    routes[("POST", "/auth/token")] = {"status": 403, "body": {}}
+    with pytest.raises(AuthError, match="403"):
+        auth_bearer_jwt(base_url, {"endpoint": "/auth/token", "body": {}}, sandbox=True)
+
+
+# ─── command ──────────────────────────────────────────────────────────
+
+
+def test_command_auth_blocked_outside_sandbox():
+    with pytest.raises(AuthError, match="sandbox-only"):
+        auth_command("http://x", {"command": "echo {}"}, sandbox=False)
+
+
+def test_command_auth_invokes_script_and_sets_headers(tmp_path):
+    """Use a small Python script that emits JSON on stdout."""
+    script = tmp_path / "auth.py"
+    script.write_text(
+        "import json, sys\n"
+        "print(json.dumps({'kind': 'header', "
+        "'headers': {'X-Custom': 'value-from-cmd'}}))\n"
+    )
+    ctx = auth_command(
+        "http://x",
+        {"command": f"{sys.executable} {script}"},
+        sandbox=True,
+    )
+    assert ctx.session.headers["X-Custom"] == "value-from-cmd"
+    assert ctx.session.headers["X-VGFlow-Sandbox"] == "true"
+
+
+def test_command_auth_cookies_kind(tmp_path):
+    script = tmp_path / "auth_cookie.py"
+    script.write_text(
+        "import json\n"
+        "print(json.dumps({'kind': 'cookies', 'cookies': {'sid': 'cmd-sid'}}))\n"
+    )
+    ctx = auth_command(
+        "http://x",
+        {"command": f"{sys.executable} {script}"},
+        sandbox=True,
+    )
+    assert ctx.session.cookies.get("sid") == "cmd-sid"
+
+
+def test_command_auth_non_zero_exit_raises(tmp_path):
+    script = tmp_path / "fail.py"
+    script.write_text("import sys; print('boom', file=sys.stderr); sys.exit(1)\n")
+    with pytest.raises(AuthError, match="exited 1"):
+        auth_command(
+            "http://x", {"command": f"{sys.executable} {script}"}, sandbox=True,
+        )
+
+
+def test_command_auth_invalid_json_raises(tmp_path):
+    script = tmp_path / "bad.py"
+    script.write_text("print('not json')\n")
+    with pytest.raises(AuthError, match="not JSON"):
+        auth_command(
+            "http://x", {"command": f"{sys.executable} {script}"}, sandbox=True,
+        )
+
+
+# ─── dispatcher ───────────────────────────────────────────────────────
+
+
+def test_authenticate_dispatcher_unknown_kind_raises():
+    with pytest.raises(AuthError, match="Unknown auth kind"):
+        authenticate("magic", "http://x", {}, sandbox=True)
+
+
+def test_authenticate_dispatcher_routes_api_key():
+    ctx = authenticate("api_key", "http://x", {"key": "k"}, sandbox=True)
+    assert ctx.session.headers.get("Authorization") == "ApiKey k"

--- a/tests/test_recipe_auth.py
+++ b/tests/test_recipe_auth.py
@@ -268,6 +268,74 @@ def test_command_auth_invalid_json_raises(tmp_path):
 # ─── dispatcher ───────────────────────────────────────────────────────
 
 
+def test_command_auth_scrubs_secret_env_vars(tmp_path, monkeypatch):
+    """Codex-R4-HIGH-5: auth_command must NOT inherit secrets."""
+    monkeypatch.setenv("CLAUDE_API_KEY", "sk-test-secret-DO-NOT-LEAK")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws-secret-DO-NOT-LEAK")
+    script = tmp_path / "leak_check.py"
+    script.write_text(
+        "import json, os\n"
+        "leaked = [k for k in os.environ if 'CLAUDE_API_KEY' in k or 'AWS_' in k]\n"
+        "if leaked:\n"
+        "  raise SystemExit(f'LEAK: {leaked}')\n"
+        "print(json.dumps({'kind': 'header', 'headers': {'X-Test': 'ok'}}))\n",
+        encoding="utf-8",
+    )
+    ctx = auth_command(
+        "http://x", {"command": f"{sys.executable} {script}"}, sandbox=True,
+    )
+    assert ctx.session.headers["X-Test"] == "ok"
+
+
+def test_command_auth_env_passthrough_opt_in(tmp_path, monkeypatch):
+    """Project can opt specific env vars in via creds.env_passthrough."""
+    monkeypatch.setenv("PROJECT_AUTH_BASE", "https://sandbox.x.com")
+    monkeypatch.setenv("CLAUDE_API_KEY", "sk-secret")  # NOT in passthrough
+    script = tmp_path / "check.py"
+    script.write_text(
+        "import json, os\n"
+        "if 'CLAUDE_API_KEY' in os.environ:\n"
+        "  raise SystemExit('LEAK: CLAUDE_API_KEY')\n"
+        "v = os.environ.get('PROJECT_AUTH_BASE', '')\n"
+        "print(json.dumps({'kind': 'header', 'headers': {'X-Auth-Base': v}}))\n",
+        encoding="utf-8",
+    )
+    ctx = auth_command(
+        "http://x",
+        {
+            "command": f"{sys.executable} {script}",
+            "env_passthrough": ["PROJECT_AUTH_BASE"],
+        },
+        sandbox=True,
+    )
+    assert ctx.session.headers["X-Auth-Base"] == "https://sandbox.x.com"
+
+
+def test_command_auth_env_passthrough_string_form(tmp_path, monkeypatch):
+    """env_passthrough as comma-separated string also works."""
+    monkeypatch.setenv("VAR_A", "val-a")
+    monkeypatch.setenv("VAR_B", "val-b")
+    script = tmp_path / "ck.py"
+    script.write_text(
+        "import json, os\n"
+        "print(json.dumps({\n"
+        "  'kind': 'header',\n"
+        "  'headers': {'X-A': os.environ.get('VAR_A', ''), 'X-B': os.environ.get('VAR_B', '')},\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    ctx = auth_command(
+        "http://x",
+        {
+            "command": f"{sys.executable} {script}",
+            "env_passthrough": "VAR_A,VAR_B",
+        },
+        sandbox=True,
+    )
+    assert ctx.session.headers["X-A"] == "val-a"
+    assert ctx.session.headers["X-B"] == "val-b"
+
+
 def test_authenticate_dispatcher_unknown_kind_raises():
     with pytest.raises(AuthError, match="Unknown auth kind"):
         authenticate("magic", "http://x", {}, sandbox=True)

--- a/tests/test_recipe_capture.py
+++ b/tests/test_recipe_capture.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/runtime/recipe_capture.py — RFC v9 PR-A1 JSONPath capture."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.recipe_capture import capture_paths, CaptureError  # noqa: E402
+
+
+PAYLOAD = {
+    "data": {
+        "id": "pending-7e9",
+        "items": [
+            {"id": "i1", "name": "alpha"},
+            {"id": "i2", "name": "beta"},
+            {"id": "i3", "name": "gamma"},
+        ],
+    },
+    "meta": {"count": 3},
+    "token": "tok-xyz",
+}
+
+
+def test_scalar_capture_returns_value():
+    out = capture_paths(PAYLOAD, {"pending_id": {"path": "$.data.id"}})
+    assert out == {"pending_id": "pending-7e9"}
+
+
+def test_scalar_capture_missing_default_fails():
+    with pytest.raises(CaptureError, match="returned no matches"):
+        capture_paths(PAYLOAD, {"absent": {"path": "$.does.not.exist"}})
+
+
+def test_scalar_capture_on_empty_skip():
+    out = capture_paths(PAYLOAD, {
+        "absent": {"path": "$.does.not.exist", "on_empty": "skip"}
+    })
+    assert out == {}
+
+
+def test_scalar_capture_on_empty_null():
+    out = capture_paths(PAYLOAD, {
+        "absent": {"path": "$.does.not.exist", "on_empty": "null"}
+    })
+    assert out == {"absent": None}
+
+
+def test_array_capture_returns_list():
+    out = capture_paths(PAYLOAD, {
+        "ids": {"path": "$.data.items[*].id", "cardinality": "array"}
+    })
+    assert out == {"ids": ["i1", "i2", "i3"]}
+
+
+def test_array_capture_empty_with_skip():
+    out = capture_paths(PAYLOAD, {
+        "absent": {
+            "path": "$.does.not.exist",
+            "cardinality": "array",
+            "on_empty": "skip",
+        }
+    })
+    assert out == {}
+
+
+def test_optional_scalar_present():
+    out = capture_paths(PAYLOAD, {
+        "tok": {"path": "$.token", "cardinality": "optional_scalar"}
+    })
+    assert out == {"tok": "tok-xyz"}
+
+
+def test_optional_scalar_missing_with_null():
+    out = capture_paths(PAYLOAD, {
+        "tok": {
+            "path": "$.no_token",
+            "cardinality": "optional_scalar",
+            "on_empty": "null",
+        }
+    })
+    assert out == {"tok": None}
+
+
+def test_scalar_with_multiple_matches_raises():
+    with pytest.raises(CaptureError, match="expected scalar"):
+        capture_paths(PAYLOAD, {
+            "all_ids": {"path": "$.data.items[*].id"}  # 3 matches
+        })
+
+
+def test_optional_scalar_with_multiple_matches_raises():
+    with pytest.raises(CaptureError, match="expected optional_scalar"):
+        capture_paths(PAYLOAD, {
+            "all_ids": {
+                "path": "$.data.items[*].id",
+                "cardinality": "optional_scalar",
+            }
+        })
+
+
+def test_indexed_capture_picks_specific():
+    out = capture_paths(PAYLOAD, {
+        "first_id": {"path": "$.data.items[0].id"}
+    })
+    assert out == {"first_id": "i1"}
+
+
+def test_unknown_cardinality_raises():
+    with pytest.raises(CaptureError, match="unknown cardinality"):
+        capture_paths(PAYLOAD, {
+            "x": {"path": "$.token", "cardinality": "weird"}
+        })
+
+
+def test_unknown_on_empty_raises():
+    with pytest.raises(CaptureError, match="unknown on_empty"):
+        capture_paths(PAYLOAD, {
+            "x": {"path": "$.no_path", "on_empty": "noisily"}
+        })
+
+
+def test_missing_path_raises():
+    with pytest.raises(CaptureError, match="missing required 'path'"):
+        capture_paths(PAYLOAD, {"x": {}})
+
+
+def test_multi_capture_independence():
+    """Failure of one capture must not contaminate others."""
+    spec = {
+        "id": {"path": "$.data.id"},
+        "missing": {"path": "$.no", "on_empty": "skip"},
+        "count": {"path": "$.meta.count"},
+    }
+    out = capture_paths(PAYLOAD, spec)
+    assert out == {"id": "pending-7e9", "count": 3}

--- a/tests/test_recipe_executor.py
+++ b/tests/test_recipe_executor.py
@@ -420,6 +420,55 @@ def test_delete_carries_idempotency_key(http_server):
 # ─── Codex-A-MEDIUM: AuthDegradedError typed exception ──────────────
 
 
+def test_loop_validate_after_sees_per_iteration_capture(http_server):
+    """Codex-R5-HIGH-2: with from_each: true, the loop iteration's
+    captured value used to skip self.store. validate_after couldn't
+    interpolate it. Now per-iteration value is exposed in store."""
+    base_url, routes, log = http_server
+    routes[("POST", "/api/x")] = {"status": 200, "body": {"id": "x-1"}}
+    # validate_after path matches whichever id was just captured
+    routes[("GET", "/api/x/x-1")] = {"status": 200, "body": {"verified": True}}
+    routes[("GET", "/api/x/x-2")] = {"status": 200, "body": {"verified": True}}
+
+    routes[("POST", "/api/iter1")] = {"status": 200, "body": {"id": "x-1"}}
+    routes[("POST", "/api/iter2")] = {"status": 200, "body": {"id": "x-2"}}
+
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0", "goal": "G-X",
+        "steps": [{
+            "id": "loop", "kind": "loop",
+            "over": ["iter1", "iter2"],
+            "each": {
+                "id": "create", "kind": "api_call", "role": "u",
+                "method": "POST", "endpoint": "/api/${_value}",
+                "idempotency_key": "k-${_index}",
+                "body": {"amount": 0.01},
+                "capture": {
+                    "current_id": {"path": "$.id", "from_each": True},
+                },
+                "validate_after": {
+                    "kind": "api_call", "method": "GET",
+                    "endpoint": "/api/x/${current_id}",
+                    "expect_status": 200,
+                    "assert_jsonpath": [
+                        {"path": "$.verified", "equals": True},
+                    ],
+                },
+            },
+        }],
+    })
+    # After loop: current_id is the accumulated array
+    assert runner.store["current_id"] == ["x-1", "x-2"]
+    # Both validate_after GETs hit the right per-iteration URLs
+    paths = [e["path"] for e in log if e["method"] == "GET"]
+    assert "/api/x/x-1" in paths
+    assert "/api/x/x-2" in paths
+
+
 def test_auth_degraded_when_refresh_then_401(http_server):
     """Bearer JWT: refresh succeeds but second response is also 401 →
     refresh-token expired, surface as AuthDegradedError so caller can

--- a/tests/test_recipe_executor.py
+++ b/tests/test_recipe_executor.py
@@ -22,7 +22,9 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 # Skip everything if requests not available
 requests = pytest.importorskip("requests")
 
-from runtime.recipe_executor import RecipeRunner, RecipeExecutionError  # noqa: E402
+from runtime.recipe_executor import (  # noqa: E402
+    AuthDegradedError, RecipeRunner, RecipeExecutionError,
+)
 
 
 class RecordingHandler(http.server.BaseHTTPRequestHandler):
@@ -330,4 +332,114 @@ def test_sandbox_safety_blocks_money_without_sentinel(http_server):
                 "idempotency_key": "k1",
                 "body": {"amount": 1000, "merchant": "real-merchant"},
             }],
+        })
+
+
+# ─── Codex-HIGH-7: URL allowlist + response echo ─────────────────────
+
+
+def test_runner_rejects_url_outside_allowlist(http_server):
+    base_url, _, _ = http_server
+    with pytest.raises(RecipeExecutionError, match="NOT in sandbox_url_allowlist"):
+        RecipeRunner(
+            base_url=base_url, env="sandbox",
+            credentials_map={"u": {"kind": "api_key", "key": "k"}},
+            sandbox_url_allowlist=["sandbox.example.com"],  # base_url is 127.0.0.1
+        )
+
+
+def test_runner_accepts_url_in_allowlist(http_server):
+    base_url, _, _ = http_server
+    # base_url is http://127.0.0.1:PORT — allowlist permits 127.0.0.1
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+        sandbox_url_allowlist=["127.0.0.1"],
+    )
+    assert runner.base_url == base_url
+
+
+def test_runner_response_echo_check_blocks_when_header_missing(http_server):
+    base_url, routes, _ = http_server
+    routes[("GET", "/api/x")] = {"status": 200, "body": {"ok": True}}
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+        response_echo_check=True,
+    )
+    with pytest.raises(RecipeExecutionError, match="echo handshake"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/api/x"}],
+        })
+
+
+# ─── Codex-B-MEDIUM: PATCH/DELETE idempotency-key ────────────────────
+
+
+def test_patch_carries_idempotency_key(http_server):
+    base_url, routes, log = http_server
+    routes[("PATCH", "/api/x")] = {"status": 200, "body": {}}
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0", "goal": "G-X",
+        "steps": [{
+            "id": "patch", "kind": "api_call", "role": "u",
+            "method": "PATCH", "endpoint": "/api/x",
+            "idempotency_key": "patch-k1",
+            "body": {"x": 1},
+        }],
+    })
+    headers_ci = {k.lower(): v for k, v in log[0]["headers"].items()}
+    assert headers_ci.get("idempotency-key") == "patch-k1"
+
+
+def test_delete_carries_idempotency_key(http_server):
+    base_url, routes, log = http_server
+    routes[("DELETE", "/api/x/1")] = {"status": 204, "body": {}}
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0", "goal": "G-X",
+        "steps": [{
+            "id": "del", "kind": "api_call", "role": "u",
+            "method": "DELETE", "endpoint": "/api/x/1",
+            "idempotency_key": "del-k1",
+        }],
+    })
+    headers_ci = {k.lower(): v for k, v in log[0]["headers"].items()}
+    assert headers_ci.get("idempotency-key") == "del-k1"
+
+
+# ─── Codex-A-MEDIUM: AuthDegradedError typed exception ──────────────
+
+
+def test_auth_degraded_when_refresh_then_401(http_server):
+    """Bearer JWT: refresh succeeds but second response is also 401 →
+    refresh-token expired, surface as AuthDegradedError so caller can
+    re-prompt for credentials."""
+    base_url, routes, _ = http_server
+    routes[("POST", "/auth/token")] = {
+        "status": 200, "body": {"access_token": "jwt-1"},
+    }
+    routes[("GET", "/api/me")] = {"status": 401, "body": {}}
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {
+            "kind": "bearer_jwt",
+            "endpoint": "/auth/token",
+            "body": {"u": "alice"},
+        }},
+    )
+    with pytest.raises(AuthDegradedError, match="refresh succeeded"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/api/me"}],
         })

--- a/tests/test_recipe_executor.py
+++ b/tests/test_recipe_executor.py
@@ -1,0 +1,333 @@
+"""Tests for scripts/runtime/recipe_executor.py — RFC v9 PR-A2.
+
+Uses a stdlib HTTP server fixture (no external mock dep). Each test spins
+up an http.server.HTTPServer in a thread, runs the recipe against it, and
+shuts down. Server records request log for assertions.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# Skip everything if requests not available
+requests = pytest.importorskip("requests")
+
+from runtime.recipe_executor import RecipeRunner, RecipeExecutionError  # noqa: E402
+
+
+class RecordingHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler that records requests + serves canned responses."""
+
+    routes: dict[tuple[str, str], dict] = {}
+    log: list[dict] = []
+
+    def log_message(self, *_args, **_kwargs):  # silence stderr noise
+        return
+
+    def _record(self, method: str, body: bytes | None) -> None:
+        try:
+            parsed_body = json.loads(body) if body else None
+        except (json.JSONDecodeError, ValueError):
+            parsed_body = body.decode("utf-8", errors="replace") if body else None
+        self.log.append({
+            "method": method,
+            "path": self.path,
+            "headers": dict(self.headers),
+            "body": parsed_body,
+        })
+
+    def _serve(self, method: str) -> None:
+        body_len = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(body_len) if body_len else b""
+        self._record(method, body)
+        route = self.routes.get((method, self.path)) or self.routes.get((method, "*"))
+        if not route:
+            self.send_response(404)
+            self.end_headers()
+            return
+        status = route.get("status", 200)
+        payload = route.get("body", {})
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode())
+
+    def do_GET(self): self._serve("GET")
+    def do_POST(self): self._serve("POST")
+    def do_PUT(self): self._serve("PUT")
+    def do_PATCH(self): self._serve("PATCH")
+    def do_DELETE(self): self._serve("DELETE")
+
+
+@pytest.fixture
+def http_server():
+    """Spin up a localhost HTTP server with shared route map. Yield (base_url, routes, log)."""
+    # Pick a free port
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    routes: dict = {}
+    log: list = []
+
+    class _H(RecordingHandler):
+        pass
+    _H.routes = routes
+    _H.log = log
+
+    server = http.server.HTTPServer(("127.0.0.1", port), _H)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}", routes, log
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_simple_get_step(http_server):
+    base_url, routes, log = http_server
+    routes[("GET", "/api/me")] = {"status": 200, "body": {"name": "alice"}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "test-key"}},
+    )
+    runner.run({
+        "schema_version": "1.0",
+        "goal": "G-X",
+        "steps": [
+            {"id": "fetch", "kind": "api_call", "role": "u",
+             "method": "GET", "endpoint": "/api/me"},
+        ],
+    })
+    assert log[0]["method"] == "GET"
+    headers_ci = {k.lower(): v for k, v in log[0]["headers"].items()}
+    assert headers_ci.get("authorization") == "ApiKey test-key"
+    assert headers_ci.get("x-vgflow-sandbox") == "true"
+
+
+def test_post_with_idempotency_key(http_server):
+    base_url, routes, log = http_server
+    routes[("POST", "/api/topup")] = {"status": 201, "body": {"id": "p7"}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "test-key"}},
+    )
+    runner.run({
+        "schema_version": "1.0",
+        "goal": "G-X",
+        "steps": [{
+            "id": "create",
+            "kind": "api_call",
+            "role": "u",
+            "method": "POST",
+            "endpoint": "/api/topup",
+            "idempotency_key": "k-001",
+            "body": {"amount": 0.01},
+        }],
+    })
+    headers_ci = {k.lower(): v for k, v in log[0]["headers"].items()}
+    assert headers_ci.get("idempotency-key") == "k-001"
+
+
+def test_capture_into_store_and_interpolation(http_server):
+    base_url, routes, log = http_server
+    routes[("POST", "/api/topup")] = {"status": 201, "body": {"data": {"id": "p99"}}}
+    routes[("GET", "*")] = {"status": 200, "body": {"ok": True}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0",
+        "goal": "G-X",
+        "steps": [
+            {"id": "create", "kind": "api_call", "role": "u",
+             "method": "POST", "endpoint": "/api/topup",
+             "idempotency_key": "k-001",
+             "body": {"amount": 0.01},
+             "capture": {"pid": {"path": "$.data.id"}}},
+            {"id": "fetch", "kind": "api_call", "role": "u",
+             "method": "GET", "endpoint": "/api/topup/${pid}"},
+        ],
+    })
+    assert runner.store["pid"] == "p99"
+    # 2nd request hit /api/topup/p99
+    paths = [e["path"] for e in log]
+    assert "/api/topup/p99" in paths
+
+
+def test_4xx_response_raises(http_server):
+    base_url, routes, _ = http_server
+    routes[("GET", "/api/x")] = {"status": 404, "body": {"err": "nope"}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    with pytest.raises(RecipeExecutionError, match="404"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/api/x"}],
+        })
+
+
+def test_expect_status_strict(http_server):
+    base_url, routes, _ = http_server
+    routes[("GET", "/api/x")] = {"status": 200, "body": {}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    with pytest.raises(RecipeExecutionError, match="expected 201"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{"id": "x", "kind": "api_call", "role": "u",
+                       "method": "GET", "endpoint": "/api/x",
+                       "expect_status": 201}],
+        })
+
+
+def test_validate_after_runs_get(http_server):
+    base_url, routes, log = http_server
+    routes[("POST", "/api/topup")] = {"status": 201, "body": {"id": "p1"}}
+    routes[("GET", "/api/topup/p1")] = {
+        "status": 200, "body": {"data": {"status": "pending"}}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0", "goal": "G-X",
+        "steps": [{
+            "id": "create", "kind": "api_call", "role": "u",
+            "method": "POST", "endpoint": "/api/topup",
+            "idempotency_key": "k1", "body": {"amount": 0.01},
+            "capture": {"pid": {"path": "$.id"}},
+            "validate_after": {
+                "kind": "api_call", "method": "GET",
+                "endpoint": "/api/topup/${pid}",
+                "expect_status": 200,
+                "assert_jsonpath": [
+                    {"path": "$.data.status", "equals": "pending"},
+                ],
+            },
+        }],
+    })
+    paths = [e["path"] for e in log]
+    assert "/api/topup/p1" in paths
+
+
+def test_validate_after_assertion_fails(http_server):
+    base_url, routes, _ = http_server
+    routes[("POST", "/api/topup")] = {"status": 201, "body": {"id": "p1"}}
+    routes[("GET", "/api/topup/p1")] = {
+        "status": 200, "body": {"data": {"status": "approved"}}}  # WRONG status
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    with pytest.raises(RecipeExecutionError, match="status"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{
+                "id": "create", "kind": "api_call", "role": "u",
+                "method": "POST", "endpoint": "/api/topup",
+                "idempotency_key": "k1", "body": {"amount": 0.01},
+                "capture": {"pid": {"path": "$.id"}},
+                "validate_after": {
+                    "kind": "api_call", "method": "GET",
+                    "endpoint": "/api/topup/${pid}",
+                    "assert_jsonpath": [
+                        {"path": "$.data.status", "equals": "pending"},
+                    ],
+                },
+            }],
+        })
+
+
+def test_loop_step_iterates(http_server):
+    base_url, routes, log = http_server
+    routes[("POST", "*")] = {"status": 200, "body": {"id": "x"}}
+
+    runner = RecipeRunner(
+        base_url=base_url,
+        env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    runner.run({
+        "schema_version": "1.0", "goal": "G-X",
+        "steps": [{
+            "id": "loop", "kind": "loop",
+            "over": 3,
+            "each": {
+                "id": "create", "kind": "api_call", "role": "u",
+                "method": "POST", "endpoint": "/api/x",
+                "idempotency_key": "iter-${_index}",
+                "body": {"amount": 0.01},
+            },
+        }],
+    })
+    posts = [e for e in log if e["method"] == "POST"]
+    assert len(posts) == 3
+    idem_keys = {
+        next((v for k, v in e["headers"].items() if k.lower() == "idempotency-key"), None)
+        for e in posts
+    }
+    assert idem_keys == {"iter-0", "iter-1", "iter-2"}
+
+
+def test_unknown_role_raises(http_server):
+    base_url, _, _ = http_server
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox", credentials_map={},
+    )
+    with pytest.raises(RecipeExecutionError, match="unknown_role"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{"id": "x", "kind": "api_call", "role": "unknown_role",
+                       "method": "GET", "endpoint": "/api/x"}],
+        })
+
+
+def test_sandbox_safety_blocks_money_without_sentinel(http_server):
+    base_url, _, _ = http_server
+    runner = RecipeRunner(
+        base_url=base_url, env="sandbox",
+        credentials_map={"u": {"kind": "api_key", "key": "k"}},
+    )
+    with pytest.raises(RecipeExecutionError, match="sentinel"):
+        runner.run({
+            "schema_version": "1.0", "goal": "G-X",
+            "steps": [{
+                "id": "topup", "kind": "api_call", "role": "u",
+                "method": "POST", "endpoint": "/api/topup",
+                "idempotency_key": "k1",
+                "body": {"amount": 1000, "merchant": "real-merchant"},
+            }],
+        })

--- a/tests/test_recipe_interpolate.py
+++ b/tests/test_recipe_interpolate.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/runtime/recipe_interpolate.py — RFC v9 PR-A1 ${var} interpolation."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.recipe_interpolate import interpolate, InterpolationError  # noqa: E402
+
+
+STORE = {
+    "pending_id": "pending-7e9",
+    "amount": 100,
+    "is_active": True,
+    "tags": ["alpha", "beta"],
+    "created": {"user": {"id": "user-42"}},
+}
+
+
+def test_whole_string_match_preserves_type():
+    assert interpolate("${amount}", STORE) == 100
+    assert interpolate("${is_active}", STORE) is True
+    assert interpolate("${tags}", STORE) == ["alpha", "beta"]
+
+
+def test_substring_match_stringifies():
+    assert interpolate("ID: ${pending_id}", STORE) == "ID: pending-7e9"
+    assert interpolate("amount=${amount}", STORE) == "amount=100"
+
+
+def test_dotted_path_resolves():
+    assert interpolate("${created.user.id}", STORE) == "user-42"
+
+
+def test_missing_top_level_variable_raises():
+    with pytest.raises(InterpolationError, match="absent"):
+        interpolate("${absent}", STORE)
+
+
+def test_missing_dotted_segment_raises():
+    with pytest.raises(InterpolationError, match="missing"):
+        interpolate("${created.user.absent}", STORE)
+
+
+def test_dotted_into_non_dict_raises():
+    with pytest.raises(InterpolationError, match="non-dict"):
+        interpolate("${pending_id.foo}", STORE)
+
+
+def test_dict_recursive_interpolation():
+    template = {
+        "id": "${pending_id}",
+        "amount": "${amount}",
+        "label": "User ${created.user.id} pending",
+    }
+    out = interpolate(template, STORE)
+    assert out == {
+        "id": "pending-7e9",
+        "amount": 100,
+        "label": "User user-42 pending",
+    }
+
+
+def test_list_recursive_interpolation():
+    template = ["${pending_id}", "${amount}", "static"]
+    out = interpolate(template, STORE)
+    assert out == ["pending-7e9", 100, "static"]
+
+
+def test_non_string_scalars_passthrough():
+    assert interpolate(42, STORE) == 42
+    assert interpolate(None, STORE) is None
+    assert interpolate(True, STORE) is True
+
+
+def test_no_variables_returns_unchanged():
+    assert interpolate("plain string", STORE) == "plain string"
+    assert interpolate({"k": "v"}, STORE) == {"k": "v"}
+
+
+def test_multiple_substitutions_in_one_string():
+    assert interpolate(
+        "${pending_id}/${amount}/${is_active}", STORE,
+    ) == "pending-7e9/100/True"
+
+
+def test_nested_dict_in_list():
+    template = [{"id": "${pending_id}"}, {"id": "${created.user.id}"}]
+    out = interpolate(template, STORE)
+    assert out == [{"id": "pending-7e9"}, {"id": "user-42"}]

--- a/tests/test_recipe_loader.py
+++ b/tests/test_recipe_loader.py
@@ -132,3 +132,134 @@ def test_yaml_parse_error_wrapped_as_validation_error(tmp_path):
 def test_file_not_found_propagates(tmp_path):
     with pytest.raises(FileNotFoundError):
         load_recipe(tmp_path / "missing.yaml")
+
+
+# ─── Codex-R4-HIGH-6: JSONPath pre-validation at load time ────────
+
+
+def test_invalid_capture_jsonpath_rejected_at_load(tmp_path):
+    """Codex-R4-HIGH-6: invalid JSONPath used to blow up AT runtime
+    (after the mutation already ran). Pre-validate at load."""
+    pytest.importorskip("jsonpath_ng")
+    content = """
+schema_version: "1.0"
+goal: G-01
+description: Capture path with bad filter expression for pre-validation test
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-01
+  validates: pre-validation regression test goal
+steps:
+  - id: x
+    kind: api_call
+    role: u
+    method: POST
+    endpoint: /api/x
+    idempotency_key: k1
+    body:
+      a: 1
+    capture:
+      bad:
+        path: "$..[?(@invalid_filter syntax!!)]"
+""".lstrip()
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError, match="JSONPath"):
+        load_recipe(p)
+
+
+def test_invalid_validate_after_jsonpath_rejected(tmp_path):
+    pytest.importorskip("jsonpath_ng")
+    content = """
+schema_version: "1.0"
+goal: G-01
+description: validate_after with bad path for regression test
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-01
+  validates: pre-validation regression on validate_after
+steps:
+  - id: x
+    kind: api_call
+    role: u
+    method: POST
+    endpoint: /api/x
+    idempotency_key: k1
+    body: {a: 1}
+    validate_after:
+      kind: api_call
+      method: GET
+      endpoint: /api/x
+      assert_jsonpath:
+        - path: "$.[?($invalid)]"
+""".lstrip()
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError, match="JSONPath"):
+        load_recipe(p)
+
+
+def test_invalid_lifecycle_jsonpath_rejected(tmp_path):
+    pytest.importorskip("jsonpath_ng")
+    content = """
+schema_version: "1.0"
+goal: G-01
+description: lifecycle with bad path for regression test
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-01
+  validates: pre-validation regression on lifecycle
+steps:
+  - id: x
+    kind: api_call
+    role: u
+    method: GET
+    endpoint: /api/x
+lifecycle:
+  pre_state:
+    role: u
+    method: GET
+    endpoint: /api/state
+    assert_jsonpath:
+      - path: "$..[?(this is broken)]"
+  action:
+    surface: ui_click
+    expected_network:
+      method: POST
+      endpoint: /api/x
+      status_range: [200, 299]
+  post_state:
+    role: u
+    method: GET
+    endpoint: /api/state
+    assert_jsonpath:
+      - path: "$.count"
+        equals: 1
+""".lstrip()
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError, match="JSONPath"):
+        load_recipe(p)
+
+
+def test_valid_jsonpath_with_filter_passes(tmp_path):
+    """Valid filter expressions should pass pre-validation."""
+    pytest.importorskip("jsonpath_ng")
+    content = """
+schema_version: "1.0"
+goal: G-01
+description: Recipe with valid jsonpath filter expression for runtime tests
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-01
+  validates: jsonpath filter syntax acceptance regression test
+steps:
+  - id: x
+    kind: api_call
+    role: u
+    method: POST
+    endpoint: /api/x
+    idempotency_key: k1
+    body:
+      a: 1
+    capture:
+      first_active:
+        path: "$.items[?(@.status == 'active')].id"
+        cardinality: optional_scalar
+""".lstrip()
+    p = _write(tmp_path, content)
+    recipe = load_recipe(p)
+    assert recipe["goal"] == "G-01"

--- a/tests/test_recipe_loader.py
+++ b/tests/test_recipe_loader.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/runtime/recipe_loader.py — RFC v9 PR-A1 recipe parser."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.recipe_loader import load_recipe, ValidationError  # noqa: E402
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "G-01.yaml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _valid_minimal() -> str:
+    return """
+schema_version: "1.0"
+goal: G-01
+description: Create tier2 topup pending entity for /api/topup approval flow tests
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-01
+  validates: approval mutation lifecycle end-to-end smoke test
+steps:
+  - id: create_topup
+    kind: api_call
+    role: user_alice
+    method: POST
+    endpoint: /api/topup
+    idempotency_key: k-001
+    body:
+      amount: 0.01
+""".lstrip()
+
+
+def test_loads_minimal_valid_recipe(tmp_path):
+    p = _write(tmp_path, _valid_minimal())
+    recipe = load_recipe(p)
+    assert recipe["schema_version"] == "1.0"
+    assert recipe["goal"] == "G-01"
+    assert len(recipe["steps"]) == 1
+
+
+def test_missing_schema_version_rejected(tmp_path):
+    p = _write(tmp_path, _valid_minimal().replace('schema_version: "1.0"\n', ""))
+    with pytest.raises(ValidationError, match="schema_version"):
+        load_recipe(p)
+
+
+def test_major_version_2_rejected(tmp_path):
+    content = _valid_minimal().replace('schema_version: "1.0"', 'schema_version: "2.0"')
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError, match="2.0"):
+        load_recipe(p)
+
+
+def test_minor_version_1_5_accepted(tmp_path):
+    content = _valid_minimal().replace('schema_version: "1.0"', 'schema_version: "1.5"')
+    p = _write(tmp_path, content)
+    # NB: jsonschema (if installed) validates schema_version: const "1.0";
+    # the const constraint will reject 1.5. The version-line check passes
+    # but schema validation may not. Skip jsonschema validation by deleting
+    # the const after load — actually for this test, just verify the
+    # version gate path doesn't reject 1.x.
+    try:
+        load_recipe(p)
+    except ValidationError as e:
+        # Accept if jsonschema raises on const "1.0"; reject if version gate did.
+        assert "schema_version" in str(e) and "1.5" not in str(e), e
+
+
+def test_missing_required_field_rejected(tmp_path):
+    """jsonschema must catch goal missing — only runs when jsonschema installed."""
+    pytest.importorskip("jsonschema")
+    content = _valid_minimal().replace("goal: G-01\n", "")
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError):
+        load_recipe(p)
+
+
+def test_short_description_rejected(tmp_path):
+    pytest.importorskip("jsonschema")
+    content = _valid_minimal().replace(
+        "description: Create tier2 topup pending entity for /api/topup approval flow tests",
+        "description: TBD",
+    )
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError, match="description"):
+        load_recipe(p)
+
+
+def test_post_without_idempotency_rejected(tmp_path):
+    pytest.importorskip("jsonschema")
+    content = _valid_minimal().replace("    idempotency_key: k-001\n", "")
+    p = _write(tmp_path, content)
+    with pytest.raises(ValidationError):
+        load_recipe(p)
+
+
+def test_get_step_does_not_need_idempotency(tmp_path):
+    pytest.importorskip("jsonschema")
+    content = """
+schema_version: "1.0"
+goal: G-02
+description: Read merchant detail to confirm provisioning succeeded
+fixture_intent:
+  declared_in: TEST-GOALS.md#G-02
+  validates: merchant detail GET-only smoke
+steps:
+  - id: fetch
+    kind: api_call
+    role: user_alice
+    method: GET
+    endpoint: /api/merchant/123
+""".lstrip()
+    p = _write(tmp_path, content)
+    recipe = load_recipe(p)
+    assert recipe["goal"] == "G-02"
+
+
+def test_yaml_parse_error_wrapped_as_validation_error(tmp_path):
+    p = _write(tmp_path, ":\n  : - [unclosed\n")
+    with pytest.raises(ValidationError, match="YAML"):
+        load_recipe(p)
+
+
+def test_file_not_found_propagates(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_recipe(tmp_path / "missing.yaml")

--- a/tests/test_recipe_safety.py
+++ b/tests/test_recipe_safety.py
@@ -1,0 +1,142 @@
+"""Tests for scripts/runtime/recipe_safety.py — RFC v9 D9 sandbox safety gate."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.recipe_safety import (  # noqa: E402
+    assert_step_safe,
+    is_sentinel_value,
+    SandboxSafetyError,
+)
+
+
+def test_sentinel_email_recognized():
+    assert is_sentinel_value("alice@fixture.vgflow.test")
+    assert is_sentinel_value("VG_FIXTURE_TENANT_ID")
+    assert not is_sentinel_value("alice@example.com")
+
+
+def test_sentinel_amount_under_threshold():
+    assert is_sentinel_value(0.01)
+    assert is_sentinel_value(0)
+    assert not is_sentinel_value(1.0)
+    assert not is_sentinel_value(1000)
+
+
+def test_risky_side_effect_blocked_outside_sandbox():
+    step = {
+        "id": "send_email",
+        "side_effect_risk": "external_call",
+        "method": "POST",
+        "endpoint": "/api/send",
+    }
+    with pytest.raises(SandboxSafetyError, match="env='main'"):
+        assert_step_safe(step, env="main")
+
+
+def test_risky_side_effect_allowed_in_sandbox():
+    step = {
+        "id": "send_email",
+        "side_effect_risk": "external_call",
+        "method": "POST",
+        "endpoint": "/api/send",
+        "body": {"to": "user@fixture.vgflow.test"},
+    }
+    # Should not raise
+    assert_step_safe(step, env="sandbox")
+
+
+def test_money_value_in_sandbox_with_sentinel_passes():
+    step = {
+        "id": "topup",
+        "method": "POST",
+        "endpoint": "/api/topup",
+        "body": {"amount": 1000, "merchant": "VG_FIXTURE_M1"},
+    }
+    assert_step_safe(step, env="sandbox")  # sentinel marker present
+
+
+def test_money_value_in_sandbox_without_sentinel_fails():
+    step = {
+        "id": "topup",
+        "method": "POST",
+        "endpoint": "/api/topup",
+        "body": {"amount": 1000, "merchant": "real-merchant-xyz"},
+    }
+    with pytest.raises(SandboxSafetyError, match="sentinel marker"):
+        assert_step_safe(step, env="sandbox")
+
+
+def test_money_value_under_threshold_passes_without_sentinel():
+    step = {
+        "id": "topup",
+        "method": "POST",
+        "endpoint": "/api/topup",
+        "body": {"amount": 0.01, "merchant": "any"},
+    }
+    assert_step_safe(step, env="sandbox")
+
+
+def test_no_money_field_passes():
+    step = {
+        "id": "fetch",
+        "method": "GET",
+        "endpoint": "/api/me",
+    }
+    assert_step_safe(step, env="sandbox")
+    assert_step_safe(step, env="main")
+
+
+def test_volume_change_blocked_outside_sandbox():
+    step = {
+        "id": "bulk",
+        "side_effect_risk": "volume_change",
+        "method": "DELETE",
+        "endpoint": "/api/users",
+    }
+    with pytest.raises(SandboxSafetyError, match="volume_change"):
+        assert_step_safe(step, env="staging")
+
+
+def test_money_like_blocked_outside_sandbox():
+    step = {
+        "id": "withdraw",
+        "side_effect_risk": "money_like",
+        "method": "POST",
+        "endpoint": "/api/withdraw",
+    }
+    with pytest.raises(SandboxSafetyError, match="money_like"):
+        assert_step_safe(step, env="prod")
+
+
+def test_email_sentinel_in_nested_body_passes():
+    step = {
+        "id": "create_user",
+        "method": "POST",
+        "endpoint": "/api/users",
+        "body": {
+            "user": {
+                "email": "tester@fixture.vgflow.test",
+                "balance": 100,  # money-like
+            },
+        },
+    }
+    assert_step_safe(step, env="sandbox")
+
+
+def test_custom_money_keys_respected():
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {"limit": 1000, "name": "real-name"},
+    }
+    # `limit` is the money key; no sentinel → fail
+    with pytest.raises(SandboxSafetyError):
+        assert_step_safe(step, env="sandbox", money_keys=("limit",))

--- a/tests/test_recipe_safety.py
+++ b/tests/test_recipe_safety.py
@@ -140,3 +140,160 @@ def test_custom_money_keys_respected():
     # `limit` is the money key; no sentinel → fail
     with pytest.raises(SandboxSafetyError):
         assert_step_safe(step, env="sandbox", money_keys=("limit",))
+
+
+# ─── Codex-HIGH-7: identity-field sentinel requirement ─────────────
+
+
+def test_sentinel_anywhere_alone_now_fails_default():
+    """RFC v9 D9 v2: sentinel must be on identity-bearing field, not just
+    anywhere. This was the Codex-HIGH-7 finding — `note: 'VG_FIXTURE_X1'`
+    used to satisfy the gate without proving the mutation targeted a
+    fixture row."""
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "topup",
+        "method": "POST",
+        "endpoint": "/api/topup",
+        "body": {
+            "amount": 1000,
+            "merchant_id": "real-merchant-xyz",  # NOT sentinel
+            "note": "VG_FIXTURE_FROM_SOMEWHERE",  # sentinel on FREE-TEXT field
+        },
+    }
+    # Default require_identity_sentinel=True → fail (sentinel not on identity)
+    with pytest.raises(SandboxSafetyError, match="identity-bearing field"):
+        assert_step_safe(step, env="sandbox")
+
+
+def test_sentinel_on_identity_field_passes():
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "topup",
+        "method": "POST",
+        "endpoint": "/api/topup",
+        "body": {"amount": 1000, "merchant_id": "VG_FIXTURE_M1"},
+    }
+    assert_step_safe(step, env="sandbox")  # sentinel on merchant_id
+
+
+def test_sentinel_email_on_email_field_passes():
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {
+            "amount": 1000,
+            "email": "alice@fixture.vgflow.test",
+        },
+    }
+    assert_step_safe(step, env="sandbox")
+
+
+def test_legacy_anywhere_mode_opt_in():
+    """Caller can opt back into D9 v1 'sentinel anywhere' for migration."""
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {"amount": 1000, "note": "VG_FIXTURE_NOTE"},
+    }
+    # require_identity_sentinel=False reverts to legacy "anywhere works"
+    assert_step_safe(step, env="sandbox", require_identity_sentinel=False)
+
+
+def test_custom_identity_fields_respected():
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {"amount": 1000, "vendor_ref": "VG_FIXTURE_V1"},
+    }
+    assert_step_safe(
+        step, env="sandbox",
+        identity_fields=("vendor_ref",),
+    )
+
+
+# ─── Codex-HIGH-7: URL allowlist ─────────────────────────────────────
+
+
+def test_url_allowlist_exact_host_passes():
+    from runtime.recipe_safety import assert_url_in_allowlist
+    assert_url_in_allowlist(
+        "https://sandbox.example.com/api",
+        allowlist=["sandbox.example.com"],
+    )
+
+
+def test_url_allowlist_wildcard_subdomain_passes():
+    from runtime.recipe_safety import assert_url_in_allowlist
+    assert_url_in_allowlist(
+        "https://eu.sandbox.example.com/api",
+        allowlist=["*.sandbox.example.com"],
+    )
+
+
+def test_url_allowlist_unknown_host_fails():
+    from runtime.recipe_safety import assert_url_in_allowlist
+    with pytest.raises(SandboxSafetyError, match="NOT in sandbox_url_allowlist"):
+        assert_url_in_allowlist(
+            "https://prod.example.com/api",
+            allowlist=["sandbox.example.com", "*.staging.example.com"],
+        )
+
+
+def test_url_allowlist_empty_disables_check():
+    from runtime.recipe_safety import assert_url_in_allowlist
+    # Empty/None disables — legacy projects without allowlist config
+    assert_url_in_allowlist("https://anything.com", allowlist=[])
+    assert_url_in_allowlist("https://anything.com", allowlist=None)
+
+
+def test_url_allowlist_no_host_fails():
+    from runtime.recipe_safety import assert_url_in_allowlist
+    with pytest.raises(SandboxSafetyError, match="no parseable host"):
+        assert_url_in_allowlist("not-a-url", allowlist=["sandbox.x.com"])
+
+
+# ─── Codex-HIGH-7: response echo handshake ──────────────────────────
+
+
+def test_response_echo_passes_when_header_present():
+    from runtime.recipe_safety import assert_response_echo
+    headers = {"X-VGFlow-Sandbox-Echo": "true"}
+    assert_response_echo(headers)
+
+
+def test_response_echo_fails_when_header_missing():
+    from runtime.recipe_safety import (
+        SandboxEchoMissingError, assert_response_echo,
+    )
+    with pytest.raises(SandboxEchoMissingError, match="missing"):
+        assert_response_echo({"X-Other": "value"})
+
+
+def test_response_echo_fails_when_value_wrong():
+    from runtime.recipe_safety import (
+        SandboxEchoMissingError, assert_response_echo,
+    )
+    with pytest.raises(SandboxEchoMissingError, match="rejected"):
+        assert_response_echo({"X-VGFlow-Sandbox-Echo": "false"})
+
+
+def test_response_echo_case_insensitive():
+    from runtime.recipe_safety import assert_response_echo
+    # requests.CaseInsensitiveDict-style lookup → both casings work
+    assert_response_echo({"x-vgflow-sandbox-echo": "TRUE"})
+
+
+def test_response_echo_custom_header_name():
+    from runtime.recipe_safety import assert_response_echo
+    assert_response_echo(
+        {"X-Custom-Echo": "yes"},
+        expected_header="X-Custom-Echo",
+        expected_value="yes",
+    )

--- a/tests/test_recipe_safety.py
+++ b/tests/test_recipe_safety.py
@@ -297,3 +297,57 @@ def test_response_echo_custom_header_name():
         expected_header="X-Custom-Echo",
         expected_value="yes",
     )
+
+
+# ─── Codex-HIGH-7-bis: numeric sentinel hole regression ──────────────
+
+
+def test_numeric_zero_account_id_no_longer_passes_as_identity_sentinel():
+    """Codex review caught: {account_id: 0, amount: 1000} used to pass
+    because 0 ≤ DEFAULT_MAX_MONEY_AMOUNT made it a 'sentinel'.
+    Now identity sentinel requires string pattern only."""
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {"amount": 1000, "account_id": 0},  # 0 not a sentinel anymore
+    }
+    with pytest.raises(SandboxSafetyError, match="identity-bearing field"):
+        assert_step_safe(step, env="sandbox")
+
+
+def test_is_sentinel_value_identity_mode_rejects_numeric():
+    from runtime.recipe_safety import is_sentinel_value
+    # Identity sentinel: string-only
+    assert is_sentinel_value("VG_FIXTURE_M1", identity=True)
+    assert is_sentinel_value("alice@fixture.vgflow.test", identity=True)
+    assert not is_sentinel_value(0, identity=True)
+    assert not is_sentinel_value(0.01, identity=True)
+    assert not is_sentinel_value("real-merchant-x", identity=True)
+
+
+def test_is_sentinel_value_money_mode_keeps_numeric():
+    """Legacy money-amount detection: under-threshold int passes."""
+    from runtime.recipe_safety import is_sentinel_value
+    assert is_sentinel_value(0.01)
+    assert is_sentinel_value(0)
+    assert not is_sentinel_value(1000)
+
+
+def test_numeric_sentinel_in_non_identity_field_does_not_auto_satisfy():
+    """Even with sentinel string in a non-identity field, the gate fails
+    because identity-fields walk needs identity field to carry sentinel."""
+    from runtime.recipe_safety import assert_step_safe
+    step = {
+        "id": "x",
+        "method": "POST",
+        "endpoint": "/api/x",
+        "body": {
+            "amount": 1000,
+            "merchant_id": 42,  # numeric — NOT sentinel
+            "note": "VG_FIXTURE_NOTE",  # string sentinel but in note, not identity
+        },
+    }
+    with pytest.raises(SandboxSafetyError):
+        assert_step_safe(step, env="sandbox")

--- a/tests/test_schema_data_invariants.py
+++ b/tests/test_schema_data_invariants.py
@@ -1,0 +1,165 @@
+"""Golden tests for schemas/data-invariants.v1.json.
+
+RFC v9 D5 — data_invariants block in ENV-CONTRACT.md. Per-consumer entity
+creation closes preflight non-convergence ping-pong (multiple destructive
+consumers all check "0 rows" → all create N rows → mutation collisions).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schemas" / "data-invariants.v1.json"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_schema_file_present_and_parses():
+    schema = _load_schema()
+    assert schema["$id"].endswith("data-invariants.v1.json")
+    assert schema["title"] == "VGFlow Data Invariants v1.0"
+
+
+def test_invariant_required_fields():
+    schema = _load_schema()
+    inv = schema["$defs"]["invariant"]
+    assert set(inv["required"]) == {"id", "resource", "where", "consumers"}
+
+
+def test_consumer_required_fields():
+    schema = _load_schema()
+    consumer = schema["$defs"]["consumer"]
+    assert set(consumer["required"]) == {"goal", "recipe", "consume_semantics"}
+    assert set(consumer["properties"]["consume_semantics"]["enum"]) == {
+        "destructive", "read_only",
+    }
+
+
+def test_isolation_enum_includes_per_consumer_default():
+    schema = _load_schema()
+    inv = schema["$defs"]["invariant"]
+    iso = inv["properties"]["isolation"]
+    assert iso["default"] == "per_consumer"
+    assert set(iso["enum"]) == {"per_consumer", "shared_when_read_only"}
+
+
+def test_invariant_id_pattern_strict_lowercase_snake():
+    schema = _load_schema()
+    inv = schema["$defs"]["invariant"]
+    assert inv["properties"]["id"]["pattern"] == r"^[a-z][a-z0-9_]*$"
+
+
+def test_consumer_goal_must_match_g_pattern():
+    schema = _load_schema()
+    pat = schema["$defs"]["consumer"]["properties"]["goal"]["pattern"]
+    assert pat == r"^G-[A-Za-z0-9._-]+$"
+
+
+def test_where_must_have_at_least_one_filter():
+    schema = _load_schema()
+    where = schema["$defs"]["invariant"]["properties"]["where"]
+    assert where["minProperties"] == 1
+
+
+# ─── jsonschema runtime validation ───────────────────────────────────
+
+
+def _has_jsonschema():
+    try:
+        import jsonschema  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+pytestmark_jsonschema = pytest.mark.skipif(
+    not _has_jsonschema(), reason="jsonschema not installed"
+)
+
+
+def _valid_minimal() -> dict:
+    return {
+        "data_invariants": [{
+            "id": "tier2_topup_pending",
+            "resource": "topup",
+            "where": {"tier": 2, "status": "pending"},
+            "consumers": [
+                {"goal": "G-10", "recipe": "G-10", "consume_semantics": "destructive"},
+                {"goal": "G-11", "recipe": "G-10", "consume_semantics": "destructive"},
+                {"goal": "G-12", "recipe": "G-10", "consume_semantics": "read_only"},
+            ],
+            "isolation": "per_consumer",
+        }],
+    }
+
+
+@pytestmark_jsonschema
+def test_minimal_valid_invariants_pass():
+    import jsonschema
+    schema = _load_schema()
+    jsonschema.validate(_valid_minimal(), schema)
+
+
+@pytestmark_jsonschema
+def test_invariant_id_uppercase_fails():
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    payload["data_invariants"][0]["id"] = "Tier2Topup"  # not snake_case
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(payload, schema)
+
+
+@pytestmark_jsonschema
+def test_consumer_invalid_goal_fails():
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    payload["data_invariants"][0]["consumers"][0]["goal"] = "goal-1"  # missing G- prefix
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(payload, schema)
+
+
+@pytestmark_jsonschema
+def test_consume_semantics_invalid_enum_fails():
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    payload["data_invariants"][0]["consumers"][0]["consume_semantics"] = "mutate"  # invalid
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(payload, schema)
+
+
+@pytestmark_jsonschema
+def test_empty_where_fails():
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    payload["data_invariants"][0]["where"] = {}  # minProperties=1
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(payload, schema)
+
+
+@pytestmark_jsonschema
+def test_no_consumers_fails():
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    payload["data_invariants"][0]["consumers"] = []  # minItems=1
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(payload, schema)
+
+
+@pytestmark_jsonschema
+def test_recipe_owning_can_differ_from_consumer_goal():
+    """G-11 reuses G-10's recipe — explicitly allowed by RFC v9."""
+    import jsonschema
+    schema = _load_schema()
+    payload = _valid_minimal()
+    # already in fixture: G-11 consumer with recipe=G-10 — passes
+    jsonschema.validate(payload, schema)

--- a/tests/test_schema_fixture_recipe.py
+++ b/tests/test_schema_fixture_recipe.py
@@ -1,0 +1,241 @@
+"""Golden tests for schemas/fixture-recipe.v1.json.
+
+RFC v9 D2 — recipe schema for FIXTURES/{G-XX}.yaml. Authored at
+/vg:build by executor; consumed by /vg:review preflight + /vg:test
+codegen. Schema version 1.0 mandatory; runner rejects unknown major.
+
+Validates positive + negative cases. Uses jsonschema if available;
+otherwise structural sanity check on the schema itself.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schemas" / "fixture-recipe.v1.json"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_schema_file_present_and_parses():
+    schema = _load_schema()
+    assert schema["$id"].endswith("fixture-recipe.v1.json")
+    assert schema["title"] == "VGFlow Fixture Recipe v1.0"
+
+
+def test_schema_required_top_level_fields():
+    schema = _load_schema()
+    required = set(schema["required"])
+    assert required == {"schema_version", "goal", "description", "fixture_intent", "steps"}
+
+
+def test_schema_version_is_const_1_0():
+    schema = _load_schema()
+    sv = schema["properties"]["schema_version"]
+    assert sv["const"] == "1.0"
+
+
+def test_step_kind_enum_includes_loop_and_api_call():
+    schema = _load_schema()
+    step = schema["$defs"]["step"]
+    assert set(step["properties"]["kind"]["enum"]) == {"api_call", "loop"}
+
+
+def test_capture_path_must_start_with_dollar():
+    schema = _load_schema()
+    cap = schema["$defs"]["capture"]
+    assert cap["properties"]["path"]["pattern"] == r"^\$"
+
+
+def test_lifecycle_block_has_pre_action_post():
+    schema = _load_schema()
+    lifecycle = schema["$defs"]["lifecycle"]
+    assert set(lifecycle["required"]) == {"pre_state", "action", "post_state"}
+
+
+def test_lifecycle_action_has_expected_network():
+    schema = _load_schema()
+    action = schema["$defs"]["lifecycle"]["properties"]["action"]
+    required = set(action["required"])
+    assert "expected_network" in required
+    assert "surface" in required
+    surfaces = action["properties"]["surface"]["enum"]
+    assert set(surfaces) == {"ui_click", "ui_form_submit", "api_direct"}
+
+
+def test_idempotency_required_for_post_put():
+    schema = _load_schema()
+    step = schema["$defs"]["step"]
+    # The conditional rule lives in step.allOf[1] — find it
+    rules = step["allOf"]
+    idem_rule = None
+    for r in rules:
+        if "idempotency_key" in str(r.get("then", {}).get("required", [])):
+            idem_rule = r
+            break
+    assert idem_rule is not None, "POST/PUT idempotency rule missing"
+    methods = idem_rule["if"]["allOf"][1]["properties"]["method"]["enum"]
+    assert set(methods) == {"POST", "PUT"}
+
+
+def test_side_effect_risk_enum():
+    schema = _load_schema()
+    risk = schema["$defs"]["step"]["properties"]["side_effect_risk"]
+    assert set(risk["enum"]) == {"none", "money_like", "external_call", "volume_change"}
+
+
+def test_validate_after_method_is_get():
+    schema = _load_schema()
+    va = schema["$defs"]["validate_after"]
+    assert va["properties"]["method"]["enum"] == ["GET"]
+
+
+# ─── jsonschema runtime validation (if available) ─────────────────────
+
+
+def _has_jsonschema():
+    try:
+        import jsonschema  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+pytestmark_jsonschema = pytest.mark.skipif(
+    not _has_jsonschema(), reason="jsonschema not installed"
+)
+
+
+def _valid_minimal_recipe() -> dict:
+    return {
+        "schema_version": "1.0",
+        "goal": "G-01",
+        "description": "Create a tier2 topup pending entity for /api/topup approval flow",
+        "fixture_intent": {
+            "declared_in": "TEST-GOALS.md#G-01",
+            "validates": "approval mutation lifecycle end-to-end",
+        },
+        "steps": [{
+            "id": "create_topup",
+            "kind": "api_call",
+            "role": "user_alice",
+            "method": "POST",
+            "endpoint": "/api/topup",
+            "idempotency_key": "k-001",
+            "body": {"amount": 0.01},
+        }],
+    }
+
+
+@pytestmark_jsonschema
+def test_minimal_valid_recipe_passes():
+    import jsonschema
+    schema = _load_schema()
+    jsonschema.validate(_valid_minimal_recipe(), schema)
+
+
+@pytestmark_jsonschema
+def test_missing_idempotency_on_post_fails():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    del recipe["steps"][0]["idempotency_key"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_get_step_does_not_need_idempotency():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["steps"][0] = {
+        "id": "fetch_topup",
+        "kind": "api_call",
+        "role": "user_alice",
+        "method": "GET",
+        "endpoint": "/api/topup/123",
+    }
+    jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_loop_step_requires_over_and_each():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["steps"][0] = {
+        "id": "loop_step",
+        "kind": "loop",
+        # missing over + each
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_short_description_fails_d27():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["description"] = "TBD"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_wrong_schema_version_fails():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["schema_version"] = "2.0"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_invalid_goal_pattern_fails():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["goal"] = "goal_one"  # not G-XX format
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(recipe, schema)
+
+
+@pytestmark_jsonschema
+def test_lifecycle_block_validates():
+    import jsonschema
+    schema = _load_schema()
+    recipe = _valid_minimal_recipe()
+    recipe["lifecycle"] = {
+        "pre_state": {
+            "role": "user_alice",
+            "method": "GET",
+            "endpoint": "/api/topup/pending",
+            "assert_jsonpath": [{"path": "$.count", "equals": 0}],
+        },
+        "action": {
+            "surface": "ui_click",
+            "target": "Submit topup",
+            "expected_network": {
+                "method": "POST",
+                "endpoint": "/api/topup",
+                "status_range": [200, 299],
+                "target_selector_must_include": "G-01-fixture",
+            },
+        },
+        "post_state": {
+            "role": "user_alice",
+            "method": "GET",
+            "endpoint": "/api/topup/pending",
+            "retry": {"max_attempts": 5, "delay_ms": 200, "until_assertion_pass": True},
+            "assert_jsonpath": [{"path": "$.count", "increased_by_at_least": 1}],
+        },
+    }
+    jsonschema.validate(recipe, schema)

--- a/tests/test_spawn_diagnostic_l2.py
+++ b/tests/test_spawn_diagnostic_l2.py
@@ -296,6 +296,87 @@ def test_evidence_secrets_redacted_before_prompt(tmp_path):
     assert "p@ssw0rd" not in diagnosis
 
 
+def test_redact_adjacent_name_value_pattern(tmp_path):
+    """Codex-R5-HIGH-1: scanner-shape headers list
+    `[{name: "Authorization", value: "Bearer ..."}]` must redact value
+    even though `value` key isn't itself a secret-name."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    echo_prompt = tmp_path / "echo.py"
+    echo_prompt.write_text(
+        "import json, sys\n"
+        "prompt = sys.argv[-1]\n"
+        "ev_start = prompt.find('## Evidence')\n"
+        "ev_section = prompt[ev_start:ev_start + 600] if ev_start >= 0 else ''\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'evidence section: ' + ev_section,\n"
+        "  'proposed_fix': 'review the prompt content above for leaks',\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    cli_cmd = f"{sys.executable} {echo_prompt}"
+    evidence = {
+        "scanner_request_headers": [
+            {"name": "Content-Type", "value": "application/json"},
+            {"name": "Authorization", "value": "Bearer secret-token-12345"},
+            {"name": "X-Cookie", "value": "sess=stealable"},
+        ],
+        "user": "alice",
+    }
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", json.dumps(evidence),
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    diagnosis = out["diagnosis"]
+    # Authorization header value must NOT leak
+    assert "secret-token-12345" not in diagnosis
+    assert "stealable" not in diagnosis
+    # Innocent header value (Content-Type) preserved
+    assert "application/json" in diagnosis
+    # Identity field preserved
+    assert "alice" in diagnosis
+
+
+def test_redact_handles_key_field_alias(tmp_path):
+    """Different scanners use 'key' instead of 'name'."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    echo_prompt = tmp_path / "echo2.py"
+    echo_prompt.write_text(
+        "import json, sys\n"
+        "prompt = sys.argv[-1]\n"
+        "ev_start = prompt.find('## Evidence')\n"
+        "ev_section = prompt[ev_start:ev_start + 500] if ev_start >= 0 else ''\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'sees: ' + ev_section,\n"
+        "  'proposed_fix': 'check redaction worked above',\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "form_fields": [
+            {"key": "username", "value": "alice"},
+            {"key": "password", "value": "p@ssw0rd"},
+        ],
+    }
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", json.dumps(evidence),
+        "--cli", f"{sys.executable} {echo_prompt}",
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert "p@ssw0rd" not in out["diagnosis"]
+    assert "alice" in out["diagnosis"]  # username key not secret → kept
+
+
 def test_env_passthrough_opt_in(tmp_path):
     """VG_DIAGNOSTIC_L2_ENV_PASSTHROUGH allowlists project-specific keys."""
     phase_dir = tmp_path / "phase"

--- a/tests/test_spawn_diagnostic_l2.py
+++ b/tests/test_spawn_diagnostic_l2.py
@@ -342,6 +342,47 @@ def test_redact_adjacent_name_value_pattern(tmp_path):
     assert "alice" in diagnosis
 
 
+def test_redact_all_value_siblings_when_name_secret(tmp_path):
+    """Codex-R6-HIGH-1 reproducer: multiple value-like siblings should
+    ALL be redacted when the name field signals secret semantics."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    echo = tmp_path / "echo.py"
+    echo.write_text(
+        "import json, sys\n"
+        "p = sys.argv[-1]\n"
+        "i = p.find('## Evidence')\n"
+        "ev = p[i:i+500] if i >= 0 else ''\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'evidence: ' + ev,\n"
+        "  'proposed_fix': 'verify all secret siblings redacted above',\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "header": {
+            "name": "Authorization",
+            "content": "public-data",
+            "value": "Bearer leak-me-secret-token",
+            "data": "another-leak-attempt",
+        },
+    }
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", json.dumps(evidence),
+        "--cli", f"{sys.executable} {echo}",
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    diagnosis = out["diagnosis"]
+    # ALL three value-like siblings must be redacted, not just first
+    assert "leak-me-secret-token" not in diagnosis
+    assert "public-data" not in diagnosis
+    assert "another-leak-attempt" not in diagnosis
+
+
 def test_redact_handles_key_field_alias(tmp_path):
     """Different scanners use 'key' instead of 'name'."""
     phase_dir = tmp_path / "phase"

--- a/tests/test_spawn_diagnostic_l2.py
+++ b/tests/test_spawn_diagnostic_l2.py
@@ -215,6 +215,117 @@ def test_invalid_evidence_json_returns_2(tmp_path):
     assert result.returncode == 2
 
 
+def test_env_scrubbed_secrets_not_passed_to_subagent(tmp_path):
+    """Codex-R4-HIGH-4: spawned CLI must NOT inherit secrets via env.
+    Confirm CLAUDE_API_KEY etc. don't reach the subagent's env."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    # Stub CLI that dumps its env to stdout
+    dump_env = tmp_path / "dump_env.py"
+    dump_env.write_text(
+        "import json, os, sys\n"
+        "envs = sorted(os.environ)\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'env keys: ' + str(envs[:5]) + '... long enough text',\n"
+        "  'proposed_fix': 'inspect env keys: ' + str(envs[:5]),\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    cli_cmd = f"{sys.executable} {dump_env}"
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+        env_extra={
+            "CLAUDE_API_KEY": "sk-secret-test-key-12345",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret-test",
+        },
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    diagnosis = out["diagnosis"]
+    # Subagent saw HOME / PATH / etc. but NOT CLAUDE_API_KEY or AWS_SECRET
+    assert "CLAUDE_API_KEY" not in diagnosis
+    assert "AWS_SECRET_ACCESS_KEY" not in diagnosis
+
+
+def test_evidence_secrets_redacted_before_prompt(tmp_path):
+    """Codex-R4-HIGH-4: secret-keyed evidence fields redacted before
+    going into the prompt sent to the subagent."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    # Stub CLI that echoes the prompt back so we can see what was sent
+    echo_prompt = tmp_path / "echo.py"
+    echo_prompt.write_text(
+        "import json, sys\n"
+        "prompt = sys.argv[-1]\n"
+        "# Look at the EVIDENCE section specifically\n"
+        "ev_start = prompt.find('## Evidence')\n"
+        "ev_section = prompt[ev_start:ev_start + 800] if ev_start >= 0 else ''\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'evidence section: ' + ev_section,\n"
+        "  'proposed_fix': 'review the prompt content above for leaks',\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    cli_cmd = f"{sys.executable} {echo_prompt}"
+    evidence = {
+        "user_id": "real-user-123",
+        "auth_token": "Bearer sk-secret-bearer-456",
+        "api_key": "real-api-key-789",
+        "request_body": {"password": "p@ssw0rd"},
+    }
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", json.dumps(evidence),
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    diagnosis = out["diagnosis"]
+    # user_id was passed verbatim (not a secret-keyed field)
+    assert "real-user-123" in diagnosis
+    # Secrets redacted
+    assert "[REDACTED]" in diagnosis
+    assert "sk-secret-bearer-456" not in diagnosis
+    assert "real-api-key-789" not in diagnosis
+    assert "p@ssw0rd" not in diagnosis
+
+
+def test_env_passthrough_opt_in(tmp_path):
+    """VG_DIAGNOSTIC_L2_ENV_PASSTHROUGH allowlists project-specific keys."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    dump_env = tmp_path / "dump.py"
+    dump_env.write_text(
+        "import json, os\n"
+        "v = os.environ.get('PROJECT_API_BASE', 'NOT_SET')\n"
+        "print(json.dumps({\n"
+        "  'diagnosis': 'PROJECT_API_BASE=' + v + ' check this passthrough',\n"
+        "  'proposed_fix': 'inspect PROJECT_API_BASE value above for passthrough',\n"
+        "  'confidence': 0.5,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", f"{sys.executable} {dump_env}",
+        env_extra={
+            "PROJECT_API_BASE": "https://sandbox.example.com",
+            "VG_DIAGNOSTIC_L2_ENV_PASSTHROUGH": "PROJECT_API_BASE",
+        },
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert "https://sandbox.example.com" in out["diagnosis"]
+
+
 def test_proposal_persisted_with_evidence_round_trip(tmp_path):
     phase_dir = tmp_path / "phase"
     phase_dir.mkdir()

--- a/tests/test_spawn_diagnostic_l2.py
+++ b/tests/test_spawn_diagnostic_l2.py
@@ -1,0 +1,240 @@
+"""Tests for scripts/spawn-diagnostic-l2.py — RFC v9 PR-D3."""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "spawn-diagnostic-l2.py"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.diagnostic_l2 import load_proposal, proposal_dir  # noqa: E402
+
+
+def _run(*args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+           "PYTHONPATH": str(REPO_ROOT / "scripts")}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env=env, capture_output=True, text=True, timeout=30,
+    )
+
+
+def _make_stub_cli(tmp_path: Path, response: str) -> str:
+    """Create a python script that, when run, prints `response` on stdout.
+
+    Returns the shlex-joined command for --cli override.
+    """
+    stub = tmp_path / "stub_cli.py"
+    stub.write_text(
+        f"import sys\nprint({response!r})\n",
+        encoding="utf-8",
+    )
+    return f"{sys.executable} {stub}"
+
+
+def test_dry_run_emits_stub_proposal(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    result = _run(
+        "--gate-id", "missing-evidence",
+        "--block-family", "provenance",
+        "--phase-dir", str(phase_dir),
+        "--gate-context", "test gate",
+        "--evidence-json", '{"goal":"G-10"}',
+        "--dry-run",
+    )
+    assert result.returncode == 0, f"stderr={result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["dry_run"] is True
+    assert out["confidence"] == 0.0
+    assert out["proposal_id"].startswith("l2-")
+    # File written
+    pid = out["proposal_id"]
+    proposal = load_proposal(phase_dir, pid)
+    assert proposal.gate_id == "missing-evidence"
+
+
+def test_live_invocation_with_stub_cli(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    response = json.dumps({
+        "diagnosis": "Mutation step at G-10/step[2] missing evidence.source",
+        "proposed_fix": "Re-run scanner with /vg:review --re-scan-goals=G-10",
+        "confidence": 0.85,
+    })
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "missing-evidence",
+        "--block-family", "provenance",
+        "--phase-dir", str(phase_dir),
+        "--gate-context", "G-10 lacks evidence after retry",
+        "--evidence-json", '{"goal":"G-10"}',
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    out = json.loads(result.stdout)
+    assert out["confidence"] == 0.85
+    assert "Re-run scanner" in out["proposed_fix"]
+    proposal = load_proposal(phase_dir, out["proposal_id"])
+    assert proposal.confidence == 0.85
+    assert proposal.diagnosis.startswith("Mutation step")
+
+
+def test_subagent_returns_short_diagnosis_fails(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    response = json.dumps({"diagnosis": "x", "proposed_fix": "y", "confidence": 0.5})
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 1
+    assert "too short" in json.loads(result.stdout)["error"]
+
+
+def test_subagent_confidence_out_of_range(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    response = json.dumps({
+        "diagnosis": "long enough diagnosis text",
+        "proposed_fix": "long enough proposed fix text",
+        "confidence": 1.5,
+    })
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 1
+    assert "out of range" in json.loads(result.stdout)["error"]
+
+
+def test_subagent_missing_fields_fails(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    # Missing confidence
+    response = json.dumps({
+        "diagnosis": "long enough diagnosis text",
+        "proposed_fix": "long enough proposed fix text",
+    })
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 1
+    assert "missing fields" in json.loads(result.stdout)["error"]
+
+
+def test_subagent_emits_prose_around_json_still_parses(tmp_path):
+    """Tolerance for models that wrap JSON in prose despite our instruction."""
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    json_block = json.dumps({
+        "diagnosis": "long enough diagnosis here",
+        "proposed_fix": "long enough proposed fix here",
+        "confidence": 0.7,
+    })
+    response = f"Here's my analysis:\\n\\n{json_block}\\n\\nLet me know if you need more."
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 0, f"stderr={result.stderr}\nstdout={result.stdout}"
+
+
+def test_subagent_invalid_json_fails(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    cli_cmd = _make_stub_cli(tmp_path, "not json at all")
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 1
+    assert "not valid JSON" in json.loads(result.stdout)["error"]
+
+
+def test_subagent_nonzero_exit_fails(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    failing = tmp_path / "fail.py"
+    failing.write_text("import sys\nsys.exit(2)\n", encoding="utf-8")
+    cli_cmd = f"{sys.executable} {failing}"
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "{}",
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 1
+    assert "exited 2" in json.loads(result.stdout)["error"]
+
+
+def test_phase_dir_missing_returns_2(tmp_path):
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(tmp_path / "nonexistent"),
+        "--evidence-json", "{}",
+        "--dry-run",
+    )
+    assert result.returncode == 2
+
+
+def test_invalid_evidence_json_returns_2(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    result = _run(
+        "--gate-id", "g", "--block-family", "f",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", "not json",
+        "--dry-run",
+    )
+    assert result.returncode == 2
+
+
+def test_proposal_persisted_with_evidence_round_trip(tmp_path):
+    phase_dir = tmp_path / "phase"
+    phase_dir.mkdir()
+    evidence = {"goal": "G-10", "step_idx": 2, "fail_reason": "no source"}
+    response = json.dumps({
+        "diagnosis": "Step 2 of G-10 missing scanner source field",
+        "proposed_fix": "Re-run scanner; ensure verify-evidence-provenance threshold met",
+        "confidence": 0.92,
+    })
+    cli_cmd = _make_stub_cli(tmp_path, response)
+    result = _run(
+        "--gate-id", "missing-evidence",
+        "--block-family", "provenance",
+        "--phase-dir", str(phase_dir),
+        "--evidence-json", json.dumps(evidence),
+        "--cli", cli_cmd,
+    )
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    proposal = load_proposal(phase_dir, out["proposal_id"])
+    assert proposal.evidence_in == evidence
+    assert proposal.confidence == 0.92
+    assert proposal.gate_id == "missing-evidence"

--- a/tests/test_tester_pro.py
+++ b/tests/test_tester_pro.py
@@ -1,0 +1,214 @@
+"""Tests for scripts/runtime/tester_pro.py — RFC v9 D17–D23."""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from runtime.tester_pro import (  # noqa: E402
+    Defect,
+    TestSummary,
+    TraceabilityRow,
+    assert_required_coverage,
+    coverage_by_test_type,
+    detect_orphan_goals,
+    detect_orphan_requirements,
+    new_defect_id,
+    parse_test_type_from_goal_body,
+    render_defect_log,
+    render_rtm,
+    render_summary_report,
+    reverse_index,
+)
+
+
+# ─── D18 test_type ────────────────────────────────────────────────
+
+
+def test_parse_test_type_recognized():
+    body = "...some prose...\n**Test type:** smoke\n..."
+    assert parse_test_type_from_goal_body(body) == "smoke"
+
+
+def test_parse_test_type_case_insensitive_keyword():
+    body = "**TEST TYPE:** Negative"
+    assert parse_test_type_from_goal_body(body) == "negative"
+
+
+def test_parse_test_type_unknown_returns_none():
+    body = "**Test type:** sanity"  # not in TEST_TYPES
+    assert parse_test_type_from_goal_body(body) is None
+
+
+def test_parse_test_type_missing_returns_none():
+    assert parse_test_type_from_goal_body("no directive here") is None
+
+
+def test_coverage_by_test_type():
+    goals = [
+        {"id": "G-1", "test_type": "smoke"},
+        {"id": "G-2", "test_type": "smoke"},
+        {"id": "G-3", "test_type": "happy"},
+        {"id": "G-4", "test_type": "edge"},
+        {"id": "G-5"},  # untyped
+    ]
+    counts = coverage_by_test_type(goals)
+    assert counts["smoke"] == 2
+    assert counts["happy"] == 1
+    assert counts["edge"] == 1
+    assert counts["negative"] == 0
+
+
+def test_assert_required_coverage_passes():
+    counts = {"smoke": 2, "happy": 3, "edge": 4}
+    missing = assert_required_coverage(counts, requirements={"smoke": 1, "happy": 1})
+    assert missing == []
+
+
+def test_assert_required_coverage_misses():
+    counts = {"smoke": 0, "happy": 1, "edge": 0}
+    missing = assert_required_coverage(
+        counts, requirements={"smoke": 1, "edge": 2},
+    )
+    assert any("smoke" in m for m in missing)
+    assert any("edge" in m for m in missing)
+
+
+# ─── D21 DEFECT-LOG ───────────────────────────────────────────────
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def test_new_defect_id_increments():
+    existing = []
+    assert new_defect_id(existing) == "D-001"
+    existing.append(Defect(
+        id="D-001", title="x", severity="high", discovered_at=_now(),
+        discovered_in="review",
+    ))
+    assert new_defect_id(existing) == "D-002"
+
+
+def test_new_defect_id_handles_gaps():
+    existing = [Defect(
+        id="D-005", title="x", severity="high", discovered_at=_now(),
+        discovered_in="review",
+    )]
+    assert new_defect_id(existing) == "D-006"
+
+
+def test_render_defect_log_includes_table_and_details():
+    defects = [
+        Defect(
+            id="D-001",
+            title="Idempotency missing on POST /topup",
+            severity="high",
+            discovered_at=_now(),
+            discovered_in="review",
+            repro_steps=["click submit twice", "observe two receipts"],
+            root_cause="No backend dedup",
+            fix_ref="commit-abc123",
+            related_goals=["G-10", "G-11"],
+        ),
+    ]
+    out = render_defect_log(defects)
+    assert "D-001" in out
+    assert "Idempotency" in out
+    assert "Repro" in out
+    assert "commit-abc123" in out
+    assert "G-10" in out
+
+
+def test_render_defect_log_open_marker():
+    defects = [Defect(
+        id="D-001", title="Open defect", severity="medium",
+        discovered_at=_now(), discovered_in="review",
+    )]
+    out = render_defect_log(defects)
+    assert "open" in out  # closed_at None → "open" in table
+
+
+# ─── D22 TEST-SUMMARY ─────────────────────────────────────────────
+
+
+def test_render_summary_report():
+    summary = TestSummary(
+        phase="3.2",
+        generated_at=_now(),
+        goals_total=50,
+        goals_passed=42,
+        goals_failed=3,
+        goals_blocked=5,
+        coverage_by_type={"smoke": 10, "happy": 25, "edge": 8, "negative": 5,
+                            "security": 2, "perf": 0, "integration": 0},
+        defects_opened=4,
+        defects_closed=2,
+        defects_open=2,
+        notes="Phase 3.2 dogfood validated wave-3.2.3 fixes",
+    )
+    out = render_summary_report(summary)
+    assert "3.2" in out
+    assert "Passed: 42" in out
+    assert "smoke: 10" in out
+    assert "Notes" in out
+
+
+# ─── D23 RTM ──────────────────────────────────────────────────────
+
+
+def test_reverse_index_maps_leaves_to_requirements():
+    rows = [
+        TraceabilityRow(
+            requirement_id="REQ-01",
+            goal_ids=["G-10", "G-11"],
+            test_case_ids=["TC-1"],
+            fix_commits=["abc"],
+        ),
+        TraceabilityRow(
+            requirement_id="REQ-02",
+            goal_ids=["G-11", "G-12"],
+            defect_ids=["D-005"],
+        ),
+    ]
+    rev = reverse_index(rows)
+    assert sorted(rev["G-11"]) == ["REQ-01", "REQ-02"]
+    assert rev["G-10"] == ["REQ-01"]
+    assert rev["abc"] == ["REQ-01"]
+    assert rev["D-005"] == ["REQ-02"]
+
+
+def test_detect_orphan_goals():
+    rows = [TraceabilityRow(requirement_id="REQ-1", goal_ids=["G-1", "G-2"])]
+    declared = {"G-1", "G-2", "G-3", "G-4"}
+    assert detect_orphan_goals(rows, declared_goals=declared) == ["G-3", "G-4"]
+
+
+def test_detect_orphan_requirements():
+    rows = [TraceabilityRow(requirement_id="REQ-1")]
+    declared = {"REQ-1", "REQ-2", "REQ-3"}
+    assert detect_orphan_requirements(
+        rows, declared_requirements=declared,
+    ) == ["REQ-2", "REQ-3"]
+
+
+def test_render_rtm():
+    rows = [
+        TraceabilityRow(
+            requirement_id="REQ-01",
+            goal_ids=["G-10"],
+            test_case_ids=["TC-100"],
+            fix_commits=["abc1234"],
+        ),
+    ]
+    out = render_rtm(rows)
+    assert "REQ-01" in out
+    assert "G-10" in out
+    assert "TC-100" in out
+    assert "abc1234" in out

--- a/tests/test_verify_codegen_fixture_ref.py
+++ b/tests/test_verify_codegen_fixture_ref.py
@@ -106,6 +106,30 @@ def test_warn_severity_does_not_block(tmp_path):
     assert "severity_downgraded" in types
 
 
+def test_url_state_spec_recognized(tmp_path):
+    """Codex-MEDIUM-1: validator must find interactive specs."""
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "g-10.url-state.spec.ts",
+          "test('x', () => { console.log(FIXTURE.id); });\n")
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 0  # interactive spec recognized + has FIXTURE.*
+
+
+def test_bracket_notation_recognized_as_fixture_ref(tmp_path):
+    """Codex-MEDIUM-2: FIXTURE['x'] should count as a fixture reference."""
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "1.0-G-10.spec.ts",
+          'test("x", () => { use(FIXTURE["pending-id"]); });\n')
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 0
+
+
 def test_allow_no_fixture_ref_override(tmp_path):
     _make_phase(tmp_path, {
         "G-10": {"captured": {"id": "p1"}},

--- a/tests/test_verify_codegen_fixture_ref.py
+++ b/tests/test_verify_codegen_fixture_ref.py
@@ -1,0 +1,120 @@
+"""Tests for verify-codegen-fixture-ref.py — Codex-HIGH-3 regression guard."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "validators" / "verify-codegen-fixture-ref.py"
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), *args],
+        env={"VG_REPO_ROOT": str(repo), "PATH": "/usr/bin:/bin",
+             "PYTHONPATH": str(REPO_ROOT / "scripts")},
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def _make_phase(tmp_path: Path, entries: dict) -> Path:
+    phase_dir = tmp_path / ".vg" / "phases" / "01.0-x"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "FIXTURES-CACHE.json").write_text(
+        json.dumps({"schema_version": "1.0", "entries": entries}, indent=2),
+        encoding="utf-8",
+    )
+    return phase_dir
+
+
+def _spec(tests_dir: Path, name: str, body: str) -> Path:
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    spec = tests_dir / name
+    spec.write_text(body, encoding="utf-8")
+    return spec
+
+
+def test_passes_when_spec_references_fixture(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "1.0-G-10.spec.ts",
+          "test('x', async () => { console.log(FIXTURE.id); });\n")
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 0, result.stdout
+    out = json.loads(result.stdout)
+    assert out["verdict"] in ("PASS", "WARN")
+
+
+def test_blocks_when_spec_does_not_reference_fixture(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "1.0-G-10.spec.ts",
+          "test('x', async () => { await page.goto('/hardcoded'); });\n")
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 1, result.stdout
+    out = json.loads(result.stdout)
+    types = [e["type"] for e in out["evidence"]]
+    assert "fixture_ref_missing" in types
+
+
+def test_blocks_when_spec_missing_for_captured_goal(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    e2e.mkdir(parents=True)
+    # No spec file for G-10 at all
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 1
+    out = json.loads(result.stdout)
+    types = [e["type"] for e in out["evidence"]]
+    assert "spec_missing_for_captured_goal" in types
+
+
+def test_skip_goal_without_captured_store(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"lease": {"owner_session": "x"}},  # no captured
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    e2e.mkdir(parents=True)
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    types = [e["type"] for e in out["evidence"]]
+    assert "no_captured_goals" in types
+
+
+def test_warn_severity_does_not_block(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "1.0-G-10.spec.ts", "test('x', async () => {});\n")
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e",
+                   "--severity", "warn")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    types = [e["type"] for e in out["evidence"]]
+    assert "severity_downgraded" in types
+
+
+def test_allow_no_fixture_ref_override(tmp_path):
+    _make_phase(tmp_path, {
+        "G-10": {"captured": {"id": "p1"}},
+    })
+    e2e = tmp_path / "apps" / "web" / "e2e"
+    _spec(e2e, "1.0-G-10.spec.ts", "test('x', async () => {});\n")
+    result = _run(tmp_path, "--phase", "1.0", "--tests-dir", "apps/web/e2e",
+                   "--allow-no-fixture-ref")
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    types = [e["type"] for e in out["evidence"]]
+    assert "override_accepted" in types


### PR DESCRIPTION
## What's in this PR

Full RFC v9 implementation across 16 logical PRs bundled into one branch.
RFC: docs/discussions/test-data-prerequisites.md (PR #80 v9, hash fcd0844).

### Foundation (PR-pre-A)
- `schemas/fixture-recipe.v1.json` — D2 recipe schema (allocation, lifecycle, retry, side_effect_risk, validate_after, idempotency-required for POST/PUT)
- `schemas/data-invariants.v1.json` — D5 N-consumer schema (consume_semantics destructive|read_only, isolation per_consumer|shared_when_read_only)
- `scripts/validators/verify-evidence-provenance.py` — D10 structured provenance gate
- `scripts/validators/verify-matrix-staleness.py` — D10 trustworthy provenance bidirectional sync (executor evidence cannot promote SUSPECTED→READY)
- `scripts/migrate-legacy-provenance.py` — pre-v9 mutation step tagger

### Native Python recipe runtime (PR-A1+A2+A3)
- `scripts/runtime/recipe_loader.py` — YAML + jsonschema validation
- `scripts/runtime/recipe_capture.py` — JSONPath capture (jsonpath-ng + stdlib fallback) with cardinality enforcement
- `scripts/runtime/recipe_interpolate.py` — `${var}` interpolation, type-preserving whole-string match
- `scripts/runtime/recipe_safety.py` — D9 sandbox safety gate (X-VGFlow-Sandbox + sentinel markers)
- `scripts/runtime/recipe_auth.py` — 4 auth handlers (cookie_login, api_key, bearer_jwt with refresh, command sandbox-only)
- `scripts/runtime/recipe_executor.py` — RecipeRunner: role auth → interpolation → safety → idempotency-key → 401 refresh → capture → validate_after assertions → loop step
- `scripts/runtime/fixture_cache.py` — FIXTURES-CACHE.json with fcntl lease (destructive serializes, read_only co-tenants), recipe-hash drift invalidation, orphan/expired reaping

### Migration + preflight (PR-A.5+C+D2)
- `scripts/fixture-backfill.py` — RUNTIME-MAP scanner-evidence → FIXTURES/{G-XX}.yaml draft (HIGH/MEDIUM/LOW confidence)
- `scripts/runtime/preflight.py` — D5 N-consumer algorithm + ENV-CONTRACT yaml parser + fix_hint
- `scripts/runtime/rcrurd_gate.py` — D12 lifecycle gate (pre_state + post_state with eventual-consistency retry, increased_by_at_least, cardinality)

### Layer-2 + UX (PR-D3+D26+block-aggregator)
- `scripts/runtime/diagnostic_l2.py` — L2 proposal storage with audit trail (proposal_id), single-advisory rendering (vi/en)
- `commands/vg/_shared/lib/block-resolver.sh::block_resolve_l3_single_advisory` — D26 single-advisory backport (confidence-gated, falls through to 3-option on low confidence)
- `scripts/runtime/block_aggregator.py` — D28 multi-Type-A block aggregation (group by gate_id, cap at max_merged_evidence, sample_evidence)

### Backend + content depth + research (PR-Z+content-depth+research-augment)
- `scripts/validators/verify-backend-mutation-evidence.py` — surface=api|data|integration replay+evidence gate
- `scripts/runtime/content_depth.py` — D27 anti-skim (word_count, cross_reference, edge_case_substance, instruction_repetition, llm_judge_sample)
- `scripts/runtime/pattern_catalog.py` + `catalog/edge-cases/*.md` — D25 local catalog with 5 seed patterns (idempotency, session fixation, mime spoof, double-submit, lost-update)

### Tester-pro + cleanup (PR-tester-pro+F)
- `scripts/runtime/tester_pro.py` — D17/D18/D21/D22/D23 (test_type taxonomy, DEFECT-LOG, TEST-SUMMARY, RTM bi-directional)
- `scripts/fixture-prune.py` — periodic cleanup (expired leases, orphan entries)

### Skill wiring (PR-B+D1+E)
- `commands/vg/build.md` — fixture wave-verify after wave-verify-isolated; missing FIXTURES surfaces /vg:fixture-backfill hint
- `commands/vg/review.md` — Phase 0.5 RFC v9 preflight (prune + invariants + lifecycle inventory) + final-gate evidence-provenance validator with config.review.provenance.enforcement
- `commands/vg/test.md` — 5d codegen reads FIXTURES-CACHE.json, emits `FIXTURE = {...}` constant block
- `commands/vg/_shared/config-loader.md` — review.provenance section drift detection
- `scripts/validators/registry.yaml` — registers matrix-staleness + evidence-provenance

## Tests

**538/538 pass with full deps installed** (`pip install -r requirements.txt`):

| File | Cases |
|------|-------|
| `test_matrix_staleness_d10_provenance.py` | 14 |
| `test_evidence_provenance.py` | 14 |
| `test_schema_fixture_recipe.py` | 18 |
| `test_schema_data_invariants.py` | 14 |
| `test_migrate_legacy_provenance.py` | 9 |
| `test_recipe_loader.py` | 10 |
| `test_recipe_capture.py` | 15 |
| `test_recipe_interpolate.py` | 12 |
| `test_recipe_safety.py` | 12 |
| `test_recipe_auth.py` | 18 |
| `test_recipe_executor.py` | 10 |
| `test_fixture_cache.py` | 16 |
| `test_fixture_backfill.py` | 10 |
| `test_preflight_invariants.py` | 16 |
| `test_rcrurd_gate.py` | 12 |
| `test_backend_mutation_evidence.py` | 10 |
| `test_block_aggregator.py` | 13 |
| `test_content_depth.py` | 20 |
| `test_pattern_catalog.py` | 12 |
| `test_diagnostic_l2.py` | 15 |
| `test_block_resolver_l3_single_advisory.sh` | 7 |
| `test_tester_pro.py` | 16 |
| `test_fixture_prune.py` | 9 |
| **Plus existing test suite** | — |

## Live verification (PrintwayV3 dogfood)

- `migrate-legacy-provenance.py --phase 3.2 --dry-run`: 6 mutation steps tagged.
- `fixture-backfill.py --phase 3.2 --dry-run`: 5 mutation goals, all MEDIUM confidence (scanner captured endpoints but not bodies — expected).

## Wiring stubs vs full integration

- `count_fn` in preflight invariants currently returns 0 (stub). Full HTTP wiring requires recipe_executor session bound to env credentials — landed when projects start using FIXTURES end-to-end.
- RCRURD pre_state/post_state gate not yet auto-invoked from review.md (counted only); next iter wires the gate-call when FIXTURES dir is populated.
- Diagnostic_l2 spawn (Haiku invocation) returns proposal storage but actual subagent spawn is the orchestrator's job (per skill standards) — module provides the audit-trail anchor.

## Migration path for existing phases

1. `pip install -r requirements.txt` (adds jsonschema, jsonpath-ng, requests).
2. `scripts/migrate-legacy-provenance.py --apply` — tags pre-v9 steps as legacy_pre_provenance.
3. `scripts/fixture-backfill.py --phase X --apply` — generates draft FIXTURES.
4. User reviews/completes draft fixtures.
5. Set `review.provenance.enforcement: warn` in vg.config.md initially; flip to `block` after migration sweep complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)