### PR TITLE
fix(vg-orchestrator): import subprocess in _verify_artifact_run_binding

### DIFF
--- a/scripts/vg-orchestrator/__main__.py
+++ b/scripts/vg-orchestrator/__main__.py
@@ -103,6 +103,7 @@ def _verify_artifact_run_binding(artifact_path: Path, run_id: str,
     """
     import hashlib as _hashlib
     import json as _json
+    import subprocess
     from pathlib import Path as _Path
 
     def _sha256(p: _Path) -> str | None:


### PR DESCRIPTION
## Summary
- One-line fix: `_verify_artifact_run_binding` in `scripts/vg-orchestrator/__main__.py` uses `subprocess.check_output` to resolve git repo root but never imports `subprocess` locally → `run-complete` crashes with `NameError`.
- Add `import subprocess` to the function's local imports block (alongside `hashlib` / `json` / `Path`).

## Reproducer
```bash
python -m vg-orchestrator run-start vg:review 3.2 "3.2"
python .claude/scripts/emit-evidence-manifest.py \
    --path <any-must-write-artifact> \
    --producer "vg:review/test"
python -m vg-orchestrator run-complete
# → Traceback (...)
#   File "scripts/vg-orchestrator/__main__.py", line 117, in _verify_artifact_run_binding
#     subprocess.check_output(...)
# NameError: name 'subprocess' is not defined
```

## Impact
Any skill that writes a `must_write` artifact + tries `run-complete` immediately after hits this. The `vg-verify-claim.py` stop hook then re-fires forever because the previous run never closed → user sees the same red BLOCK message at every prompt until manually `run-abort`.

## Why local import (vs top-level)
Mirroring the existing pattern in the same function — `hashlib` / `json` / `Path` are also imported function-local, presumably to keep the orchestrator module's import graph cheap on the hot run-status / mark-step paths that don't touch this verification code.

## Test plan
- [x] AST parse passes (`python3 -c "import ast; ast.parse(open('scripts/vg-orchestrator/__main__.py').read())"`)
- [x] Manual reproducer above now succeeds (tested on PrintwayV3 dogfood, vg:review 3.2 re-verification 2026-05-02)
- [x] `vg-verify-claim.py` stop hook stops re-firing after run-complete
- [ ] Add unit test if vgflow has a test harness for `_verify_artifact_run_binding` (none found in `scripts/tests/`)

## Discovered via
PrintwayV3 dogfood — `/vg:review 3.2` re-verification flow. After binding `api-contract-precheck.txt` to the run, `run-complete` immediately crashed. Same bug present in PrintwayV3's mirror at `.claude/scripts/vg-orchestrator/__main__.py` (fixed in PrintwayV3 commit 7f851ccc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)