### PR TITLE
fix(codex): enforce task UI runtime lock

### DIFF
--- a/.claude/commands/vg/_shared/blueprint/preflight.md
+++ b/.claude/commands/vg/_shared/blueprint/preflight.md
@@ -350,6 +350,10 @@ Per sub-step lifecycle:
 - BEFORE sub-step work: set its sub-step todo `in_progress`. Group header
   stays `in_progress` while ANY of its sub-steps is pending/active.
 - AFTER `mark-step` writes marker: set sub-step todo `completed`.
+- AFTER any `vg-orchestrator mark-step`: refresh the runtime-native task UI
+  before the next `step-active`, `mark-step`, `run-complete`, or code edit.
+  Claude must call TodoWrite again; Codex must update compact `update_plan`
+  and re-run `tasklist-projected --adapter codex`.
 - When ALL sub-steps in a group are `completed`: set group header todo `completed`.
 - On run-complete: clear projected tasklist per `close-on-complete`.
 

--- a/.claude/commands/vg/_shared/build/preflight.md
+++ b/.claude/commands/vg/_shared/build/preflight.md
@@ -340,6 +340,10 @@ Per sub-step lifecycle:
 - BEFORE sub-step work: set its sub-step todo `in_progress`. Group header
   stays `in_progress` while ANY of its sub-steps is pending/active.
 - AFTER `mark-step` writes marker: set sub-step todo `completed`.
+- AFTER any `vg-orchestrator mark-step`: refresh the runtime-native task UI
+  before the next `step-active`, `mark-step`, `run-complete`, or code edit.
+  Claude must call TodoWrite again; Codex must update compact `update_plan`
+  and re-run `tasklist-projected --adapter codex`.
 - When ALL sub-steps in a group are `completed`: set group header todo `completed`.
 - On run-complete: clear projected tasklist per `close-on-complete`.
 

--- a/.claude/scripts/generate-codex-skills.sh
+++ b/.claude/scripts/generate-codex-skills.sh
@@ -75,6 +75,19 @@ write_generic_adapter() {
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+\`VG_RUNTIME=codex\`, use Codex \`update_plan\` for the compact visible task
+window, and bind it with \`vg-orchestrator tasklist-projected --adapter codex\`.
+
+\`.claude/scripts/*\` and \`.claude/commands/*\` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", \`TodoWrite\`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.claude/scripts/hooks/vg-post-tool-use-todowrite.sh
+++ b/.claude/scripts/hooks/vg-post-tool-use-todowrite.sh
@@ -20,13 +20,15 @@ fi
 # Build evidence payload from TodoWrite input + contract.
 # NOTE: pass hook input via env var (VG_HOOK_INPUT) — heredoc consumes stdin.
 payload="$(VG_HOOK_INPUT="$input" python3 - "$contract_path" "$run_id" <<'PY'
-import hashlib, json, os, sys
+import hashlib, json, os, sqlite3, sys
+from pathlib import Path
 from datetime import datetime, timezone
 contract_path, run_id = sys.argv[1:]
 hook_input = json.loads(os.environ.get("VG_HOOK_INPUT", "{}"))
 todos = hook_input.get("tool_input", {}).get("todos", [])
 contract = json.loads(open(contract_path).read())
 checklists = contract.get("checklists", [])
+projection_items = contract.get("projection_items", []) or []
 
 # Tolerant match: each contract checklist matched if any group-header todo
 # content contains its id or its title. Allows AI to format group content
@@ -73,8 +75,44 @@ flat_groups = [gid for gid, n in sub_counts.items() if n == 0]
 groups_with_subs_count = sum(1 for n in sub_counts.values() if n >= 1)
 depth_valid = (len(matched_ids) > 0) and (len(flat_groups) == 0)
 
+latest_marked_step = None
+latest_marked_at = None
+latest_marked_status = None
+latest_marked_status_valid = True
+db_path = Path(".vg/events.db")
+if db_path.exists():
+    try:
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT step, ts FROM events "
+            "WHERE run_id = ? AND event_type = 'step.marked' "
+            "ORDER BY id DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        conn.close()
+    except Exception:
+        row = None
+    if row and row[0]:
+        latest_marked_step = row[0]
+        latest_marked_at = row[1]
+        accepted = {latest_marked_step}
+        for item in projection_items:
+            if item.get("kind") == "step" and item.get("id") == latest_marked_step:
+                title = str(item.get("title") or "").strip()
+                if title:
+                    accepted.add(title)
+                    accepted.add(title.lstrip(" ↳").strip())
+        latest_marked_status_valid = False
+        for todo in todos:
+            content = str(todo.get("content") or "")
+            if any(token and token in content for token in accepted):
+                latest_marked_status = str(todo.get("status") or "")
+                latest_marked_status_valid = latest_marked_status == "completed"
+                break
+
 payload = {
     "run_id": run_id,
+    "adapter": "claude",
     "todowrite_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     "todo_count": len(todos),
     "contract_sha256": hashlib.sha256(open(contract_path, "rb").read()).hexdigest(),
@@ -84,6 +122,10 @@ payload = {
     "depth_valid": depth_valid,
     "groups_with_subs_count": groups_with_subs_count,
     "flat_groups": sorted(flat_groups),
+    "latest_marked_step": latest_marked_step,
+    "latest_marked_at": latest_marked_at,
+    "latest_marked_status": latest_marked_status,
+    "latest_marked_status_valid": latest_marked_status_valid,
 }
 print(json.dumps(payload))
 PY

--- a/.claude/scripts/hooks/vg-pre-tool-use-bash.sh
+++ b/.claude/scripts/hooks/vg-pre-tool-use-bash.sh
@@ -276,12 +276,65 @@ emit_codex_pretasklist_scope_block() {
   exit 2
 }
 
+is_codex_claude_vg_entrypoint() {
+  [ "${VG_RUNTIME:-}" = "codex" ] || return 1
+  [ -n "${run_id:-}" ] || return 1
+  case "$command_from_run" in
+    vg:*) ;;
+    *) return 1 ;;
+  esac
+  [[ "$cmd_text" =~ (^|[[:space:];|&])claude([[:space:]]|$) ]] || return 1
+  [[ "$cmd_text" =~ /vg: ]] || return 1
+  return 0
+}
+
+emit_codex_claude_entrypoint_block() {
+  local gate_id="PreToolUse-codex-runtime-lock"
+  local cause="Codex active VG run attempted to switch workflow entrypoint to Claude CLI"
+  local block_dir=".vg/blocks/${run_id:-unknown}"
+  local block_file="${block_dir}/${gate_id}.md"
+  mkdir -p "$block_dir" 2>/dev/null
+  {
+    echo "# Block diagnostic — ${gate_id}"
+    echo ""
+    echo "## Cause"
+    echo "$cause"
+    echo ""
+    echo "## Blocked command"
+    echo '```bash'
+    echo "$cmd_text"
+    echo '```'
+    echo ""
+    echo "## Required fix"
+    echo ""
+    echo "Do not abort a Codex VG run and relaunch /vg:* through Claude CLI."
+    echo ".claude/scripts and .claude/commands are canonical source paths, not"
+    echo "runtime ownership. Continue in Codex with:"
+    echo ""
+    echo '```bash'
+    echo "export VG_RUNTIME=codex"
+    echo "python3 .claude/scripts/vg-orchestrator run-status --pretty"
+    echo "python3 .claude/scripts/vg-orchestrator tasklist-projected --adapter codex"
+    echo '```'
+    echo ""
+    echo "Claude CLI remains allowed only as a configured CrossAI reviewer, not as"
+    echo "the primary /vg:* workflow entrypoint for this Codex session."
+  } > "$block_file"
+
+  printf "\033[38;5;208m%s: %s\033[0m\n→ Read %s for fix\n→ Continue current Codex run; do not relaunch /vg through Claude\n" \
+    "$gate_id" "$cause" "$block_file" >&2
+  exit 2
+}
+
 # HOTFIX session 2 (2026-05-05) — extend gate from step-active to ALSO
 # cover mark-step. Bug: AI could skip step-active entirely and call
 # mark-step directly to fake step completion without ever projecting
-# the tasklist. Both commands now require evidence file before they fire
-# (with same bootstrap-step exemption).
-if [[ ! "$cmd_text" =~ vg-orchestrator[[:space:]]+(step-active|mark-step) ]]; then
+# the tasklist. run-complete is covered too so a stale visible task UI
+# cannot be hidden at workflow close.
+if [[ ! "$cmd_text" =~ vg-orchestrator[[:space:]]+(step-active|mark-step|run-complete) ]]; then
+  if is_codex_claude_vg_entrypoint; then
+    emit_codex_claude_entrypoint_block
+  fi
   if codex_before_first_step && is_broad_codex_prestep_scan; then
     emit_codex_prestep_scope_block
   fi
@@ -309,10 +362,9 @@ if [[ "$cmd_text" =~ vg-orchestrator[[:space:]]+mark-step[[:space:]]+([A-Za-z0-9
   _early_evidence_path=".vg/runs/${run_id}/.tasklist-projected.evidence.json"
   if [ -f "$run_file" ] && [ -f "$_early_evidence_path" ]; then
     printf "VG TodoWrite reminder: after mark-step %s/%s succeeds, update native task UI: complete this step, set next pending in_progress, keep active group first.\\n" "$mark_step_ns" "$mark_step_name" >&2
-    exit 0
   fi
-  # Evidence missing — do NOT exit here, fall through to evidence gate
-  # below so unprojected tasklist blocks mark-step too.
+  # Do NOT exit here. Fall through to the evidence gate so mark-step still
+  # verifies HMAC/depth/adapter/run binding before it proceeds.
 fi
 
 if [ ! -f "$run_file" ]; then
@@ -694,6 +746,91 @@ case "$run_id_check_result" in
     emit_block "evidence missing run_id field — re-run TodoWrite + tasklist-projected to refresh signed evidence (additive Task 44b field)."
     ;;
   *) emit_block "run_id check failed: ${run_id_check_result}" ;;
+esac
+
+# HOTFIX task UI recency (2026-05-07) — evidence must reflect the latest
+# `mark-step`. Earlier hook behavior only printed a reminder after mark-step,
+# then allowed the next step to proceed with stale TodoWrite/update_plan UI.
+# This gate requires a fresh tasklist-projected evidence payload after the
+# latest step.marked event. Claude additionally proves TodoWrite marked that
+# sub-step completed via latest_marked_status_valid=true.
+tasklist_sync_check_result="ok"
+if [ -f ".vg/events.db" ]; then
+  tasklist_sync_check_result="$(VG_RUN_ID="${run_id}" VG_EV_PATH="$evidence_path" VG_DB_PATH=".vg/events.db" python3 - <<'PY'
+import json, os, sqlite3, sys
+from pathlib import Path
+
+run_id = os.environ["VG_RUN_ID"]
+ev_path = Path(os.environ["VG_EV_PATH"])
+db_path = Path(os.environ["VG_DB_PATH"])
+
+if not ev_path.exists() or not db_path.exists():
+    print("ok", end="")
+    sys.exit(0)
+
+conn = sqlite3.connect(str(db_path))
+try:
+    row = conn.execute(
+        "SELECT step, ts FROM events "
+        "WHERE run_id = ? AND event_type = 'step.marked' AND step IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+finally:
+    conn.close()
+
+if not row:
+    print("ok", end="")
+    sys.exit(0)
+
+latest_step, latest_ts = row
+try:
+    ev = json.loads(ev_path.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"sync_unreadable|{exc}", end="")
+    sys.exit(0)
+
+payload = ev.get("payload", {}) if isinstance(ev, dict) else {}
+if (
+    payload.get("latest_marked_step") != latest_step
+    or payload.get("latest_marked_at") != latest_ts
+):
+    print(
+        "sync_stale|"
+        f"latest={latest_step}@{latest_ts}|"
+        f"evidence={payload.get('latest_marked_step')}@{payload.get('latest_marked_at')}",
+        end="",
+    )
+    sys.exit(0)
+
+if payload.get("adapter") == "claude" and payload.get("latest_marked_status_valid") is not True:
+    print(
+        "sync_status_invalid|"
+        f"step={latest_step}|status={payload.get('latest_marked_status')}",
+        end="",
+    )
+    sys.exit(0)
+
+print("ok", end="")
+PY
+)"
+fi
+
+case "$tasklist_sync_check_result" in
+  ok) ;;
+  sync_stale*)
+    detail="${tasklist_sync_check_result#sync_stale|}"
+    emit_block "task UI is stale after latest mark-step (${detail}). Update TodoWrite/update_plan from tasklist-contract.json, then re-run tasklist-projected before continuing."
+    ;;
+  sync_status_invalid*)
+    detail="${tasklist_sync_check_result#sync_status_invalid|}"
+    emit_block "TodoWrite did not mark the latest completed step as completed (${detail}). Re-run TodoWrite with that sub-step completed, next sub-step in_progress, then re-run tasklist-projected."
+    ;;
+  sync_unreadable*)
+    detail="${tasklist_sync_check_result#sync_unreadable|}"
+    emit_block "tasklist evidence unreadable during sync check: ${detail}"
+    ;;
+  *) emit_block "tasklist sync check failed: ${tasklist_sync_check_result}" ;;
 esac
 
 # Task 44b — Rule V4: block.handled counter-check. Closes audit P1 (15+ PV3

--- a/.claude/scripts/hooks/vg-pre-tool-use-write.sh
+++ b/.claude/scripts/hooks/vg-pre-tool-use-write.sh
@@ -40,7 +40,55 @@ if [ -f "$run_file" ]; then
   run_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["run_id"])' "$run_file" 2>/dev/null || echo "")"
   if [ -n "$run_id" ]; then
     evidence_path=".vg/runs/${run_id}/.tasklist-projected.evidence.json"
+    tasklist_gate_cause=""
     if [ ! -f "$evidence_path" ]; then
+      tasklist_gate_cause="mutating tool blocked: tasklist not yet projected for run ${run_id}"
+    elif [ -f ".vg/events.db" ]; then
+      tasklist_sync_result="$(VG_RUN_ID="${run_id}" VG_EV_PATH="$evidence_path" VG_DB_PATH=".vg/events.db" python3 - <<'PY'
+import json, os, sqlite3, sys
+from pathlib import Path
+
+run_id = os.environ["VG_RUN_ID"]
+ev_path = Path(os.environ["VG_EV_PATH"])
+db_path = Path(os.environ["VG_DB_PATH"])
+
+try:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT step, ts FROM events "
+        "WHERE run_id = ? AND event_type = 'step.marked' AND step IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+    conn.close()
+except Exception:
+    row = None
+
+if not row:
+    print("ok", end="")
+    sys.exit(0)
+
+latest_step, latest_ts = row
+try:
+    payload = json.loads(ev_path.read_text(encoding="utf-8")).get("payload", {})
+except Exception as exc:
+    print(f"unreadable:{exc}", end="")
+    sys.exit(0)
+
+if payload.get("latest_marked_step") != latest_step or payload.get("latest_marked_at") != latest_ts:
+    print(f"stale after mark-step {latest_step}@{latest_ts}", end="")
+    sys.exit(0)
+if payload.get("adapter") == "claude" and payload.get("latest_marked_status_valid") is not True:
+    print(f"TodoWrite status stale for {latest_step}", end="")
+    sys.exit(0)
+print("ok", end="")
+PY
+)"
+      if [ "$tasklist_sync_result" != "ok" ]; then
+        tasklist_gate_cause="mutating tool blocked: task UI not refreshed (${tasklist_sync_result})"
+      fi
+    fi
+    if [ -n "$tasklist_gate_cause" ]; then
       # Whitelist: only allow writes under .vg/ when tasklist not yet projected.
       # AI can still run emit-tasklist.py preflight (writes contract under .vg/runs/)
       # and orchestrator state, but cannot edit code/specs/anything outside .vg/.
@@ -48,7 +96,7 @@ if [ -f "$run_file" ]; then
         gate_id="PreToolUse-Write-tasklist-required"
         block_dir=".vg/blocks/${run_id}"
         block_file="${block_dir}/${gate_id}.md"
-        cause="mutating tool blocked: tasklist not yet projected for run ${run_id}"
+        cause="$tasklist_gate_cause"
         mkdir -p "$block_dir" 2>/dev/null
         cat > "$block_file" <<EOF
 # Block diagnostic — ${gate_id}

--- a/.claude/scripts/tests/test_codex_mirror_equivalence.py
+++ b/.claude/scripts/tests/test_codex_mirror_equivalence.py
@@ -13,7 +13,13 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 VERIFIER = REPO_ROOT / "scripts" / "verify-codex-mirror-equivalence.py"
 SYNC_CMD = REPO_ROOT / "commands" / "vg" / "sync.md"
 SYNC_MIRROR = REPO_ROOT / "codex-skills" / "vg-sync" / "SKILL.md"

--- a/.claude/scripts/tests/test_hook_pretooluse_blocks.py
+++ b/.claude/scripts/tests/test_hook_pretooluse_blocks.py
@@ -46,6 +46,28 @@ def _seed_step_active_event(repo: Path):
     conn.commit()
     conn.close()
 
+def _seed_step_marked_event(repo: Path, step="2a_plan", ts="2026-05-04T00:01:00Z"):
+    db_path = repo / ".vg/events.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY,
+        run_id TEXT,
+        command TEXT,
+        event_type TEXT,
+        step TEXT,
+        ts TEXT,
+        payload_json TEXT,
+        actor TEXT,
+        outcome TEXT
+    )""")
+    conn.execute(
+        "INSERT INTO events(run_id, command, event_type, step, ts, payload_json, actor, outcome) VALUES (?,?,?,?,?,?,?,?)",
+        ("r1", "vg:blueprint", "step.marked", step, ts, "{}", "orchestrator", "INFO"),
+    )
+    conn.commit()
+    conn.close()
+
 
 def _run_hook(command: str, env=None):
     cmd_input = json.dumps({
@@ -142,6 +164,112 @@ def test_passes_when_evidence_signed_and_matches(tmp_path, monkeypatch):
     cmd_input = json.dumps({
         "tool_name": "Bash",
         "tool_input": {"command": "vg-orchestrator step-active 2a_plan"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+def test_blocks_when_tasklist_evidence_stale_after_mark_step(tmp_path, monkeypatch):
+    """Latest step.marked must be reflected in tasklist evidence before next step."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "old_step",
+            "latest_marked_at": "2026-05-04T00:00:00Z",
+            "latest_marked_status_valid": True,
+        },
+        key,
+    )
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 2
+    assert "task UI is stale" in result.stderr
+
+def test_blocks_when_claude_todowrite_latest_step_not_completed(tmp_path, monkeypatch):
+    """Claude evidence must show the latest marked sub-step as completed."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "2a_plan",
+            "latest_marked_at": "2026-05-04T00:01:00Z",
+            "latest_marked_status": "in_progress",
+            "latest_marked_status_valid": False,
+        },
+        key,
+    )
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 2
+    assert "did not mark the latest completed step" in result.stderr
+
+def test_passes_when_tasklist_evidence_synced_after_mark_step(tmp_path, monkeypatch):
+    """Fresh evidence can proceed after mark-step."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "2a_plan",
+            "latest_marked_at": "2026-05-04T00:01:00Z",
+            "latest_marked_status": "completed",
+            "latest_marked_status_valid": True,
+        },
+        key,
+    )
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
     })
     result = subprocess.run(
         ["bash", str(HOOK)],
@@ -328,4 +456,22 @@ def test_codex_prestep_scope_guard_does_not_affect_non_codex(tmp_path, monkeypat
     _seed_active_run(tmp_path)
     _seed_session_context(tmp_path)
     result = _run_hook("rg --files")
+    assert result.returncode == 0, result.stderr
+
+def test_codex_runtime_lock_blocks_claude_vg_entrypoint(tmp_path, monkeypatch):
+    """Codex active run must not relaunch /vg:* through Claude CLI."""
+    monkeypatch.chdir(tmp_path)
+    _seed_active_run(tmp_path)
+    _seed_session_context(tmp_path, current_step="phase2_browser_discovery")
+    result = _run_hook("claude -p '/vg:review 4.2 --scanner=haiku-only'", env={"VG_RUNTIME": "codex"})
+    assert result.returncode == 2
+    assert "PreToolUse-codex-runtime-lock" in result.stderr
+    assert (tmp_path / ".vg/blocks/r1/PreToolUse-codex-runtime-lock.md").exists()
+
+def test_codex_runtime_lock_allows_claude_crossai_non_vg_prompt(tmp_path, monkeypatch):
+    """CrossAI Claude CLI prompts remain allowed if they are not /vg entrypoints."""
+    monkeypatch.chdir(tmp_path)
+    _seed_active_run(tmp_path)
+    _seed_session_context(tmp_path, current_step="phase2_browser_discovery")
+    result = _run_hook("claude -p 'review this RUNTIME-MAP for gaps'", env={"VG_RUNTIME": "codex"})
     assert result.returncode == 0, result.stderr

--- a/.claude/scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py
+++ b/.claude/scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py
@@ -10,11 +10,19 @@ stale tasklist (observed PV3 build 4.2 dogfood 2026-05-05).
 Fix: hook fires non-blocking on mark-step bash and writes a stderr reminder.
 PreToolUse stdout JSON cannot include additionalContext on current runtimes.
 """
+import hashlib
+import hmac
 import json
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-bash.sh"
 
 
@@ -33,15 +41,40 @@ def _run_hook(tmp_path, cmd_text, session_id="test-sess", with_evidence=True):
                     "session_id": session_id})
     )
     if with_evidence:
+        key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+        key_path = tmp_path / ".vg/.evidence-key"
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_bytes(key)
+        key_path.chmod(0o600)
         (tmp_path / f".vg/runs/{run_id}").mkdir(parents=True, exist_ok=True)
+        contract_path = tmp_path / f".vg/runs/{run_id}/tasklist-contract.json"
+        contract_path.write_text(
+            json.dumps({"checklists": [{"id": "build_execute", "items": ["8_execute_waves"]}]}),
+            encoding="utf-8",
+        )
+        payload = {
+            "run_id": run_id,
+            "contract_sha256": hashlib.sha256(contract_path.read_bytes()).hexdigest(),
+            "depth_valid": True,
+            "match": True,
+            "adapter": "claude",
+            "todo_ids": ["build_execute"],
+            "contract_ids": ["build_execute"],
+        }
+        sig = hmac.new(key, json.dumps(payload, sort_keys=True).encode(), hashlib.sha256).hexdigest()
         (tmp_path / f".vg/runs/{run_id}/.tasklist-projected.evidence.json").write_text(
-            "{}"  # presence-only check at the early-out
+            json.dumps({"payload": payload, "hmac_sha256": sig}),
+            encoding="utf-8",
         )
     payload = json.dumps({"tool_input": {"command": cmd_text}})
     proc = subprocess.run(
         ["bash", str(HOOK)],
         input=payload, cwd=tmp_path, capture_output=True, text=True,
-        env={"CLAUDE_HOOK_SESSION_ID": session_id, "PATH": "/usr/bin:/bin"},
+        env={
+            "CLAUDE_HOOK_SESSION_ID": session_id,
+            "VG_EVIDENCE_KEY_PATH": str(tmp_path / ".vg/.evidence-key"),
+            "PATH": "/usr/bin:/bin",
+        },
     )
     return proc.returncode, proc.stdout, proc.stderr
 

--- a/.claude/scripts/tests/test_secrets_scan.py
+++ b/.claude/scripts/tests/test_secrets_scan.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[3]
-VALIDATOR = REPO_ROOT / ".claude" / "scripts" / "validators" / "secrets-scan.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = REPO_ROOT / "scripts" / "validators" / "secrets-scan.py"
 
 
 def _git_available() -> bool:

--- a/.claude/scripts/tests/test_tasklist_projected_claude_evidence_gate.py
+++ b/.claude/scripts/tests/test_tasklist_projected_claude_evidence_gate.py
@@ -16,7 +16,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 ORCH = REPO_ROOT / "scripts" / "vg-orchestrator" / "__main__.py"
 
 

--- a/.claude/scripts/tests/test_universal_mutating_tool_gate.py
+++ b/.claude/scripts/tests/test_universal_mutating_tool_gate.py
@@ -20,7 +20,13 @@ import shutil
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 WRITE_HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-write.sh"
 BASH_HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-bash.sh"
 

--- a/.claude/scripts/vg-orchestrator/__main__.py
+++ b/.claude/scripts/vg-orchestrator/__main__.py
@@ -859,6 +859,51 @@ def _ensure_evidence_key() -> bytes:
         raise ValueError(f"evidence key too short at {key_path}")
     return key
 
+def _latest_marked_step_event(run_id: str) -> dict | None:
+    """Return latest durable step marker event for this run, if any."""
+    events = db.query_events(run_id=run_id, event_type="step.marked", limit=10000)
+    if not events:
+        return None
+    for event in reversed(events):
+        if event.get("step"):
+            return event
+    return None
+
+def _tasklist_evidence_sync_verdict(
+    evidence_path: Path,
+    run_id: str,
+    *,
+    require_claude_status: bool = False,
+) -> tuple[bool, str]:
+    """Check task UI evidence is synced after the latest marked step."""
+    latest = _latest_marked_step_event(run_id)
+    if not latest:
+        return True, "ok"
+    try:
+        evidence_record = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return False, f"tasklist evidence unreadable: {exc}"
+    payload = evidence_record.get("payload", {}) if isinstance(evidence_record, dict) else {}
+    latest_step = latest.get("step")
+    latest_ts = latest.get("ts")
+    if (
+        payload.get("latest_marked_step") != latest_step
+        or payload.get("latest_marked_at") != latest_ts
+    ):
+        return (
+            False,
+            "tasklist evidence stale after latest mark-step "
+            f"{latest_step}@{latest_ts}; update the native task UI, then "
+            "re-run tasklist-projected",
+        )
+    if require_claude_status and payload.get("latest_marked_status_valid") is not True:
+        return (
+            False,
+            "TodoWrite evidence does not show latest marked step as completed: "
+            f"{latest_step} status={payload.get('latest_marked_status')!r}",
+        )
+    return True, "ok"
+
 
 def _write_tasklist_projection_evidence(
     run_id: str,
@@ -890,6 +935,9 @@ def _write_tasklist_projection_evidence(
         1 for c in checklists_in_contract if (c.get("items") or [])
     )
     depth_valid = (len(checklists_in_contract) > 0) and (len(flat_groups) == 0)
+    latest_marked = _latest_marked_step_event(run_id)
+    latest_marked_step = latest_marked.get("step") if latest_marked else None
+    latest_marked_at = latest_marked.get("ts") if latest_marked else None
     payload = {
         "run_id": run_id,
         "todowrite_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -902,6 +950,10 @@ def _write_tasklist_projection_evidence(
         "depth_valid": depth_valid,
         "groups_with_subs_count": groups_with_subs_count,
         "flat_groups": flat_groups,
+        "latest_marked_step": latest_marked_step,
+        "latest_marked_at": latest_marked_at,
+        "latest_marked_status": "projected_after_mark" if latest_marked else None,
+        "latest_marked_status_valid": True,
     }
     key = _ensure_evidence_key()
     canonical = json.dumps(payload, sort_keys=True).encode()
@@ -1184,6 +1236,21 @@ def cmd_tasklist_projected(args) -> int:
                 "  Fix: call the TodoWrite tool with one item per checklists[]\n"
                 "  row from tasklist-contract.json (with `↳` sub-items per\n"
                 "  group). Then re-run this command.",
+                file=sys.stderr,
+            )
+            return 2
+        sync_ok, sync_reason = _tasklist_evidence_sync_verdict(
+            evidence_path,
+            run_id,
+            require_claude_status=True,
+        )
+        if not sync_ok:
+            print("\033[38;5;208mTodoWrite evidence is stale.\033[0m", file=sys.stderr)
+            print(
+                f"  Reason: {sync_reason}\n\n"
+                "  Fix: call TodoWrite again from tasklist-contract.json, mark\n"
+                "  the latest completed sub-step as completed, set the next\n"
+                "  sub-step in_progress, then re-run this command.",
                 file=sys.stderr,
             )
             return 2

--- a/.codex/skills/api-contract/SKILL.md
+++ b/.codex/skills/api-contract/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/flow-codegen/SKILL.md
+++ b/.codex/skills/flow-codegen/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/flow-runner/SKILL.md
+++ b/.codex/skills/flow-runner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/flow-scan/SKILL.md
+++ b/.codex/skills/flow-scan/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/flow-spec/SKILL.md
+++ b/.codex/skills/flow-spec/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/sandbox-test/SKILL.md
+++ b/.codex/skills/sandbox-test/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/test-depth/SKILL.md
+++ b/.codex/skills/test-depth/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/test-gen/SKILL.md
+++ b/.codex/skills/test-gen/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/test-review/SKILL.md
+++ b/.codex/skills/test-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/test-scan/SKILL.md
+++ b/.codex/skills/test-scan/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-accept/SKILL.md
+++ b/.codex/skills/vg-accept/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-add-phase/SKILL.md
+++ b/.codex/skills/vg-add-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-amend/SKILL.md
+++ b/.codex/skills/vg-amend/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-blueprint/SKILL.md
+++ b/.codex/skills/vg-blueprint/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-bootstrap/SKILL.md
+++ b/.codex/skills/vg-bootstrap/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-bug-report/SKILL.md
+++ b/.codex/skills/vg-bug-report/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-build/SKILL.md
+++ b/.codex/skills/vg-build/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |
@@ -266,7 +279,13 @@ if [ "$IS_FINAL_WAVE" != "true" ]; then
   echo "  Post-execution markers (9_post_execution, 10_postmortem_sanity,"
   echo "  11_crossai_build_verify_loop, 12_run_complete) waived by"
   echo "  is_partial_wave exemption in contract validator."
-  echo "  Run \`/vg:build ${PHASE_NUMBER}\` (no --wave) for the FINAL wave to fire post-execution."
+  NEXT_BUILD_COMMAND=$("${PYTHON_BIN:-python3}" .claude/scripts/build-continuation.py show \
+    --phase-dir "${PHASE_DIR}" --field canonical_command 2>/dev/null || true)
+  if [ -n "$NEXT_BUILD_COMMAND" ]; then
+    echo "  Type 'tiếp tục' to resume, or run: ${NEXT_BUILD_COMMAND}"
+  else
+    echo "  Run \`/vg:build ${PHASE_NUMBER}\` (no --wave) for the FINAL wave to fire post-execution."
+  fi
   # Mark partial-wave run-complete (orchestrator emits run.completed with partial flag)
   "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete --partial-wave 2>/dev/null || \
     "${PYTHON_BIN:-python3}" .claude/scripts/vg-orchestrator run-complete 2>/dev/null || true

--- a/.codex/skills/vg-codegen-interactive/SKILL.md
+++ b/.codex/skills/vg-codegen-interactive/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-complete-milestone/SKILL.md
+++ b/.codex/skills/vg-complete-milestone/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-crossai/SKILL.md
+++ b/.codex/skills/vg-crossai/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-debug/SKILL.md
+++ b/.codex/skills/vg-debug/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-deploy/SKILL.md
+++ b/.codex/skills/vg-deploy/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-extract/SKILL.md
+++ b/.codex/skills/vg-design-extract/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-gap-hunter/SKILL.md
+++ b/.codex/skills/vg-design-gap-hunter/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-reverse/SKILL.md
+++ b/.codex/skills/vg-design-reverse/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-scaffold/SKILL.md
+++ b/.codex/skills/vg-design-scaffold/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-scanner/SKILL.md
+++ b/.codex/skills/vg-design-scanner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-design-system/SKILL.md
+++ b/.codex/skills/vg-design-system/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-doctor/SKILL.md
+++ b/.codex/skills/vg-doctor/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-extract-utils/SKILL.md
+++ b/.codex/skills/vg-extract-utils/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-gate-stats/SKILL.md
+++ b/.codex/skills/vg-gate-stats/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-haiku-scanner/SKILL.md
+++ b/.codex/skills/vg-haiku-scanner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-health/SKILL.md
+++ b/.codex/skills/vg-health/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-init/SKILL.md
+++ b/.codex/skills/vg-init/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-integrity/SKILL.md
+++ b/.codex/skills/vg-integrity/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-learn/SKILL.md
+++ b/.codex/skills/vg-learn/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-lesson/SKILL.md
+++ b/.codex/skills/vg-lesson/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-map/SKILL.md
+++ b/.codex/skills/vg-map/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-migrate-planning-vg/SKILL.md
+++ b/.codex/skills/vg-migrate-planning-vg/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-migrate-state/SKILL.md
+++ b/.codex/skills/vg-migrate-state/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-migrate/SKILL.md
+++ b/.codex/skills/vg-migrate/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-milestone-summary/SKILL.md
+++ b/.codex/skills/vg-milestone-summary/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-next/SKILL.md
+++ b/.codex/skills/vg-next/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-override-resolve/SKILL.md
+++ b/.codex/skills/vg-override-resolve/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-phase/SKILL.md
+++ b/.codex/skills/vg-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-polish/SKILL.md
+++ b/.codex/skills/vg-polish/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-prioritize/SKILL.md
+++ b/.codex/skills/vg-prioritize/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-progress/SKILL.md
+++ b/.codex/skills/vg-progress/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-project/SKILL.md
+++ b/.codex/skills/vg-project/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-reapply-patches/SKILL.md
+++ b/.codex/skills/vg-reapply-patches/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-recover/SKILL.md
+++ b/.codex/skills/vg-recover/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-reflector/SKILL.md
+++ b/.codex/skills/vg-reflector/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-regression/SKILL.md
+++ b/.codex/skills/vg-regression/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-remove-phase/SKILL.md
+++ b/.codex/skills/vg-remove-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-review-batch/SKILL.md
+++ b/.codex/skills/vg-review-batch/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-review/SKILL.md
+++ b/.codex/skills/vg-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-roadmap/SKILL.md
+++ b/.codex/skills/vg-roadmap/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-roam/SKILL.md
+++ b/.codex/skills/vg-roam/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-rule/SKILL.md
+++ b/.codex/skills/vg-rule/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-scope-review/SKILL.md
+++ b/.codex/skills/vg-scope-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-scope/SKILL.md
+++ b/.codex/skills/vg-scope/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-security-audit-milestone/SKILL.md
+++ b/.codex/skills/vg-security-audit-milestone/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-setup-mobile/SKILL.md
+++ b/.codex/skills/vg-setup-mobile/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-specs/SKILL.md
+++ b/.codex/skills/vg-specs/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-sync/SKILL.md
+++ b/.codex/skills/vg-sync/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-telemetry/SKILL.md
+++ b/.codex/skills/vg-telemetry/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-test/SKILL.md
+++ b/.codex/skills/vg-test/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-uninstall/SKILL.md
+++ b/.codex/skills/vg-uninstall/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-update/SKILL.md
+++ b/.codex/skills/vg-update/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/vg-validators/SKILL.md
+++ b/.codex/skills/vg-validators/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/.codex/skills/write-test-spec/SKILL.md
+++ b/.codex/skills/write-test-spec/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/api-contract/SKILL.md
+++ b/codex-skills/api-contract/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/flow-codegen/SKILL.md
+++ b/codex-skills/flow-codegen/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/flow-runner/SKILL.md
+++ b/codex-skills/flow-runner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/flow-scan/SKILL.md
+++ b/codex-skills/flow-scan/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/flow-spec/SKILL.md
+++ b/codex-skills/flow-spec/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/sandbox-test/SKILL.md
+++ b/codex-skills/sandbox-test/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/test-depth/SKILL.md
+++ b/codex-skills/test-depth/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/test-gen/SKILL.md
+++ b/codex-skills/test-gen/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/test-review/SKILL.md
+++ b/codex-skills/test-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/test-scan/SKILL.md
+++ b/codex-skills/test-scan/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-accept/SKILL.md
+++ b/codex-skills/vg-accept/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-add-phase/SKILL.md
+++ b/codex-skills/vg-add-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-amend/SKILL.md
+++ b/codex-skills/vg-amend/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-blueprint/SKILL.md
+++ b/codex-skills/vg-blueprint/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-bootstrap/SKILL.md
+++ b/codex-skills/vg-bootstrap/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-bug-report/SKILL.md
+++ b/codex-skills/vg-bug-report/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-build/SKILL.md
+++ b/codex-skills/vg-build/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-codegen-interactive/SKILL.md
+++ b/codex-skills/vg-codegen-interactive/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-complete-milestone/SKILL.md
+++ b/codex-skills/vg-complete-milestone/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-crossai/SKILL.md
+++ b/codex-skills/vg-crossai/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-debug/SKILL.md
+++ b/codex-skills/vg-debug/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-deploy/SKILL.md
+++ b/codex-skills/vg-deploy/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-extract/SKILL.md
+++ b/codex-skills/vg-design-extract/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-gap-hunter/SKILL.md
+++ b/codex-skills/vg-design-gap-hunter/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-reverse/SKILL.md
+++ b/codex-skills/vg-design-reverse/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-scaffold/SKILL.md
+++ b/codex-skills/vg-design-scaffold/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-scanner/SKILL.md
+++ b/codex-skills/vg-design-scanner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-design-system/SKILL.md
+++ b/codex-skills/vg-design-system/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-doctor/SKILL.md
+++ b/codex-skills/vg-doctor/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-extract-utils/SKILL.md
+++ b/codex-skills/vg-extract-utils/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-gate-stats/SKILL.md
+++ b/codex-skills/vg-gate-stats/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-haiku-scanner/SKILL.md
+++ b/codex-skills/vg-haiku-scanner/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-health/SKILL.md
+++ b/codex-skills/vg-health/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-init/SKILL.md
+++ b/codex-skills/vg-init/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-integrity/SKILL.md
+++ b/codex-skills/vg-integrity/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-learn/SKILL.md
+++ b/codex-skills/vg-learn/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-lesson/SKILL.md
+++ b/codex-skills/vg-lesson/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-map/SKILL.md
+++ b/codex-skills/vg-map/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-migrate-planning-vg/SKILL.md
+++ b/codex-skills/vg-migrate-planning-vg/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-migrate-state/SKILL.md
+++ b/codex-skills/vg-migrate-state/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-migrate/SKILL.md
+++ b/codex-skills/vg-migrate/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-milestone-summary/SKILL.md
+++ b/codex-skills/vg-milestone-summary/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-next/SKILL.md
+++ b/codex-skills/vg-next/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-override-resolve/SKILL.md
+++ b/codex-skills/vg-override-resolve/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-phase/SKILL.md
+++ b/codex-skills/vg-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-polish/SKILL.md
+++ b/codex-skills/vg-polish/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-prioritize/SKILL.md
+++ b/codex-skills/vg-prioritize/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-progress/SKILL.md
+++ b/codex-skills/vg-progress/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-project/SKILL.md
+++ b/codex-skills/vg-project/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-reapply-patches/SKILL.md
+++ b/codex-skills/vg-reapply-patches/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-recover/SKILL.md
+++ b/codex-skills/vg-recover/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-reflector/SKILL.md
+++ b/codex-skills/vg-reflector/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-regression/SKILL.md
+++ b/codex-skills/vg-regression/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-remove-phase/SKILL.md
+++ b/codex-skills/vg-remove-phase/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-review-batch/SKILL.md
+++ b/codex-skills/vg-review-batch/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-review/SKILL.md
+++ b/codex-skills/vg-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-roadmap/SKILL.md
+++ b/codex-skills/vg-roadmap/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-roam/SKILL.md
+++ b/codex-skills/vg-roam/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-rule/SKILL.md
+++ b/codex-skills/vg-rule/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-scope-review/SKILL.md
+++ b/codex-skills/vg-scope-review/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-scope/SKILL.md
+++ b/codex-skills/vg-scope/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-security-audit-milestone/SKILL.md
+++ b/codex-skills/vg-security-audit-milestone/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-setup-mobile/SKILL.md
+++ b/codex-skills/vg-setup-mobile/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-specs/SKILL.md
+++ b/codex-skills/vg-specs/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-sync/SKILL.md
+++ b/codex-skills/vg-sync/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-telemetry/SKILL.md
+++ b/codex-skills/vg-telemetry/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-test/SKILL.md
+++ b/codex-skills/vg-test/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-uninstall/SKILL.md
+++ b/codex-skills/vg-uninstall/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-update/SKILL.md
+++ b/codex-skills/vg-update/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/vg-validators/SKILL.md
+++ b/codex-skills/vg-validators/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/codex-skills/write-test-spec/SKILL.md
+++ b/codex-skills/write-test-spec/SKILL.md
@@ -11,6 +11,19 @@ metadata:
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+`VG_RUNTIME=codex`, use Codex `update_plan` for the compact visible task
+window, and bind it with `vg-orchestrator tasklist-projected --adapter codex`.
+
+`.claude/scripts/*` and `.claude/commands/*` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", `TodoWrite`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/commands/vg/_shared/blueprint/preflight.md
+++ b/commands/vg/_shared/blueprint/preflight.md
@@ -350,6 +350,10 @@ Per sub-step lifecycle:
 - BEFORE sub-step work: set its sub-step todo `in_progress`. Group header
   stays `in_progress` while ANY of its sub-steps is pending/active.
 - AFTER `mark-step` writes marker: set sub-step todo `completed`.
+- AFTER any `vg-orchestrator mark-step`: refresh the runtime-native task UI
+  before the next `step-active`, `mark-step`, `run-complete`, or code edit.
+  Claude must call TodoWrite again; Codex must update compact `update_plan`
+  and re-run `tasklist-projected --adapter codex`.
 - When ALL sub-steps in a group are `completed`: set group header todo `completed`.
 - On run-complete: clear projected tasklist per `close-on-complete`.
 

--- a/commands/vg/_shared/build/preflight.md
+++ b/commands/vg/_shared/build/preflight.md
@@ -340,6 +340,10 @@ Per sub-step lifecycle:
 - BEFORE sub-step work: set its sub-step todo `in_progress`. Group header
   stays `in_progress` while ANY of its sub-steps is pending/active.
 - AFTER `mark-step` writes marker: set sub-step todo `completed`.
+- AFTER any `vg-orchestrator mark-step`: refresh the runtime-native task UI
+  before the next `step-active`, `mark-step`, `run-complete`, or code edit.
+  Claude must call TodoWrite again; Codex must update compact `update_plan`
+  and re-run `tasklist-projected --adapter codex`.
 - When ALL sub-steps in a group are `completed`: set group header todo `completed`.
 - On run-complete: clear projected tasklist per `close-on-complete`.
 

--- a/scripts/generate-codex-skills.sh
+++ b/scripts/generate-codex-skills.sh
@@ -75,6 +75,19 @@ write_generic_adapter() {
 This skill body is generated from VGFlow's canonical source. Claude Code and
 Codex use the same workflow contracts, but their orchestration primitives differ.
 
+### Runtime lock
+
+When this skill is running inside Codex, DO NOT switch to Claude CLI to execute
+the workflow entrypoint. Keep the current Codex runtime, export
+\`VG_RUNTIME=codex\`, use Codex \`update_plan\` for the compact visible task
+window, and bind it with \`vg-orchestrator tasklist-projected --adapter codex\`.
+
+\`.claude/scripts/*\` and \`.claude/commands/*\` are canonical VGFlow source
+paths shared by both adapters; those paths do not mean the runtime changed to
+Claude. References below to "Claude CLI", \`TodoWrite\`, or Haiku describe the
+Claude adapter only. Codex must map them through this adapter contract instead
+of aborting the current run and relaunching Claude.
+
 ### Tool mapping
 
 | Claude Code concept | Codex-compatible pattern | Notes |

--- a/scripts/hooks/vg-post-tool-use-todowrite.sh
+++ b/scripts/hooks/vg-post-tool-use-todowrite.sh
@@ -20,13 +20,15 @@ fi
 # Build evidence payload from TodoWrite input + contract.
 # NOTE: pass hook input via env var (VG_HOOK_INPUT) — heredoc consumes stdin.
 payload="$(VG_HOOK_INPUT="$input" python3 - "$contract_path" "$run_id" <<'PY'
-import hashlib, json, os, sys
+import hashlib, json, os, sqlite3, sys
+from pathlib import Path
 from datetime import datetime, timezone
 contract_path, run_id = sys.argv[1:]
 hook_input = json.loads(os.environ.get("VG_HOOK_INPUT", "{}"))
 todos = hook_input.get("tool_input", {}).get("todos", [])
 contract = json.loads(open(contract_path).read())
 checklists = contract.get("checklists", [])
+projection_items = contract.get("projection_items", []) or []
 
 # Tolerant match: each contract checklist matched if any group-header todo
 # content contains its id or its title. Allows AI to format group content
@@ -73,8 +75,44 @@ flat_groups = [gid for gid, n in sub_counts.items() if n == 0]
 groups_with_subs_count = sum(1 for n in sub_counts.values() if n >= 1)
 depth_valid = (len(matched_ids) > 0) and (len(flat_groups) == 0)
 
+latest_marked_step = None
+latest_marked_at = None
+latest_marked_status = None
+latest_marked_status_valid = True
+db_path = Path(".vg/events.db")
+if db_path.exists():
+    try:
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT step, ts FROM events "
+            "WHERE run_id = ? AND event_type = 'step.marked' "
+            "ORDER BY id DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+        conn.close()
+    except Exception:
+        row = None
+    if row and row[0]:
+        latest_marked_step = row[0]
+        latest_marked_at = row[1]
+        accepted = {latest_marked_step}
+        for item in projection_items:
+            if item.get("kind") == "step" and item.get("id") == latest_marked_step:
+                title = str(item.get("title") or "").strip()
+                if title:
+                    accepted.add(title)
+                    accepted.add(title.lstrip(" ↳").strip())
+        latest_marked_status_valid = False
+        for todo in todos:
+            content = str(todo.get("content") or "")
+            if any(token and token in content for token in accepted):
+                latest_marked_status = str(todo.get("status") or "")
+                latest_marked_status_valid = latest_marked_status == "completed"
+                break
+
 payload = {
     "run_id": run_id,
+    "adapter": "claude",
     "todowrite_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     "todo_count": len(todos),
     "contract_sha256": hashlib.sha256(open(contract_path, "rb").read()).hexdigest(),
@@ -84,6 +122,10 @@ payload = {
     "depth_valid": depth_valid,
     "groups_with_subs_count": groups_with_subs_count,
     "flat_groups": sorted(flat_groups),
+    "latest_marked_step": latest_marked_step,
+    "latest_marked_at": latest_marked_at,
+    "latest_marked_status": latest_marked_status,
+    "latest_marked_status_valid": latest_marked_status_valid,
 }
 print(json.dumps(payload))
 PY

--- a/scripts/hooks/vg-pre-tool-use-bash.sh
+++ b/scripts/hooks/vg-pre-tool-use-bash.sh
@@ -276,12 +276,65 @@ emit_codex_pretasklist_scope_block() {
   exit 2
 }
 
+is_codex_claude_vg_entrypoint() {
+  [ "${VG_RUNTIME:-}" = "codex" ] || return 1
+  [ -n "${run_id:-}" ] || return 1
+  case "$command_from_run" in
+    vg:*) ;;
+    *) return 1 ;;
+  esac
+  [[ "$cmd_text" =~ (^|[[:space:];|&])claude([[:space:]]|$) ]] || return 1
+  [[ "$cmd_text" =~ /vg: ]] || return 1
+  return 0
+}
+
+emit_codex_claude_entrypoint_block() {
+  local gate_id="PreToolUse-codex-runtime-lock"
+  local cause="Codex active VG run attempted to switch workflow entrypoint to Claude CLI"
+  local block_dir=".vg/blocks/${run_id:-unknown}"
+  local block_file="${block_dir}/${gate_id}.md"
+  mkdir -p "$block_dir" 2>/dev/null
+  {
+    echo "# Block diagnostic — ${gate_id}"
+    echo ""
+    echo "## Cause"
+    echo "$cause"
+    echo ""
+    echo "## Blocked command"
+    echo '```bash'
+    echo "$cmd_text"
+    echo '```'
+    echo ""
+    echo "## Required fix"
+    echo ""
+    echo "Do not abort a Codex VG run and relaunch /vg:* through Claude CLI."
+    echo ".claude/scripts and .claude/commands are canonical source paths, not"
+    echo "runtime ownership. Continue in Codex with:"
+    echo ""
+    echo '```bash'
+    echo "export VG_RUNTIME=codex"
+    echo "python3 .claude/scripts/vg-orchestrator run-status --pretty"
+    echo "python3 .claude/scripts/vg-orchestrator tasklist-projected --adapter codex"
+    echo '```'
+    echo ""
+    echo "Claude CLI remains allowed only as a configured CrossAI reviewer, not as"
+    echo "the primary /vg:* workflow entrypoint for this Codex session."
+  } > "$block_file"
+
+  printf "\033[38;5;208m%s: %s\033[0m\n→ Read %s for fix\n→ Continue current Codex run; do not relaunch /vg through Claude\n" \
+    "$gate_id" "$cause" "$block_file" >&2
+  exit 2
+}
+
 # HOTFIX session 2 (2026-05-05) — extend gate from step-active to ALSO
 # cover mark-step. Bug: AI could skip step-active entirely and call
 # mark-step directly to fake step completion without ever projecting
-# the tasklist. Both commands now require evidence file before they fire
-# (with same bootstrap-step exemption).
-if [[ ! "$cmd_text" =~ vg-orchestrator[[:space:]]+(step-active|mark-step) ]]; then
+# the tasklist. run-complete is covered too so a stale visible task UI
+# cannot be hidden at workflow close.
+if [[ ! "$cmd_text" =~ vg-orchestrator[[:space:]]+(step-active|mark-step|run-complete) ]]; then
+  if is_codex_claude_vg_entrypoint; then
+    emit_codex_claude_entrypoint_block
+  fi
   if codex_before_first_step && is_broad_codex_prestep_scan; then
     emit_codex_prestep_scope_block
   fi
@@ -309,10 +362,9 @@ if [[ "$cmd_text" =~ vg-orchestrator[[:space:]]+mark-step[[:space:]]+([A-Za-z0-9
   _early_evidence_path=".vg/runs/${run_id}/.tasklist-projected.evidence.json"
   if [ -f "$run_file" ] && [ -f "$_early_evidence_path" ]; then
     printf "VG TodoWrite reminder: after mark-step %s/%s succeeds, update native task UI: complete this step, set next pending in_progress, keep active group first.\\n" "$mark_step_ns" "$mark_step_name" >&2
-    exit 0
   fi
-  # Evidence missing — do NOT exit here, fall through to evidence gate
-  # below so unprojected tasklist blocks mark-step too.
+  # Do NOT exit here. Fall through to the evidence gate so mark-step still
+  # verifies HMAC/depth/adapter/run binding before it proceeds.
 fi
 
 if [ ! -f "$run_file" ]; then
@@ -694,6 +746,91 @@ case "$run_id_check_result" in
     emit_block "evidence missing run_id field — re-run TodoWrite + tasklist-projected to refresh signed evidence (additive Task 44b field)."
     ;;
   *) emit_block "run_id check failed: ${run_id_check_result}" ;;
+esac
+
+# HOTFIX task UI recency (2026-05-07) — evidence must reflect the latest
+# `mark-step`. Earlier hook behavior only printed a reminder after mark-step,
+# then allowed the next step to proceed with stale TodoWrite/update_plan UI.
+# This gate requires a fresh tasklist-projected evidence payload after the
+# latest step.marked event. Claude additionally proves TodoWrite marked that
+# sub-step completed via latest_marked_status_valid=true.
+tasklist_sync_check_result="ok"
+if [ -f ".vg/events.db" ]; then
+  tasklist_sync_check_result="$(VG_RUN_ID="${run_id}" VG_EV_PATH="$evidence_path" VG_DB_PATH=".vg/events.db" python3 - <<'PY'
+import json, os, sqlite3, sys
+from pathlib import Path
+
+run_id = os.environ["VG_RUN_ID"]
+ev_path = Path(os.environ["VG_EV_PATH"])
+db_path = Path(os.environ["VG_DB_PATH"])
+
+if not ev_path.exists() or not db_path.exists():
+    print("ok", end="")
+    sys.exit(0)
+
+conn = sqlite3.connect(str(db_path))
+try:
+    row = conn.execute(
+        "SELECT step, ts FROM events "
+        "WHERE run_id = ? AND event_type = 'step.marked' AND step IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+finally:
+    conn.close()
+
+if not row:
+    print("ok", end="")
+    sys.exit(0)
+
+latest_step, latest_ts = row
+try:
+    ev = json.loads(ev_path.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"sync_unreadable|{exc}", end="")
+    sys.exit(0)
+
+payload = ev.get("payload", {}) if isinstance(ev, dict) else {}
+if (
+    payload.get("latest_marked_step") != latest_step
+    or payload.get("latest_marked_at") != latest_ts
+):
+    print(
+        "sync_stale|"
+        f"latest={latest_step}@{latest_ts}|"
+        f"evidence={payload.get('latest_marked_step')}@{payload.get('latest_marked_at')}",
+        end="",
+    )
+    sys.exit(0)
+
+if payload.get("adapter") == "claude" and payload.get("latest_marked_status_valid") is not True:
+    print(
+        "sync_status_invalid|"
+        f"step={latest_step}|status={payload.get('latest_marked_status')}",
+        end="",
+    )
+    sys.exit(0)
+
+print("ok", end="")
+PY
+)"
+fi
+
+case "$tasklist_sync_check_result" in
+  ok) ;;
+  sync_stale*)
+    detail="${tasklist_sync_check_result#sync_stale|}"
+    emit_block "task UI is stale after latest mark-step (${detail}). Update TodoWrite/update_plan from tasklist-contract.json, then re-run tasklist-projected before continuing."
+    ;;
+  sync_status_invalid*)
+    detail="${tasklist_sync_check_result#sync_status_invalid|}"
+    emit_block "TodoWrite did not mark the latest completed step as completed (${detail}). Re-run TodoWrite with that sub-step completed, next sub-step in_progress, then re-run tasklist-projected."
+    ;;
+  sync_unreadable*)
+    detail="${tasklist_sync_check_result#sync_unreadable|}"
+    emit_block "tasklist evidence unreadable during sync check: ${detail}"
+    ;;
+  *) emit_block "tasklist sync check failed: ${tasklist_sync_check_result}" ;;
 esac
 
 # Task 44b — Rule V4: block.handled counter-check. Closes audit P1 (15+ PV3

--- a/scripts/hooks/vg-pre-tool-use-write.sh
+++ b/scripts/hooks/vg-pre-tool-use-write.sh
@@ -40,7 +40,55 @@ if [ -f "$run_file" ]; then
   run_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["run_id"])' "$run_file" 2>/dev/null || echo "")"
   if [ -n "$run_id" ]; then
     evidence_path=".vg/runs/${run_id}/.tasklist-projected.evidence.json"
+    tasklist_gate_cause=""
     if [ ! -f "$evidence_path" ]; then
+      tasklist_gate_cause="mutating tool blocked: tasklist not yet projected for run ${run_id}"
+    elif [ -f ".vg/events.db" ]; then
+      tasklist_sync_result="$(VG_RUN_ID="${run_id}" VG_EV_PATH="$evidence_path" VG_DB_PATH=".vg/events.db" python3 - <<'PY'
+import json, os, sqlite3, sys
+from pathlib import Path
+
+run_id = os.environ["VG_RUN_ID"]
+ev_path = Path(os.environ["VG_EV_PATH"])
+db_path = Path(os.environ["VG_DB_PATH"])
+
+try:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT step, ts FROM events "
+        "WHERE run_id = ? AND event_type = 'step.marked' AND step IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+    conn.close()
+except Exception:
+    row = None
+
+if not row:
+    print("ok", end="")
+    sys.exit(0)
+
+latest_step, latest_ts = row
+try:
+    payload = json.loads(ev_path.read_text(encoding="utf-8")).get("payload", {})
+except Exception as exc:
+    print(f"unreadable:{exc}", end="")
+    sys.exit(0)
+
+if payload.get("latest_marked_step") != latest_step or payload.get("latest_marked_at") != latest_ts:
+    print(f"stale after mark-step {latest_step}@{latest_ts}", end="")
+    sys.exit(0)
+if payload.get("adapter") == "claude" and payload.get("latest_marked_status_valid") is not True:
+    print(f"TodoWrite status stale for {latest_step}", end="")
+    sys.exit(0)
+print("ok", end="")
+PY
+)"
+      if [ "$tasklist_sync_result" != "ok" ]; then
+        tasklist_gate_cause="mutating tool blocked: task UI not refreshed (${tasklist_sync_result})"
+      fi
+    fi
+    if [ -n "$tasklist_gate_cause" ]; then
       # Whitelist: only allow writes under .vg/ when tasklist not yet projected.
       # AI can still run emit-tasklist.py preflight (writes contract under .vg/runs/)
       # and orchestrator state, but cannot edit code/specs/anything outside .vg/.
@@ -48,7 +96,7 @@ if [ -f "$run_file" ]; then
         gate_id="PreToolUse-Write-tasklist-required"
         block_dir=".vg/blocks/${run_id}"
         block_file="${block_dir}/${gate_id}.md"
-        cause="mutating tool blocked: tasklist not yet projected for run ${run_id}"
+        cause="$tasklist_gate_cause"
         mkdir -p "$block_dir" 2>/dev/null
         cat > "$block_file" <<EOF
 # Block diagnostic — ${gate_id}

--- a/scripts/tests/test_codex_mirror_equivalence.py
+++ b/scripts/tests/test_codex_mirror_equivalence.py
@@ -13,7 +13,13 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 VERIFIER = REPO_ROOT / "scripts" / "verify-codex-mirror-equivalence.py"
 SYNC_CMD = REPO_ROOT / "commands" / "vg" / "sync.md"
 SYNC_MIRROR = REPO_ROOT / "codex-skills" / "vg-sync" / "SKILL.md"

--- a/scripts/tests/test_hook_pretooluse_blocks.py
+++ b/scripts/tests/test_hook_pretooluse_blocks.py
@@ -46,6 +46,28 @@ def _seed_step_active_event(repo: Path):
     conn.commit()
     conn.close()
 
+def _seed_step_marked_event(repo: Path, step="2a_plan", ts="2026-05-04T00:01:00Z"):
+    db_path = repo / ".vg/events.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY,
+        run_id TEXT,
+        command TEXT,
+        event_type TEXT,
+        step TEXT,
+        ts TEXT,
+        payload_json TEXT,
+        actor TEXT,
+        outcome TEXT
+    )""")
+    conn.execute(
+        "INSERT INTO events(run_id, command, event_type, step, ts, payload_json, actor, outcome) VALUES (?,?,?,?,?,?,?,?)",
+        ("r1", "vg:blueprint", "step.marked", step, ts, "{}", "orchestrator", "INFO"),
+    )
+    conn.commit()
+    conn.close()
+
 
 def _run_hook(command: str, env=None):
     cmd_input = json.dumps({
@@ -142,6 +164,112 @@ def test_passes_when_evidence_signed_and_matches(tmp_path, monkeypatch):
     cmd_input = json.dumps({
         "tool_name": "Bash",
         "tool_input": {"command": "vg-orchestrator step-active 2a_plan"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+def test_blocks_when_tasklist_evidence_stale_after_mark_step(tmp_path, monkeypatch):
+    """Latest step.marked must be reflected in tasklist evidence before next step."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "old_step",
+            "latest_marked_at": "2026-05-04T00:00:00Z",
+            "latest_marked_status_valid": True,
+        },
+        key,
+    )
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 2
+    assert "task UI is stale" in result.stderr
+
+def test_blocks_when_claude_todowrite_latest_step_not_completed(tmp_path, monkeypatch):
+    """Claude evidence must show the latest marked sub-step as completed."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "2a_plan",
+            "latest_marked_at": "2026-05-04T00:01:00Z",
+            "latest_marked_status": "in_progress",
+            "latest_marked_status_valid": False,
+        },
+        key,
+    )
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
+    })
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input=cmd_input, capture_output=True, text=True,
+        env={**os.environ, "CLAUDE_HOOK_SESSION_ID": "sess-1"},
+    )
+    assert result.returncode == 2
+    assert "did not mark the latest completed step" in result.stderr
+
+def test_passes_when_tasklist_evidence_synced_after_mark_step(tmp_path, monkeypatch):
+    """Fresh evidence can proceed after mark-step."""
+    monkeypatch.chdir(tmp_path)
+    key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+    key_path = tmp_path / ".vg/.evidence-key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(key)
+    key_path.chmod(0o600)
+    monkeypatch.setenv("VG_EVIDENCE_KEY_PATH", str(key_path))
+    _seed_active_run(tmp_path)
+    contract_path = _seed_contract(tmp_path)
+    contract_sha = hashlib.sha256(contract_path.read_bytes()).hexdigest()
+    _seed_step_marked_event(tmp_path, step="2a_plan", ts="2026-05-04T00:01:00Z")
+    _seed_signed_evidence(
+        tmp_path,
+        {
+            "contract_sha256": contract_sha,
+            "latest_marked_step": "2a_plan",
+            "latest_marked_at": "2026-05-04T00:01:00Z",
+            "latest_marked_status": "completed",
+            "latest_marked_status_valid": True,
+        },
+        key,
+    )
+    cmd_input = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": "vg-orchestrator step-active 2b_contracts"},
     })
     result = subprocess.run(
         ["bash", str(HOOK)],
@@ -328,4 +456,22 @@ def test_codex_prestep_scope_guard_does_not_affect_non_codex(tmp_path, monkeypat
     _seed_active_run(tmp_path)
     _seed_session_context(tmp_path)
     result = _run_hook("rg --files")
+    assert result.returncode == 0, result.stderr
+
+def test_codex_runtime_lock_blocks_claude_vg_entrypoint(tmp_path, monkeypatch):
+    """Codex active run must not relaunch /vg:* through Claude CLI."""
+    monkeypatch.chdir(tmp_path)
+    _seed_active_run(tmp_path)
+    _seed_session_context(tmp_path, current_step="phase2_browser_discovery")
+    result = _run_hook("claude -p '/vg:review 4.2 --scanner=haiku-only'", env={"VG_RUNTIME": "codex"})
+    assert result.returncode == 2
+    assert "PreToolUse-codex-runtime-lock" in result.stderr
+    assert (tmp_path / ".vg/blocks/r1/PreToolUse-codex-runtime-lock.md").exists()
+
+def test_codex_runtime_lock_allows_claude_crossai_non_vg_prompt(tmp_path, monkeypatch):
+    """CrossAI Claude CLI prompts remain allowed if they are not /vg entrypoints."""
+    monkeypatch.chdir(tmp_path)
+    _seed_active_run(tmp_path)
+    _seed_session_context(tmp_path, current_step="phase2_browser_discovery")
+    result = _run_hook("claude -p 'review this RUNTIME-MAP for gaps'", env={"VG_RUNTIME": "codex"})
     assert result.returncode == 0, result.stderr

--- a/scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py
+++ b/scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py
@@ -10,11 +10,19 @@ stale tasklist (observed PV3 build 4.2 dogfood 2026-05-05).
 Fix: hook fires non-blocking on mark-step bash and writes a stderr reminder.
 PreToolUse stdout JSON cannot include additionalContext on current runtimes.
 """
+import hashlib
+import hmac
 import json
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-bash.sh"
 
 
@@ -33,15 +41,40 @@ def _run_hook(tmp_path, cmd_text, session_id="test-sess", with_evidence=True):
                     "session_id": session_id})
     )
     if with_evidence:
+        key = b"test-key-32-bytes-aaaaaaaaaaaaaaa"
+        key_path = tmp_path / ".vg/.evidence-key"
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_bytes(key)
+        key_path.chmod(0o600)
         (tmp_path / f".vg/runs/{run_id}").mkdir(parents=True, exist_ok=True)
+        contract_path = tmp_path / f".vg/runs/{run_id}/tasklist-contract.json"
+        contract_path.write_text(
+            json.dumps({"checklists": [{"id": "build_execute", "items": ["8_execute_waves"]}]}),
+            encoding="utf-8",
+        )
+        payload = {
+            "run_id": run_id,
+            "contract_sha256": hashlib.sha256(contract_path.read_bytes()).hexdigest(),
+            "depth_valid": True,
+            "match": True,
+            "adapter": "claude",
+            "todo_ids": ["build_execute"],
+            "contract_ids": ["build_execute"],
+        }
+        sig = hmac.new(key, json.dumps(payload, sort_keys=True).encode(), hashlib.sha256).hexdigest()
         (tmp_path / f".vg/runs/{run_id}/.tasklist-projected.evidence.json").write_text(
-            "{}"  # presence-only check at the early-out
+            json.dumps({"payload": payload, "hmac_sha256": sig}),
+            encoding="utf-8",
         )
     payload = json.dumps({"tool_input": {"command": cmd_text}})
     proc = subprocess.run(
         ["bash", str(HOOK)],
         input=payload, cwd=tmp_path, capture_output=True, text=True,
-        env={"CLAUDE_HOOK_SESSION_ID": session_id, "PATH": "/usr/bin:/bin"},
+        env={
+            "CLAUDE_HOOK_SESSION_ID": session_id,
+            "VG_EVIDENCE_KEY_PATH": str(tmp_path / ".vg/.evidence-key"),
+            "PATH": "/usr/bin:/bin",
+        },
     )
     return proc.returncode, proc.stdout, proc.stderr
 

--- a/scripts/tests/test_tasklist_projected_claude_evidence_gate.py
+++ b/scripts/tests/test_tasklist_projected_claude_evidence_gate.py
@@ -16,7 +16,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 ORCH = REPO_ROOT / "scripts" / "vg-orchestrator" / "__main__.py"
 
 

--- a/scripts/tests/test_universal_mutating_tool_gate.py
+++ b/scripts/tests/test_universal_mutating_tool_gate.py
@@ -20,7 +20,13 @@ import shutil
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts").is_dir() and (parent / "commands").is_dir() and (parent / "codex-skills").is_dir():
+            return parent
+    return Path(__file__).resolve().parents[2]
+
+REPO_ROOT = _repo_root()
 WRITE_HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-write.sh"
 BASH_HOOK = REPO_ROOT / "scripts" / "hooks" / "vg-pre-tool-use-bash.sh"
 

--- a/scripts/vg-orchestrator/__main__.py
+++ b/scripts/vg-orchestrator/__main__.py
@@ -859,6 +859,51 @@ def _ensure_evidence_key() -> bytes:
         raise ValueError(f"evidence key too short at {key_path}")
     return key
 
+def _latest_marked_step_event(run_id: str) -> dict | None:
+    """Return latest durable step marker event for this run, if any."""
+    events = db.query_events(run_id=run_id, event_type="step.marked", limit=10000)
+    if not events:
+        return None
+    for event in reversed(events):
+        if event.get("step"):
+            return event
+    return None
+
+def _tasklist_evidence_sync_verdict(
+    evidence_path: Path,
+    run_id: str,
+    *,
+    require_claude_status: bool = False,
+) -> tuple[bool, str]:
+    """Check task UI evidence is synced after the latest marked step."""
+    latest = _latest_marked_step_event(run_id)
+    if not latest:
+        return True, "ok"
+    try:
+        evidence_record = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return False, f"tasklist evidence unreadable: {exc}"
+    payload = evidence_record.get("payload", {}) if isinstance(evidence_record, dict) else {}
+    latest_step = latest.get("step")
+    latest_ts = latest.get("ts")
+    if (
+        payload.get("latest_marked_step") != latest_step
+        or payload.get("latest_marked_at") != latest_ts
+    ):
+        return (
+            False,
+            "tasklist evidence stale after latest mark-step "
+            f"{latest_step}@{latest_ts}; update the native task UI, then "
+            "re-run tasklist-projected",
+        )
+    if require_claude_status and payload.get("latest_marked_status_valid") is not True:
+        return (
+            False,
+            "TodoWrite evidence does not show latest marked step as completed: "
+            f"{latest_step} status={payload.get('latest_marked_status')!r}",
+        )
+    return True, "ok"
+
 
 def _write_tasklist_projection_evidence(
     run_id: str,
@@ -890,6 +935,9 @@ def _write_tasklist_projection_evidence(
         1 for c in checklists_in_contract if (c.get("items") or [])
     )
     depth_valid = (len(checklists_in_contract) > 0) and (len(flat_groups) == 0)
+    latest_marked = _latest_marked_step_event(run_id)
+    latest_marked_step = latest_marked.get("step") if latest_marked else None
+    latest_marked_at = latest_marked.get("ts") if latest_marked else None
     payload = {
         "run_id": run_id,
         "todowrite_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -902,6 +950,10 @@ def _write_tasklist_projection_evidence(
         "depth_valid": depth_valid,
         "groups_with_subs_count": groups_with_subs_count,
         "flat_groups": flat_groups,
+        "latest_marked_step": latest_marked_step,
+        "latest_marked_at": latest_marked_at,
+        "latest_marked_status": "projected_after_mark" if latest_marked else None,
+        "latest_marked_status_valid": True,
     }
     key = _ensure_evidence_key()
     canonical = json.dumps(payload, sort_keys=True).encode()
@@ -1184,6 +1236,21 @@ def cmd_tasklist_projected(args) -> int:
                 "  Fix: call the TodoWrite tool with one item per checklists[]\n"
                 "  row from tasklist-contract.json (with `↳` sub-items per\n"
                 "  group). Then re-run this command.",
+                file=sys.stderr,
+            )
+            return 2
+        sync_ok, sync_reason = _tasklist_evidence_sync_verdict(
+            evidence_path,
+            run_id,
+            require_claude_status=True,
+        )
+        if not sync_ok:
+            print("\033[38;5;208mTodoWrite evidence is stale.\033[0m", file=sys.stderr)
+            print(
+                f"  Reason: {sync_reason}\n\n"
+                "  Fix: call TodoWrite again from tasklist-contract.json, mark\n"
+                "  the latest completed sub-step as completed, set the next\n"
+                "  sub-step in_progress, then re-run this command.",
                 file=sys.stderr,
             )
             return 2


### PR DESCRIPTION
## Summary
- lock Codex VG runs to Codex runtime; block relaunching `/vg:*` through Claude CLI
- require task UI evidence to refresh after latest `mark-step` before next step/run-complete/edit
- add Claude TodoWrite latest-step completion evidence and Codex compact-plan runtime guidance
- regenerate Codex skill mirrors and sync project-local `.codex/skills`

## Verification
- `python3 -m pytest scripts/tests/test_hook_posttooluse_writes_evidence.py scripts/tests/test_hook_pretooluse_blocks.py scripts/tests/test_tasklist_projected_claude_evidence_gate.py scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py scripts/tests/test_universal_mutating_tool_gate.py scripts/tests/test_codex_mirror_equivalence.py scripts/tests/test_codex_runtime_adapter.py -q`
- `python3 -m pytest .claude/scripts/tests/test_hook_posttooluse_writes_evidence.py .claude/scripts/tests/test_hook_pretooluse_blocks.py .claude/scripts/tests/test_tasklist_projected_claude_evidence_gate.py .claude/scripts/tests/test_hotfix_a_markstep_todowrite_reminder.py .claude/scripts/tests/test_universal_mutating_tool_gate.py .claude/scripts/tests/test_codex_mirror_equivalence.py .claude/scripts/tests/test_codex_runtime_adapter.py -q`
- `python3 scripts/verify-codex-mirror-equivalence.py`
- `python3 scripts/validators/verify-codex-skill-mirror-sync.py --skip-global --skip-vgflow --quiet`