### PR TITLE
fix(bug-reporter): use --body-file to avoid empty issue body on Windows

### DIFF
--- a/.claude/commands/vg/_shared/lib/bug-reporter.sh
+++ b/.claude/commands/vg/_shared/lib/bug-reporter.sh
@@ -487,9 +487,21 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     local assign_args=()
     [ -n "$assignee" ] && assign_args=(--assignee "$assignee")
 
+    # Issue #130: pass body via --body-file to avoid argv truncation on
+    # Windows + Git Bash. Multi-line `--body "$body"` loses content at the
+    # bash → MSYS → cmd.exe → gh.exe boundary; gh creates issue with empty
+    # body but exit 0, so caller marks it sent. --body-file bypasses argv
+    # entirely and works identically on POSIX + Windows.
+    local body_tmp
+    body_tmp=$(mktemp -t vg-bug-body-XXXXXX 2>/dev/null) \
+      || body_tmp="${TMPDIR:-/tmp}/vg-bug-body-$$-${RANDOM}"
+    printf '%s' "$body" > "$body_tmp"
+    # shellcheck disable=SC2064
+    trap "rm -f '$body_tmp'" RETURN
+
     # Try issue create. If fails due to missing labels (404), auto-create + retry.
     local create_err
-    create_err=$(gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" "${assign_args[@]}" 2>&1 >/dev/null)
+    create_err=$(gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" "${assign_args[@]}" 2>&1 >/dev/null)
     if [ $? -eq 0 ]; then
       bug_reporter_mark_sent "$sig"
       return 0
@@ -498,7 +510,7 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     # Auto-create missing labels (one-time per session) then retry once
     if echo "$create_err" | grep -q "label.*not found"; then
       bug_reporter_ensure_labels "$repo" "$labels" >/dev/null 2>&1
-      if gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" "${assign_args[@]}" >/dev/null 2>&1; then
+      if gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" "${assign_args[@]}" >/dev/null 2>&1; then
         bug_reporter_mark_sent "$sig"
         return 0
       fi
@@ -508,7 +520,7 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     # External submitters can still report; only assignment is sacrificed.
     if [ ${#assign_args[@]} -gt 0 ] && \
        echo "$create_err" | grep -qE "ReplaceActorsForAssignable|does not have.*permission|Resource not accessible"; then
-      if gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" >/dev/null 2>&1; then
+      if gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" >/dev/null 2>&1; then
         bug_reporter_mark_sent "$sig"
         return 0
       fi

--- a/commands/vg/_shared/lib/bug-reporter.sh
+++ b/commands/vg/_shared/lib/bug-reporter.sh
@@ -487,9 +487,21 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     local assign_args=()
     [ -n "$assignee" ] && assign_args=(--assignee "$assignee")
 
+    # Issue #130: pass body via --body-file to avoid argv truncation on
+    # Windows + Git Bash. Multi-line `--body "$body"` loses content at the
+    # bash → MSYS → cmd.exe → gh.exe boundary; gh creates issue with empty
+    # body but exit 0, so caller marks it sent. --body-file bypasses argv
+    # entirely and works identically on POSIX + Windows.
+    local body_tmp
+    body_tmp=$(mktemp -t vg-bug-body-XXXXXX 2>/dev/null) \
+      || body_tmp="${TMPDIR:-/tmp}/vg-bug-body-$$-${RANDOM}"
+    printf '%s' "$body" > "$body_tmp"
+    # shellcheck disable=SC2064
+    trap "rm -f '$body_tmp'" RETURN
+
     # Try issue create. If fails due to missing labels (404), auto-create + retry.
     local create_err
-    create_err=$(gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" "${assign_args[@]}" 2>&1 >/dev/null)
+    create_err=$(gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" "${assign_args[@]}" 2>&1 >/dev/null)
     if [ $? -eq 0 ]; then
       bug_reporter_mark_sent "$sig"
       return 0
@@ -498,7 +510,7 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     # Auto-create missing labels (one-time per session) then retry once
     if echo "$create_err" | grep -q "label.*not found"; then
       bug_reporter_ensure_labels "$repo" "$labels" >/dev/null 2>&1
-      if gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" "${assign_args[@]}" >/dev/null 2>&1; then
+      if gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" "${assign_args[@]}" >/dev/null 2>&1; then
         bug_reporter_mark_sent "$sig"
         return 0
       fi
@@ -508,7 +520,7 @@ print(f"""**Auto-reported via vg bug-reporter** (v{ev.get("version", "?")})
     # External submitters can still report; only assignment is sacrificed.
     if [ ${#assign_args[@]} -gt 0 ] && \
        echo "$create_err" | grep -qE "ReplaceActorsForAssignable|does not have.*permission|Resource not accessible"; then
-      if gh issue create --repo "$repo" --title "$title" --body "$body" --label "$labels" >/dev/null 2>&1; then
+      if gh issue create --repo "$repo" --title "$title" --body-file "$body_tmp" --label "$labels" >/dev/null 2>&1; then
         bug_reporter_mark_sent "$sig"
         return 0
       fi


### PR DESCRIPTION
## Summary
- Switch `gh issue create` calls in `bug-reporter.sh` from `--body "$body"` to `--body-file <tmpfile>` to fix silent body truncation on Windows + Git Bash.
- Body is now written to a tempfile once and reused across all 3 retry paths (initial, missing-label retry, assignee-permission retry). Tempfile is cleaned via `trap RETURN`.
- Patches both `commands/...` (canonical) and `.claude/commands/...` (mirror) to keep them in sync.

## Bug

On Windows + Git Bash, `gh issue create --body "$body"` with multi-line body (~2KB+) loses content somewhere along `bash → MSYS → cmd.exe → gh.exe`. `gh` happily creates the issue with empty body and returns exit 0. The bug-reporter then marks the signature as `sent` and clears it from the queue — silent data loss.

Linux/Mac don't hit this because argv passing is clean.

## Empirical verification (2026-05-07)

- Submitted bug via `/vg:bug-report` → issue #129 created with title correct but body empty.
- Verified emptiness: `gh issue view 129 --repo vietdev99/vgflow --json body` returned `""`.
- Re-submitted body manually via `gh issue edit 129 --body-file <path>` → body populated (2314 chars), no other change.
- Conclusion: body generation is fine, loss is at the `--body` argv boundary on Windows.

## Fix approach

Use `--body-file` which reads from a file path — bypasses argv entirely on every platform. Body is built once, written to a tempfile, then referenced from all 3 retry paths:

```bash
local body_tmp
body_tmp=$(mktemp -t vg-bug-body-XXXXXX 2>/dev/null) \
  || body_tmp="${TMPDIR:-/tmp}/vg-bug-body-$$-${RANDOM}"
printf '%s' "$body" > "$body_tmp"
trap "rm -f '$body_tmp'" RETURN

gh issue create ... --body-file "$body_tmp" ...
```

Fallback path for `mktemp` covers minimal Git Bash environments where `mktemp -t` may not be available.

## Tradeoffs considered

| Approach | Pro | Con |
|---|---|---|
| `--body-file <tmp>` (chosen) | Single body write, cleanup via trap, no stdin contention | Requires tempfile + cleanup |
| `printf '%s' "$body" \| gh ... --body-file -` | No tempfile, no cleanup | Re-pipes 3× (one per retry); harder to capture create_err vs body in single subshell |
| Detect Windows + branch logic | No code change on POSIX | Two code paths to maintain |

`--body-file <tmp>` is the simplest correct fix: same code path on all platforms, body materialized once, cleaned up via RETURN trap.

## Test plan

- [ ] Linux: run `/vg:bug-report --test` then `--flush` → verify created issue body matches local generated body.
- [ ] macOS: same as Linux.
- [ ] Windows + Git Bash: `/vg:bug-report --test` then `--flush` → verify body populated (regression test for #130).
- [ ] Verify tempfile cleanup: `ls "${TMPDIR:-/tmp}"/vg-bug-body-*` after submission should be empty.
- [ ] Verify retry paths still work: simulate missing-label and assignee-permission failures, confirm body populates on retry attempts.

## Related
- Closes #130 (the bug being fixed)
- Refs #129 (the victim issue with empty body — used as empirical evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
