### PR TITLE
fix(hooks): bypass python wrapper on Windows to fix "cannot execute binary file"

### DIFF
--- a/.claude/scripts/hooks/install-hooks.sh
+++ b/.claude/scripts/hooks/install-hooks.sh
@@ -64,6 +64,23 @@ settings.setdefault("hooks", {})
 #                           (legacy/escape hatch via VG_HOOKS_PATH_MODE=absolute).
 def _cmd(script_name: str) -> str:
     runner_name = "vg-run-bash-hook.py"
+    # Issue #129: on Windows, Claude Code spawns hooks via `bash <argv>`
+    # without `-c`. Bash treats argv[0] as a script file path. When argv[0]
+    # is "python" / "python3" (binary), bash opens python.exe, reads PE
+    # header bytes, and rejects with "cannot execute binary file" — every
+    # hook fails on the first message after install. Empirically verified
+    # on find_location + super_com_hub, 2026-05-07; substituting `python3`
+    # → `python` does NOT help (both are binaries).
+    #
+    # On Windows, emit the .sh path directly. argv[0] becomes a shell
+    # script — bash reads its shebang and runs it. The python wrapper's
+    # WSL-bash protection is sacrificed; modern Claude Code on Windows
+    # already prefers Git Bash, and users with WSL-only bash are rare.
+    if os.name == "nt":
+        if mode == "absolute":
+            return shlex.quote(f"{hooks_dir}/{script_name}")
+        return f'"${{CLAUDE_PROJECT_DIR}}/.claude/scripts/hooks/{script_name}"'
+
     if mode == "absolute":
         # CRITICAL: hooks_dir may contain spaces (e.g., "Vibe Code") — shell word-splits
         # unquoted command. Use shlex.quote to wrap each path.

--- a/.claude/scripts/tests/test_install_hooks_idempotent.py
+++ b/.claude/scripts/tests/test_install_hooks_idempotent.py
@@ -20,9 +20,16 @@ def test_install_creates_hooks_block(tmp_path, monkeypatch):
     assert "SessionStart" in settings["hooks"]
     assert "PostToolUse" in settings["hooks"]
     user_prompt_cmd = settings["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
-    assert "vg-run-bash-hook.py" in user_prompt_cmd
     assert "vg-user-prompt-submit.sh" in user_prompt_cmd
     assert not user_prompt_cmd.startswith("bash ")
+    # Issue #129: on Windows the python wrapper is bypassed (argv[0] must
+    # be a shell script, not a binary, because Claude Code spawns hooks
+    # via `bash <argv>` without `-c`). On POSIX the wrapper is retained
+    # for its WSL-bash protection.
+    if os.name == "nt":
+        assert "vg-run-bash-hook.py" not in user_prompt_cmd
+    else:
+        assert "vg-run-bash-hook.py" in user_prompt_cmd
 
 
 def test_install_idempotent_no_duplicates(tmp_path, monkeypatch):

--- a/scripts/hooks/install-hooks.sh
+++ b/scripts/hooks/install-hooks.sh
@@ -64,6 +64,23 @@ settings.setdefault("hooks", {})
 #                           (legacy/escape hatch via VG_HOOKS_PATH_MODE=absolute).
 def _cmd(script_name: str) -> str:
     runner_name = "vg-run-bash-hook.py"
+    # Issue #129: on Windows, Claude Code spawns hooks via `bash <argv>`
+    # without `-c`. Bash treats argv[0] as a script file path. When argv[0]
+    # is "python" / "python3" (binary), bash opens python.exe, reads PE
+    # header bytes, and rejects with "cannot execute binary file" — every
+    # hook fails on the first message after install. Empirically verified
+    # on find_location + super_com_hub, 2026-05-07; substituting `python3`
+    # → `python` does NOT help (both are binaries).
+    #
+    # On Windows, emit the .sh path directly. argv[0] becomes a shell
+    # script — bash reads its shebang and runs it. The python wrapper's
+    # WSL-bash protection is sacrificed; modern Claude Code on Windows
+    # already prefers Git Bash, and users with WSL-only bash are rare.
+    if os.name == "nt":
+        if mode == "absolute":
+            return shlex.quote(f"{hooks_dir}/{script_name}")
+        return f'"${{CLAUDE_PROJECT_DIR}}/.claude/scripts/hooks/{script_name}"'
+
     if mode == "absolute":
         # CRITICAL: hooks_dir may contain spaces (e.g., "Vibe Code") — shell word-splits
         # unquoted command. Use shlex.quote to wrap each path.

--- a/scripts/tests/test_install_hooks_idempotent.py
+++ b/scripts/tests/test_install_hooks_idempotent.py
@@ -20,9 +20,16 @@ def test_install_creates_hooks_block(tmp_path, monkeypatch):
     assert "SessionStart" in settings["hooks"]
     assert "PostToolUse" in settings["hooks"]
     user_prompt_cmd = settings["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
-    assert "vg-run-bash-hook.py" in user_prompt_cmd
     assert "vg-user-prompt-submit.sh" in user_prompt_cmd
     assert not user_prompt_cmd.startswith("bash ")
+    # Issue #129: on Windows the python wrapper is bypassed (argv[0] must
+    # be a shell script, not a binary, because Claude Code spawns hooks
+    # via `bash <argv>` without `-c`). On POSIX the wrapper is retained
+    # for its WSL-bash protection.
+    if os.name == "nt":
+        assert "vg-run-bash-hook.py" not in user_prompt_cmd
+    else:
+        assert "vg-run-bash-hook.py" in user_prompt_cmd
 
 
 def test_install_idempotent_no_duplicates(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Platform-detect Windows in `install-hooks.sh` `_cmd()` function — when on Windows (`os.name == 'nt'`), emit the .sh path directly without the `python vg-run-bash-hook.py` wrapper.
- POSIX (Linux/Mac) path unchanged — wrapper retained for its WSL-bash protection logic.
- Test updated to be Windows-aware: asserts wrapper absence on Windows, presence on POSIX.
- Patches both `scripts/...` (canonical) and `.claude/scripts/...` (mirror) to keep them in sync.

## Bug

On Windows + Git Bash, Claude Code spawns hook commands via `bash <argv>` without `-c`. Bash treats argv[0] as a **script file path**. When argv[0] is `python` or `python3` (a binary), bash opens python.exe, reads PE header bytes, and rejects with `cannot execute binary file`. Every hook fails on the first message after install.

```
Failed with non-blocking status code: /c/Users/Admin/AppData/Local/Programs/Python/Python314/python: /c/Users/Admin/AppData/Local/Programs/Python/Python314/python: cannot execute binary file
```

## Empirical verification (2026-05-07)

- **Repo A (find_location)**: hit fail after `/vg:update`, hand-fixed manually.
- **Repo B (super_com_hub)**: freshly `/vg:sync`, immediately fails with same error.
- Tried `python3` → `python` (commit `40f966c` style): **STILL FAILS** — both are binaries, so the shape of the bug is the same regardless of which python name is used.
- Removed wrapper, kept only quoted .sh path: **WORKS** — bash reads the .sh shebang and runs it.

This PR ports that empirical fix into the canonical installer.

## Fix approach

```python
def _cmd(script_name: str) -> str:
    runner_name = "vg-run-bash-hook.py"

    if os.name == "nt":
        if mode == "absolute":
            return shlex.quote(f"{hooks_dir}/{script_name}")
        return f'"${{CLAUDE_PROJECT_DIR}}/.claude/scripts/hooks/{script_name}"'

    # POSIX path — unchanged, retains wrapper
    if mode == "absolute":
        return (
            f"{python_cmd} {shlex.quote(f'{hooks_dir}/{runner_name}')} "
            f"{shlex.quote(f'{hooks_dir}/{script_name}')}"
        )
    return (
        f'{python_cmd} "${{CLAUDE_PROJECT_DIR}}/.claude/scripts/hooks/{runner_name}" '
        f'"${{CLAUDE_PROJECT_DIR}}/.claude/scripts/hooks/{script_name}"'
    )
```

## Tradeoff acknowledged

The wrapper `vg-run-bash-hook.py` was added to protect against WSL bash interception (it prefers Git Bash via `candidate_bashes()`). On Windows this PR drops that protection. Justification:

- Modern Claude Code on Windows already prefers Git Bash for hook spawn (which is exactly why the original wrapper was needed — but the wrapper itself can't run because of the argv[0] issue).
- Users whose only `bash` on PATH is WSL bash AND who don't have Git Bash installed are very rare.
- The current state (wrapper present) **fails 100% of the time on Windows** — no protection in practice. Dropping the wrapper at least makes hooks work for the common case.

If WSL-only-bash users are a real concern, a follow-up could ship a small `.sh` launcher script that re-invokes the python wrapper from inside a bash context (where argv[0] is the .sh, the `exec python ...` inside is fine). Out of scope for this PR.

## Test plan

- [x] Windows 10 + Git Bash 5.2 + Python 3.14: ran `bash scripts/hooks/install-hooks.sh --target /tmp/test/.claude/settings.json` → emitted `"${CLAUDE_PROJECT_DIR}/.claude/scripts/hooks/vg-user-prompt-submit.sh"` (no wrapper). Verified.
- [ ] CI (POSIX): `pytest scripts/tests/test_install_hooks_idempotent.py` — should pass with `vg-run-bash-hook.py` present in command (POSIX branch unchanged).
- [ ] CI (Windows runner if available): same test — should pass with `vg-run-bash-hook.py` absent (Windows branch new).
- [ ] End-to-end on real Windows project: `/vg:sync`, send a message — no `cannot execute binary file`, hook actually fires.

## Related
- Closes #129 (the bug being fixed)
- Refs #130 (separate bug; PR #131 fixes it independently — they don't depend on each other)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
