### PR TITLE
fix(review): split runtime blockers from test-pending gate

### DIFF
--- a/codex-skills/vg-next/SKILL.md
+++ b/codex-skills/vg-next/SKILL.md
@@ -291,7 +291,7 @@ Display only — không block. User decision: re-migrate (recommended) hay skip.
 - `NEXT_STEP == "blueprint"` → Next: `/vg:blueprint {phase}`
 - `NEXT_STEP == "build"` → Next: `/vg:build {phase}`
 - `NEXT_STEP == "review"` → Next: `/vg:review {phase}` (see Cross-CLI option below)
-- `NEXT_STEP == "test"` → Next: `/vg:test {phase}` (UNLESS prior review verdict ∈ FAIL/BLOCK — see verdict gate)
+- `NEXT_STEP == "test"` → Next: `/vg:test {phase}` (UNLESS prior review verdict ∈ FAIL/BLOCK — see verdict gate; TEST_PENDING may advance)
 - `NEXT_STEP == "accept"` → Next: `/vg:accept {phase}` (UNLESS prior test verdict ∈ GAPS_FOUND/FAILED — see verdict gate)
 - `NEXT_STEP == "complete"` → Phase done (check Route 8/9)
 
@@ -300,6 +300,10 @@ Display only — không block. User decision: re-migrate (recommended) hay skip.
 Before routing to `/vg:test` or `/vg:accept`, read PIPELINE-STATE.json verdict
 of the prior step. If non-PASS verdict, do NOT auto-advance — show the same
 verdict-aware guidance the prior skill printed at exit:
+
+Exception: review verdict `TEST_PENDING` is allowed to advance to `/vg:test`.
+It means runtime/code/spec/infra blockers are clear and remaining lifecycle
+evidence is owned by test/codegen.
 
 ```bash
 PRIOR_REVIEW_VERDICT=$(${PYTHON_BIN:-python3} -c "
@@ -374,11 +378,12 @@ Display cross-CLI option:
 ```
 
 **Route 5b:** `RUNTIME-MAP.json` exists + `GOAL-COVERAGE-MATRIX.md` exists + gate = BLOCK (goals < 100%)
-→ Review ran but goals not met. Auto-detect cause from artifacts:
+→ Review ran but runtime/code/spec/infra blockers remain. Auto-detect cause from artifacts.
+If gate = TEST_PENDING, skip this route and use Route 6.
 
 ```
 Read discovery-state.json → completed_phase field
-Read GOAL-COVERAGE-MATRIX.md → goal statuses (READY / BLOCKED / UNREACHABLE / FAILED)
+Read GOAL-COVERAGE-MATRIX.md → goal statuses (READY / TEST_PENDING / BLOCKED / UNREACHABLE / FAILED)
 Read RUNTIME-MAP.json → goal_sequences[goal_id].start_view for each failed goal
 
 SIGNAL 1 — discovery-state.json.completed_phase ≠ "investigate":
@@ -394,6 +399,7 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
                   (review didn't replay — multi-step wizard, orphan route, timeout, retry-scope miss)
     BLOCKED/FAILED = goal has start_view but result=failed
                      (view found, scan ran, criteria not met → code bug)
+    TEST_PENDING = review found no runtime blocker, but lifecycle proof belongs to /vg:test
 ```
 
 **Display to user (explain, then action):**
@@ -416,6 +422,9 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
 │                    (form didn't submit, API error, etc.)      │
 │                    → Code has a bug — fix and re-scan         │
 │                                                               │
+│ TEST_PENDING ({N}) Runtime clean; lifecycle proof pending     │
+│                    → Fix: /vg:test {phase}                    │
+│                                                               │
 │ INTERRUPTED        Review died mid-scan (token/timeout)       │
 │                    → Just resume where it left off            │
 └───────────────────────────────────────────────────────────────┘
@@ -423,6 +432,7 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
 Failed goals:
   [UNREACHABLE] {goal_id}: {goal_desc}
   [NOT_SCANNED] {goal_id}: {goal_desc} (code: {path/to/page.tsx})
+  [TEST_PENDING] {goal_id}: {goal_desc}
   [BLOCKED]     {goal_id}: {goal_desc} (view: {start_view})
   ...
 ```
@@ -446,6 +456,11 @@ IF all NOT_SCANNED (code exists, review skipped):
         (fresh re-scan of only failed views)
     DO NOT run /vg:build --gaps-only — code already exists.
 
+IF all TEST_PENDING:
+  Print: "Runtime blockers clear — lifecycle evidence belongs to test."
+  Display:
+    /vg:test {phase}
+
 IF all BLOCKED (code bugs — user fix required first):
   Print: "All failures BLOCKED — code bugs in {N} views. Workflow:"
   Display (do NOT auto-invoke):
@@ -464,7 +479,7 @@ IF mix (any combination):
     Step 4: /vg:review {phase} --retry-failed   ← re-verify everything
 ```
 
-**Route 6:** `RUNTIME-MAP.json` + `RUNTIME-MAP.md` exist + GOAL-COVERAGE-MATRIX gate = PASS + no `*-SANDBOX-TEST.md`
+**Route 6:** `RUNTIME-MAP.json` + `RUNTIME-MAP.md` exist + GOAL-COVERAGE-MATRIX gate = PASS or TEST_PENDING + no `*-SANDBOX-TEST.md`
 → Next: `/vg:test {phase}`
 Note: RUNTIME-MAP.json is the canonical artifact — .md alone is NOT sufficient for /vg:test.
 

--- a/commands/vg/_shared/lib/matrix-merger.sh
+++ b/commands/vg/_shared/lib/matrix-merger.sh
@@ -31,7 +31,7 @@
 #
 # Exposed functions:
 #   - merge_and_write_matrix PHASE_DIR TEST_GOALS RUNTIME_MAP PROBE_RESULTS OUTPUT_MD
-#       → stdout: "PASS|BLOCK|INTERMEDIATE" + counts in $MERGE_*
+#       → stdout: "PASS|BLOCK|INTERMEDIATE|TEST_PENDING" + counts in $MERGE_*
 #       → writes OUTPUT_MD
 #
 # Usage in review.md Phase 4b + 4d:
@@ -45,6 +45,7 @@
 #     PASS) echo "✓ Gate PASS" ;;
 #     BLOCK) echo "⛔ Gate BLOCK" ;;
 #     INTERMEDIATE) echo "⚠ Gate: intermediate goals present" ;;
+#     TEST_PENDING) echo "🧪 Gate: runtime clear, test coverage pending" ;;
 #   esac
 
 merge_and_write_matrix() {
@@ -270,6 +271,56 @@ def _has_persistence_proof(seq):
             return True
     return False
 
+TEST_PENDING_PATTERNS = (
+    'not exercised',
+    'not observed',
+    'not proven',
+    'not prove',
+    'did not prove',
+    'proof missing',
+    'lifecycle',
+    'multi-step',
+    'mutation evidence',
+    'realtime evidence',
+    'without a successful post/put/patch/delete',
+    'no persistence_probe',
+    'persistence proof',
+    'needs dedicated browser session',
+    'acceptance-grade proof',
+)
+
+RUNTIME_BLOCKER_PATTERNS = (
+    'api error',
+    ' 400',
+    ' 401',
+    ' 403',
+    ' 404',
+    ' 409',
+    ' 422',
+    ' 500',
+    ' 502',
+    ' 503',
+    'exception',
+    'crash',
+    'cannot render',
+    'failed to render',
+    'route missing',
+    'not found',
+    'redirected to login',
+    'auth failed',
+    'nan',
+    'raw i18n',
+    'placeholder',
+)
+
+def _is_test_pending_evidence(text):
+    compact = re.sub(r'\s+', ' ', str(text or '').strip()).lower()
+    if not compact:
+        return False
+    if any(pattern in compact for pattern in RUNTIME_BLOCKER_PATTERNS):
+        return False
+    return any(pattern in compact for pattern in TEST_PENDING_PATTERNS)
+
 # ─── Load surface probe results ───────────────────────────────────
 probe_results = {}
 if Path(probe_path).exists():
@@ -292,8 +343,13 @@ for g in goals:
                 g['status'] = 'READY'
                 g['evidence'] = f"browser: {len(seq.get('steps',[]))} steps"
             elif result == 'failed':
-                g['status'] = 'BLOCKED'
-                g['evidence'] = f"browser failed: {seq.get('failure_reason','?')[:80]}"
+                reason = str(seq.get('failure_reason', '?'))
+                g['status'] = 'TEST_PENDING' if _is_test_pending_evidence(reason) else 'BLOCKED'
+                g['evidence'] = f"browser failed: {reason[:80]}"
+            elif result == 'partial':
+                reason = str(seq.get('failure_reason', '?'))
+                g['status'] = 'TEST_PENDING' if _is_test_pending_evidence(reason) else 'BLOCKED'
+                g['evidence'] = f"browser partial: {reason[:80]}"
             else:
                 g['status'] = 'FAILED'
                 g['evidence'] = f"browser result unknown"
@@ -309,14 +365,14 @@ for g in goals:
         # assertion or "row visible" snapshot is not CRUD evidence.
         if g['status'] == 'READY' and _meaningful(g.get('mutation_evidence')):
             if not _has_mutation_step(seq):
-                g['status'] = 'BLOCKED'
+                g['status'] = 'TEST_PENDING'
                 g['evidence'] = (
                     "shallow CRUD evidence: goal_sequence passed without a successful "
                     "POST/PUT/PATCH/DELETE observation; list-only review cannot satisfy "
                     "Mutation evidence"
                 )
             elif not _has_persistence_proof(seq):
-                g['status'] = 'BLOCKED'
+                g['status'] = 'TEST_PENDING'
                 g['evidence'] = (
                     "ghost-save risk: mutation observed but no persistence_probe.persisted=true; "
                     "Layer 4 verify (refresh + re-read + diff) missing"
@@ -338,7 +394,7 @@ for g in goals:
         g['evidence'] = 'no probe result; surface probe phase may not have run'
 
 # ─── Aggregate counts ────────────────────────────────────────────
-total_by_status = {'READY': 0, 'BLOCKED': 0, 'NOT_SCANNED': 0, 'UNREACHABLE': 0, 'INFRA_PENDING': 0, 'FAILED': 0}
+total_by_status = {'READY': 0, 'BLOCKED': 0, 'TEST_PENDING': 0, 'NOT_SCANNED': 0, 'UNREACHABLE': 0, 'INFRA_PENDING': 0, 'FAILED': 0}
 by_priority = {
     'critical':     {'total': 0, 'ready': 0, 'blocked': 0, 'other': 0, 'threshold': 100},
     'important':    {'total': 0, 'ready': 0, 'blocked': 0, 'other': 0, 'threshold': 80},
@@ -358,6 +414,7 @@ for g in goals:
 
 # ─── Gate verdict ────────────────────────────────────────────────
 # 4 conclusion statuses: READY, BLOCKED, UNREACHABLE, INFRA_PENDING
+# 1 coverage-pending status: TEST_PENDING → may advance to /vg:test
 # 2 intermediate: NOT_SCANNED, FAILED → force INTERMEDIATE verdict
 intermediate = total_by_status['NOT_SCANNED'] + total_by_status['FAILED']
 
@@ -372,13 +429,15 @@ elif total_by_status['BLOCKED'] > 0 or total_by_status['UNREACHABLE'] > 0:
     # priority threshold — pre-fix: weighted gate masked BLOCKED < threshold pct
     # and emitted PASS. Now blocks first.
     verdict = 'BLOCK'
+elif total_by_status['TEST_PENDING'] > 0:
+    verdict = 'TEST_PENDING'
 else:
     # Compute weighted gate (only if 0 BLOCKED + 0 UNREACHABLE)
     for prio, info in by_priority.items():
         if info['total'] == 0: continue
         pct = 100 * info['ready'] / info['total']
         if pct < info['threshold']:
-            verdict = 'BLOCK'
+            verdict = 'TEST_PENDING' if info['other'] > 0 and total_by_status['TEST_PENDING'] > 0 else 'BLOCK'
             info['failed_gate'] = True
 
 # ─── Write GOAL-COVERAGE-MATRIX.md ───────────────────────────────
@@ -394,6 +453,7 @@ lines = [
     f'- **Total goals:** {len(goals)}',
     f'- **READY:** {total_by_status["READY"]}',
     f'- **BLOCKED:** {total_by_status["BLOCKED"]}',
+    f'- **TEST_PENDING:** {total_by_status["TEST_PENDING"]} (test coverage pending)',
     f'- **NOT_SCANNED:** {total_by_status["NOT_SCANNED"]} (intermediate)',
     f'- **UNREACHABLE:** {total_by_status["UNREACHABLE"]}',
     f'- **INFRA_PENDING:** {total_by_status["INFRA_PENDING"]}',
@@ -410,7 +470,12 @@ for prio in ('critical', 'important', 'nice-to-have'):
         lines.append(f'| {prio} | 0 | 0 | 0 | 0 | {info["threshold"]}% | n/a | — |')
         continue
     pct = 100 * info['ready'] / info['total']
-    status_icon = '✅ PASS' if pct >= info['threshold'] else '⛔ BLOCK'
+    if pct >= info['threshold']:
+        status_icon = '✅ PASS'
+    elif info['blocked'] == 0 and total_by_status['TEST_PENDING'] > 0:
+        status_icon = '🧪 TEST_PENDING'
+    else:
+        status_icon = '⛔ BLOCK'
     lines.append(f'| {prio} | {info["ready"]} | {info["blocked"]} | {info["other"]} | {info["total"]} | {info["threshold"]}% | {pct:.1f}% | {status_icon} |')
 
 lines += ['', '## Goal Details', '', '| Goal | Priority | Surface | Status | Evidence |', '|------|----------|---------|--------|----------|']
@@ -419,7 +484,7 @@ for g in goals:
     lines.append(f'| {g["id"]} | {g["priority"]} | {g["surface"]} | {g["status"]} | {ev} |')
 
 # Gate verdict section
-gate_icon = {'PASS': '✅', 'BLOCK': '⛔', 'INTERMEDIATE': '⚠️'}[verdict]
+gate_icon = {'PASS': '✅', 'BLOCK': '⛔', 'INTERMEDIATE': '⚠️', 'TEST_PENDING': '🧪'}[verdict]
 lines += ['', f'## Gate: {gate_icon} **{verdict}**', '']
 if verdict == 'INTERMEDIATE':
     lines += [
@@ -443,7 +508,13 @@ elif verdict == 'BLOCK':
             'Fix blockers or escalate to /vg:accept with debt entry.',
         ]
 else:
-    lines += [f'All priority thresholds met. {total_by_status["READY"]}/{len(goals)} READY — proceed to /vg:test.']
+    if verdict == 'TEST_PENDING':
+        lines += [
+            f'Review runtime blockers clear. {total_by_status["TEST_PENDING"]} goals still need lifecycle/test evidence.',
+            'Proceed to /vg:test; do not loop back to /vg:review unless test finds a concrete runtime/code blocker.',
+        ]
+    else:
+        lines += [f'All priority thresholds met. {total_by_status["READY"]}/{len(goals)} READY — proceed to /vg:test.']
 
 lines.append('')
 Path(out_path).write_text('\n'.join(lines) + '\n', encoding='utf-8')
@@ -454,6 +525,7 @@ print(f"VERDICT={verdict}")
 print(f"TOTAL={len(goals)}")
 print(f"READY={total_by_status['READY']}")
 print(f"BLOCKED={total_by_status['BLOCKED']}")
+print(f"TEST_PENDING={total_by_status['TEST_PENDING']}")
 print(f"NOT_SCANNED={total_by_status['NOT_SCANNED']}")
 print(f"UNREACHABLE={total_by_status['UNREACHABLE']}")
 print(f"INFRA_PENDING={total_by_status['INFRA_PENDING']}")

--- a/commands/vg/_shared/review/close.md
+++ b/commands/vg/_shared/review/close.md
@@ -309,6 +309,20 @@ Next (pick one):
   edit {file:line}; git commit; /vg:next    # fix flags first, then continue
 ```
 
+### When verdict = TEST_PENDING (runtime clear, lifecycle proof belongs to test)
+```
+Review complete for Phase {N} — TEST_PENDING.
+  Goals: {ready}/{total} READY ({test_pending} TEST_PENDING, 0 runtime blockers)
+  Gate: TEST_PENDING (review rendered routes/API clean; lifecycle evidence pending)
+  Runtime blockers: 0 API/render/route blockers
+  Coverage pending: mutation/realtime/multi-step lifecycle proof
+
+Next:
+  /vg:test {phase}            # codegen + Playwright proves lifecycle evidence
+
+Do not loop back to /vg:review unless /vg:test surfaces a concrete runtime/code blocker.
+```
+
 ### When verdict = BLOCK (cannot proceed)
 ```
 Review complete for Phase {N} — BLOCK.
@@ -359,6 +373,7 @@ Per CONTEXT.md D-XX OR Per API-CONTRACTS.md"  # body must cite
 
 ### Hard rules for AI orchestrator (Claude/Codex/Gemini)
 1. **Never end a BLOCK review without listing per-finding fixes + verify steps.** Bare list of issues = user has to re-derive next action — anti-pattern.
+   BLOCK means runtime/code/spec/infra blocker. Missing lifecycle proof with runtime blockers cleared MUST be TEST_PENDING.
 2. **Use RELATIVE paths** in narration (`apps/api/src/plugins/health.ts:23`), NOT absolute (`/D/Workspace/...`). Absolute paths waste 60% of terminal width on repeated prefixes.
 3. **Per-finding format MUST be:**
    ```

--- a/commands/vg/_shared/review/fix-loop-and-goals.md
+++ b/commands/vg/_shared/review/fix-loop-and-goals.md
@@ -922,11 +922,12 @@ if type -t merge_and_write_matrix >/dev/null 2>&1; then
   VERDICT=$(echo "$MERGE_OUTPUT" | grep '^VERDICT=' | cut -d= -f2)
   READY=$(echo "$MERGE_OUTPUT" | grep '^READY=' | cut -d= -f2)
   BLOCKED=$(echo "$MERGE_OUTPUT" | grep '^BLOCKED=' | cut -d= -f2)
+  TEST_PENDING=$(echo "$MERGE_OUTPUT" | grep '^TEST_PENDING=' | cut -d= -f2)
   NOT_SCANNED=$(echo "$MERGE_OUTPUT" | grep '^NOT_SCANNED=' | cut -d= -f2)
   INTERMEDIATE=$(echo "$MERGE_OUTPUT" | grep '^INTERMEDIATE=' | cut -d= -f2)
-  export VERDICT READY BLOCKED NOT_SCANNED INTERMEDIATE
+  export VERDICT READY BLOCKED TEST_PENDING NOT_SCANNED INTERMEDIATE
 
-  echo "✓ GOAL-COVERAGE-MATRIX.md: VERDICT=$VERDICT (ready=$READY blocked=$BLOCKED not_scanned=$NOT_SCANNED)"
+  echo "✓ GOAL-COVERAGE-MATRIX.md: VERDICT=$VERDICT (ready=$READY blocked=$BLOCKED test_pending=$TEST_PENDING not_scanned=$NOT_SCANNED)"
 else
   echo "⚠ matrix-merger.sh missing — falling back to manual matrix write (legacy path)"
   # Legacy path: orchestrator writes matrix directly using template below

--- a/commands/vg/next.md
+++ b/commands/vg/next.md
@@ -149,7 +149,7 @@ Display only — không block. User decision: re-migrate (recommended) hay skip.
 - `NEXT_STEP == "blueprint"` → Next: `/vg:blueprint {phase}`
 - `NEXT_STEP == "build"` → Next: `/vg:build {phase}`
 - `NEXT_STEP == "review"` → Next: `/vg:review {phase}` (see Cross-CLI option below)
-- `NEXT_STEP == "test"` → Next: `/vg:test {phase}` (UNLESS prior review verdict ∈ FAIL/BLOCK — see verdict gate)
+- `NEXT_STEP == "test"` → Next: `/vg:test {phase}` (UNLESS prior review verdict ∈ FAIL/BLOCK — see verdict gate; TEST_PENDING may advance)
 - `NEXT_STEP == "accept"` → Next: `/vg:accept {phase}` (UNLESS prior test verdict ∈ GAPS_FOUND/FAILED — see verdict gate)
 - `NEXT_STEP == "complete"` → Phase done (check Route 8/9)
 
@@ -158,6 +158,10 @@ Display only — không block. User decision: re-migrate (recommended) hay skip.
 Before routing to `/vg:test` or `/vg:accept`, read PIPELINE-STATE.json verdict
 of the prior step. If non-PASS verdict, do NOT auto-advance — show the same
 verdict-aware guidance the prior skill printed at exit:
+
+Exception: review verdict `TEST_PENDING` is allowed to advance to `/vg:test`.
+It means runtime/code/spec/infra blockers are clear and remaining lifecycle
+evidence is owned by test/codegen.
 
 ```bash
 PRIOR_REVIEW_VERDICT=$(${PYTHON_BIN:-python3} -c "
@@ -232,11 +236,12 @@ Display cross-CLI option:
 ```
 
 **Route 5b:** `RUNTIME-MAP.json` exists + `GOAL-COVERAGE-MATRIX.md` exists + gate = BLOCK (goals < 100%)
-→ Review ran but goals not met. Auto-detect cause from artifacts:
+→ Review ran but runtime/code/spec/infra blockers remain. Auto-detect cause from artifacts.
+If gate = TEST_PENDING, skip this route and use Route 6.
 
 ```
 Read discovery-state.json → completed_phase field
-Read GOAL-COVERAGE-MATRIX.md → goal statuses (READY / BLOCKED / UNREACHABLE / FAILED)
+Read GOAL-COVERAGE-MATRIX.md → goal statuses (READY / TEST_PENDING / BLOCKED / UNREACHABLE / FAILED)
 Read RUNTIME-MAP.json → goal_sequences[goal_id].start_view for each failed goal
 
 SIGNAL 1 — discovery-state.json.completed_phase ≠ "investigate":
@@ -252,6 +257,7 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
                   (review didn't replay — multi-step wizard, orphan route, timeout, retry-scope miss)
     BLOCKED/FAILED = goal has start_view but result=failed
                      (view found, scan ran, criteria not met → code bug)
+    TEST_PENDING = review found no runtime blocker, but lifecycle proof belongs to /vg:test
 ```
 
 **Display to user (explain, then action):**
@@ -274,6 +280,9 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
 │                    (form didn't submit, API error, etc.)      │
 │                    → Code has a bug — fix and re-scan         │
 │                                                               │
+│ TEST_PENDING ({N}) Runtime clean; lifecycle proof pending     │
+│                    → Fix: /vg:test {phase}                    │
+│                                                               │
 │ INTERRUPTED        Review died mid-scan (token/timeout)       │
 │                    → Just resume where it left off            │
 └───────────────────────────────────────────────────────────────┘
@@ -281,6 +290,7 @@ SIGNAL 2 — completed_phase == "investigate" (review fully completed):
 Failed goals:
   [UNREACHABLE] {goal_id}: {goal_desc}
   [NOT_SCANNED] {goal_id}: {goal_desc} (code: {path/to/page.tsx})
+  [TEST_PENDING] {goal_id}: {goal_desc}
   [BLOCKED]     {goal_id}: {goal_desc} (view: {start_view})
   ...
 ```
@@ -304,6 +314,11 @@ IF all NOT_SCANNED (code exists, review skipped):
         (fresh re-scan of only failed views)
     DO NOT run /vg:build --gaps-only — code already exists.
 
+IF all TEST_PENDING:
+  Print: "Runtime blockers clear — lifecycle evidence belongs to test."
+  Display:
+    /vg:test {phase}
+
 IF all BLOCKED (code bugs — user fix required first):
   Print: "All failures BLOCKED — code bugs in {N} views. Workflow:"
   Display (do NOT auto-invoke):
@@ -322,7 +337,7 @@ IF mix (any combination):
     Step 4: /vg:review {phase} --retry-failed   ← re-verify everything
 ```
 
-**Route 6:** `RUNTIME-MAP.json` + `RUNTIME-MAP.md` exist + GOAL-COVERAGE-MATRIX gate = PASS + no `*-SANDBOX-TEST.md`
+**Route 6:** `RUNTIME-MAP.json` + `RUNTIME-MAP.md` exist + GOAL-COVERAGE-MATRIX gate = PASS or TEST_PENDING + no `*-SANDBOX-TEST.md`
 → Next: `/vg:test {phase}`
 Note: RUNTIME-MAP.json is the canonical artifact — .md alone is NOT sufficient for /vg:test.
 

--- a/scripts/tests/test_matrix_evidence_link_test_pending.py
+++ b/scripts/tests/test_matrix_evidence_link_test_pending.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = REPO_ROOT / "scripts" / "validators" / "verify-matrix-evidence-link.py"
+
+
+def test_test_pending_status_does_not_require_runtime_sequence(tmp_path: Path) -> None:
+    phase = tmp_path / ".vg" / "phases" / "06-fixture"
+    phase.mkdir(parents=True)
+    phase.joinpath("GOAL-COVERAGE-MATRIX.md").write_text(
+        "\n".join(
+            [
+                "# Goal Coverage Matrix",
+                "",
+                "| Goal | Priority | Surface | Status | Evidence |",
+                "|------|----------|---------|--------|----------|",
+                "| G-01 | important | ui | TEST_PENDING | lifecycle proof not exercised |",
+                "",
+                "## Gate: 🧪 **TEST_PENDING**",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    phase.joinpath("RUNTIME-MAP.json").write_text(
+        json.dumps({"goal_sequences": {}}, indent=2),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["VG_REPO_ROOT"] = str(tmp_path)
+
+    proc = subprocess.run(
+        [sys.executable, str(VALIDATOR), "--phase", "6", "--json"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "PASS"

--- a/scripts/tests/test_runtime_map_crud_depth.py
+++ b/scripts/tests/test_runtime_map_crud_depth.py
@@ -255,7 +255,7 @@ def test_structural_fallback_still_blocks_mutation_missing_sequence(tmp_path: Pa
     assert "runtime_crud_sequence_missing" in _evidence_types(payload)
 
 
-def test_matrix_merger_downgrades_list_only_crud_goal(tmp_path: Path) -> None:
+def test_matrix_merger_marks_list_only_crud_goal_test_pending(tmp_path: Path) -> None:
     bash = _bash()
     if bash is None:
         pytest.skip("bash is required for matrix-merger integration test")
@@ -305,8 +305,74 @@ def test_matrix_merger_downgrades_list_only_crud_goal(tmp_path: Path) -> None:
 
     assert proc.returncode == 0, proc.stderr
     matrix = output.read_text(encoding="utf-8")
+    assert "VERDICT=TEST_PENDING" in proc.stdout
+    assert "TEST_PENDING=1" in proc.stdout
+    assert "## Gate: 🧪 **TEST_PENDING**" in matrix
+    assert "| G-01 | important | ui | TEST_PENDING | shallow CRUD evidence" in matrix
+
+def test_matrix_merger_keeps_real_runtime_error_blocked(tmp_path: Path) -> None:
+    bash = _bash()
+    if bash is None:
+        pytest.skip("bash is required for matrix-merger integration test")
+
+    phase = _phase(tmp_path)
+    _write_goals(
+        phase,
+        (
+            "## Goal G-01: Campaign create handles API\n\n"
+            "**Surface:** ui\n\n"
+            "**Start view:** /campaigns\n\n"
+            "**Success criteria:** Campaign API saves cleanly.\n\n"
+            "**Mutation evidence:** none\n"
+        ),
+    )
+    _write_runtime(
+        phase,
+        {
+            "result": "failed",
+            "start_view": "/campaigns",
+            "failure_reason": "POST /api/campaigns returned 500 API error",
+            "steps": [{"action": "click", "target": "Save"}],
+            "network": [{"method": "POST", "url": "/api/campaigns", "status": 500}],
+        },
+    )
+    phase.joinpath(".surface-probe-results.json").write_text("{}", encoding="utf-8")
+    output = phase / "GOAL-COVERAGE-MATRIX.md"
+    runner = tmp_path / "run-matrix-runtime-block.sh"
+    runner.write_text(
+        "\n".join(
+            [
+                "set -euo pipefail",
+                f'source "{_shell_path(REPO_ROOT / "commands/vg/_shared/lib/matrix-merger.sh")}"',
+                "PYTHON_BIN=python",
+                (
+                    f'merge_and_write_matrix "{_shell_path(phase)}" '
+                    f'"{_shell_path(phase / "TEST-GOALS.md")}" '
+                    f'"{_shell_path(phase / "RUNTIME-MAP.json")}" '
+                    f'"{_shell_path(phase / ".surface-probe-results.json")}" '
+                    f'"{_shell_path(output)}"'
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [bash, str(runner)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    matrix = output.read_text(encoding="utf-8")
     assert "VERDICT=BLOCK" in proc.stdout
-    assert "| G-01 | important | ui | BLOCKED | shallow CRUD evidence" in matrix
+    assert "TEST_PENDING=0" in proc.stdout
+    assert "| G-01 | important | ui | BLOCKED | browser failed: POST /api/campaigns returned 500 API error |" in matrix
 
 
 def test_matrix_merger_ignores_none_mutation_evidence(tmp_path: Path) -> None:

--- a/scripts/validators/verify-matrix-evidence-link.py
+++ b/scripts/validators/verify-matrix-evidence-link.py
@@ -19,6 +19,7 @@ Allowed Status values that DON'T require a runtime sequence:
   - INFRA_PENDING — goal needs infra not available, deferred to UAT
   - UNREACHABLE   — code not in repo
   - DEFERRED      — phase target not yet deployed
+  - TEST_PENDING  — runtime is clear, lifecycle evidence belongs to /vg:test
 
 Any other Status (READY, MANUAL_VERIFIED, etc.) requires a non-empty
 goal_sequences entry whose result is "passed" / "ready" / "ok".
@@ -61,7 +62,7 @@ MATRIX_ROW_RE = re.compile(
 # are semantically aligned and should NOT trigger
 # matrix_status_contradicts_runtime_result. Pre-fix: workflow forced
 # DEFERRED workaround instead of the natural BLOCKED.
-STATUSES_WITHOUT_RUNTIME = {"INFRA_PENDING", "UNREACHABLE", "DEFERRED", "BLOCKED"}
+STATUSES_WITHOUT_RUNTIME = {"INFRA_PENDING", "UNREACHABLE", "DEFERRED", "BLOCKED", "TEST_PENDING"}
 RUNTIME_FAILURE_RESULTS = {"blocked", "failed", "error"}
 RUNTIME_PASS_RESULTS = {"passed", "ready", "ok", "deferred-structural"}
 


### PR DESCRIPTION
## Summary
- Add TEST_PENDING review verdict/status for lifecycle evidence that belongs to /vg:test, while keeping BLOCK for runtime/code/spec/infra blockers.
- Route /vg:next TEST_PENDING reviews to /vg:test instead of review/debug loops.
- Allow matrix-evidence-link validator to accept TEST_PENDING and add regression coverage for test-pending vs real runtime blocker cases.

## Dogfood
- PrintwayV3 Phase 6 deep scan cleared runtime blockers, but lifecycle evidence gaps were still reported as BLOCK.
- This PR generalizes that into runtime_blockers vs test_coverage_pending semantics without project-specific routes, APIs, or goal IDs.

## Tests
- bash -n commands/vg/_shared/lib/matrix-merger.sh
- python3 -m pytest scripts/tests/test_runtime_map_crud_depth.py scripts/tests/test_matrix_evidence_link_test_pending.py -q
- python3 scripts/verify-codex-mirror-equivalence.py