### PR TITLE
fix: repair invalid Codex skill YAML before curated skip

### DIFF
--- a/scripts/generate-codex-skills.sh
+++ b/scripts/generate-codex-skills.sh
@@ -269,6 +269,70 @@ target_has_curated_codex_content() {
   return 1
 }
 
+target_skill_frontmatter_invalid() {
+  local target="$1"
+  if [ ! -f "$target" ]; then
+    return 1
+  fi
+  python - "$target" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+try:
+    import yaml
+except Exception:
+    # If PyYAML is absent, do not guess. The generator can still emit valid
+    # YAML for newly written files; this guard only repairs existing targets.
+    sys.exit(1)
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+match = re.match(r"^---\n(.*?)\n---(?:\n|\Z)", text, re.S)
+if not match:
+    sys.exit(0)
+
+try:
+    front = yaml.safe_load(match.group(1)) or {}
+except yaml.YAMLError:
+    sys.exit(0)
+
+if not isinstance(front, dict):
+    sys.exit(0)
+if not front.get("name") or not front.get("description"):
+    sys.exit(0)
+sys.exit(1)
+PY
+}
+
+repair_codex_skill_frontmatter() {
+  local target="$1"
+  local skill_name="$2"
+  local description_yaml="$3"
+
+  python - "$target" "$skill_name" "$description_yaml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+name = sys.argv[2]
+description = sys.argv[3]
+text = path.read_text(encoding="utf-8", errors="replace") if path.exists() else ""
+
+match = re.match(r"^---\n.*?\n---(?:\n|\Z)", text, re.S)
+body = text[match.end():] if match else text
+frontmatter = (
+    "---\n"
+    f'name: "{name}"\n'
+    f'description: "{description}"\n'
+    "metadata:\n"
+    f'  short-description: "{description}"\n'
+    "---\n\n"
+)
+path.write_text(frontmatter + body.lstrip("\n"), encoding="utf-8")
+PY
+}
+
 write_codex_skill() {
   local src="$1"
   local target="$2"
@@ -276,6 +340,7 @@ write_codex_skill() {
   local description="$4"
   local adapter_mode="${5:-generic}"
   local preserved_adapter=""
+  local target_invalid_yaml="false"
 
   if [ -z "$description" ]; then
     description="VGFlow skill generated from ${src#$REPO_ROOT/}"
@@ -290,7 +355,17 @@ write_codex_skill() {
   description_yaml="${description//\\/\\\\}"
   description_yaml="${description_yaml//\"/\\\"}"
 
+  if target_skill_frontmatter_invalid "$target"; then
+    target_invalid_yaml="true"
+  fi
+
   if [ -f "$target" ] && [ "$FORCE" = "false" ]; then
+    if [ "$target_invalid_yaml" = "true" ]; then
+      repair_codex_skill_frontmatter "$target" "$skill_name" "$description_yaml"
+      REPAIRED=$((REPAIRED + 1))
+      echo "Repaired invalid YAML frontmatter: ${skill_name}"
+      return
+    fi
     SKIPPED=$((SKIPPED + 1))
     return
   fi
@@ -309,6 +384,12 @@ write_codex_skill() {
   #     survives, in case it carries provider-mapping customizations.
   if target_has_curated_codex_content "$target"; then
     if [ "${FORCE_OVERWRITE_CURATED:-false}" != "true" ]; then
+      if [ "$target_invalid_yaml" = "true" ]; then
+        repair_codex_skill_frontmatter "$target" "$skill_name" "$description_yaml"
+        REPAIRED=$((REPAIRED + 1))
+        echo "Repaired invalid YAML frontmatter (curated content preserved): ${skill_name}"
+        return
+      fi
       SKIPPED=$((SKIPPED + 1))
       echo "Skipped (curated content detected): ${skill_name} — use --force-overwrite-curated to override"
       return
@@ -365,6 +446,7 @@ copy_support_assets() {
 
 GENERATED=0
 SKIPPED=0
+REPAIRED=0
 
 for src in "$COMMANDS_DIR"/*.md; do
   [ -f "$src" ] || continue
@@ -389,4 +471,4 @@ for src in "$SHARED_SKILLS_DIR"/*/SKILL.md; do
 done
 
 echo ""
-echo "Summary: ${GENERATED} generated, ${SKIPPED} skipped (use --force to overwrite)"
+echo "Summary: ${GENERATED} generated, ${SKIPPED} skipped, ${REPAIRED} repaired (use --force to overwrite)"

--- a/tests/test_v3_6_2_followup.py
+++ b/tests/test_v3_6_2_followup.py
@@ -8,6 +8,8 @@ Coverage:
 5. canonical/mirror byte-identity for rotate-and-repair.md
 6. Smoke: running generator with --force on a target with HARD-GATE-CODEX
    does NOT modify the target.
+7. Deep matrix: invalid YAML repair across no-force, --force, curated,
+   mark-step heuristic, overwrite opt-in, and idempotent reruns.
 """
 from __future__ import annotations
 
@@ -30,6 +32,75 @@ _BASH_SKIP = pytest.mark.skipif(
     not shutil.which("bash") or sys.platform == "win32",
     reason="bash + POSIX semantics required for generator smoke",
 )
+
+SOURCE_DESC = 'Source says "quoted phrase" safely'
+SOURCE_BODY = "Source body generated from canonical command.\n"
+CURATED_BODY = (
+    "Curated content must remain.\n\n"
+    "<HARD-GATE-CODEX>\n"
+    "Operator MUST emit mark-step manually.\n"
+    "</HARD-GATE-CODEX>\n"
+)
+INVALID_FM = (
+    "---\n"
+    'name: "vg-yamlrepair"\n'
+    'description: "Broken "quoted phrase" frontmatter"\n'
+    "metadata:\n"
+    '  short-description: "Broken "quoted phrase" frontmatter"\n'
+    "---\n\n"
+)
+VALID_FM = (
+    "---\n"
+    'name: "vg-yamlrepair"\n'
+    'description: "curated"\n'
+    "metadata:\n"
+    '  short-description: "curated"\n'
+    "---\n\n"
+)
+
+
+def _stage_generator_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a minimal repo that exercises the real generator script."""
+    fake_repo = tmp_path / "repo"
+    (fake_repo / "commands" / "vg").mkdir(parents=True)
+    (fake_repo / "skills").mkdir(parents=True)
+    (fake_repo / "codex-skills" / "vg-yamlrepair").mkdir(parents=True)
+
+    (fake_repo / "commands" / "vg" / "yamlrepair.md").write_text(
+        "---\n"
+        "name: vg:yamlrepair\n"
+        f"description: {SOURCE_DESC}\n"
+        "---\n\n"
+        f"{SOURCE_BODY}",
+        encoding="utf-8",
+    )
+
+    (fake_repo / "scripts").mkdir()
+    shutil.copy(GENERATOR, fake_repo / "scripts" / "generate-codex-skills.sh")
+    os.chmod(fake_repo / "scripts" / "generate-codex-skills.sh", 0o755)
+    return fake_repo, fake_repo / "codex-skills" / "vg-yamlrepair" / "SKILL.md"
+
+
+def _run_generator(fake_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(fake_repo / "scripts" / "generate-codex-skills.sh"), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _frontmatter_from_text(text: str) -> dict:
+    fm_text = text.split("---", 2)[1]
+    return yaml.safe_load(fm_text)
+
+
+def _assert_valid_source_frontmatter(text: str) -> None:
+    fm = _frontmatter_from_text(text)
+    assert fm["name"] == "vg-yamlrepair"
+    assert fm["description"] == SOURCE_DESC
+    assert fm["metadata"]["short-description"] == SOURCE_DESC
 
 
 # ── content checks ────────────────────────────────────────────────────────
@@ -192,3 +263,134 @@ def test_generator_repairs_invalid_yaml_even_when_curated(tmp_path):
     assert "<HARD-GATE-CODEX>" in repaired
     assert "Source body that should not replace curated content." not in repaired
     assert "Repaired invalid YAML frontmatter" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_repairs_invalid_yaml_existing_target_without_force(tmp_path):
+    """No-force skip path must repair invalid frontmatter before returning."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    target.write_text(
+        INVALID_FM + "Manual non-curated content must remain.\n",
+        encoding="utf-8",
+    )
+
+    r = _run_generator(fake_repo)
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    repaired = target.read_text(encoding="utf-8")
+    _assert_valid_source_frontmatter(repaired)
+    assert "Manual non-curated content must remain." in repaired
+    assert SOURCE_BODY not in repaired
+    assert "Repaired invalid YAML frontmatter: vg-yamlrepair" in r.stdout
+    assert "Summary: 0 generated, 0 skipped, 1 repaired" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_regenerates_non_curated_invalid_yaml_when_forced(tmp_path):
+    """--force may replace invalid non-curated targets with generated content."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    target.write_text(
+        INVALID_FM + "Manual non-curated content should be replaced.\n",
+        encoding="utf-8",
+    )
+
+    r = _run_generator(fake_repo, "--force")
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    generated = target.read_text(encoding="utf-8")
+    _assert_valid_source_frontmatter(generated)
+    assert SOURCE_BODY in generated
+    assert "Manual non-curated content should be replaced." not in generated
+    assert "Generated: vg-yamlrepair" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_repairs_curated_invalid_yaml_without_force(tmp_path):
+    """Curated targets still get frontmatter repair on no-force runs."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    target.write_text(INVALID_FM + CURATED_BODY, encoding="utf-8")
+
+    r = _run_generator(fake_repo)
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    repaired = target.read_text(encoding="utf-8")
+    _assert_valid_source_frontmatter(repaired)
+    assert CURATED_BODY in repaired
+    assert SOURCE_BODY not in repaired
+    assert "Repaired invalid YAML frontmatter: vg-yamlrepair" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_force_overwrite_curated_replaces_body(tmp_path):
+    """Explicit override is still an escape hatch for curated targets."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    target.write_text(VALID_FM + CURATED_BODY, encoding="utf-8")
+
+    r = _run_generator(fake_repo, "--force-overwrite-curated")
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    generated = target.read_text(encoding="utf-8")
+    _assert_valid_source_frontmatter(generated)
+    assert SOURCE_BODY in generated
+    assert CURATED_BODY not in generated
+    assert "<HARD-GATE-CODEX>" not in generated
+    assert "Generated: vg-yamlrepair" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_mark_step_heuristic_preserves_curated_without_hard_gate(tmp_path):
+    """Eight explicit mark-step lines count as curated content without hard gate."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    mark_steps = "\n".join(
+        f"vg-orchestrator mark-step review marker_{i}" for i in range(8)
+    )
+    original = VALID_FM + "Manual marker table.\n" + mark_steps + "\n"
+    target.write_text(original, encoding="utf-8")
+
+    r = _run_generator(fake_repo, "--force")
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    assert target.read_text(encoding="utf-8") == original
+    assert "Skipped (curated content detected): vg-yamlrepair" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_mark_step_heuristic_repairs_invalid_yaml(tmp_path):
+    """Invalid YAML is repaired even when curation is detected by mark-step count."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    mark_steps = "\n".join(
+        f"vg-orchestrator mark-step review marker_{i}" for i in range(8)
+    )
+    target.write_text(
+        INVALID_FM + "Manual marker table.\n" + mark_steps + "\n",
+        encoding="utf-8",
+    )
+
+    r = _run_generator(fake_repo, "--force")
+
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+    repaired = target.read_text(encoding="utf-8")
+    _assert_valid_source_frontmatter(repaired)
+    assert "Manual marker table." in repaired
+    assert mark_steps in repaired
+    assert SOURCE_BODY not in repaired
+    assert "Repaired invalid YAML frontmatter (curated content preserved)" in r.stdout
+
+
+@_BASH_SKIP
+def test_generator_repair_then_rerun_is_idempotent_for_curated_target(tmp_path):
+    """After repair, a second --force run skips curated content unchanged."""
+    fake_repo, target = _stage_generator_repo(tmp_path)
+    target.write_text(INVALID_FM + CURATED_BODY, encoding="utf-8")
+
+    first = _run_generator(fake_repo, "--force")
+    after_first = target.read_text(encoding="utf-8")
+    second = _run_generator(fake_repo, "--force")
+    after_second = target.read_text(encoding="utf-8")
+
+    assert first.returncode == 0, f"first run failed\n{first.stdout}\n{first.stderr}"
+    assert second.returncode == 0, f"second run failed\n{second.stdout}\n{second.stderr}"
+    _assert_valid_source_frontmatter(after_first)
+    assert after_second == after_first
+    assert "Repaired invalid YAML frontmatter (curated content preserved)" in first.stdout
+    assert "Skipped (curated content detected): vg-yamlrepair" in second.stdout

--- a/tests/test_v3_6_2_followup.py
+++ b/tests/test_v3_6_2_followup.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GENERATOR = REPO_ROOT / "scripts" / "generate-codex-skills.sh"
@@ -136,3 +137,58 @@ def test_generator_force_does_not_clobber_curated(tmp_path):
     )
     # And stdout should mention the skip
     assert "Skipped (curated content detected)" in r.stdout or "vg-curatedtest" in r.stdout
+
+@_BASH_SKIP
+def test_generator_repairs_invalid_yaml_even_when_curated(tmp_path):
+    """Invalid SKILL frontmatter must not stay skipped behind curated guard."""
+    fake_repo = tmp_path / "repo"
+    (fake_repo / "commands" / "vg").mkdir(parents=True)
+    (fake_repo / "skills").mkdir(parents=True)
+    (fake_repo / "codex-skills" / "vg-yamlrepair").mkdir(parents=True)
+
+    (fake_repo / "commands" / "vg" / "yamlrepair.md").write_text(
+        "---\n"
+        "name: vg:yamlrepair\n"
+        "description: Source says \"quoted phrase\" safely\n"
+        "---\n\n"
+        "Source body that should not replace curated content.\n",
+        encoding="utf-8",
+    )
+
+    target = fake_repo / "codex-skills" / "vg-yamlrepair" / "SKILL.md"
+    target.write_text(
+        '---\n'
+        'name: "vg-yamlrepair"\n'
+        'description: "Broken "quoted phrase" frontmatter"\n'
+        'metadata:\n'
+        '  short-description: "Broken "quoted phrase" frontmatter"\n'
+        '---\n\n'
+        "Curated content must remain.\n\n"
+        "<HARD-GATE-CODEX>\n"
+        "Operator MUST emit mark-step manually.\n"
+        "</HARD-GATE-CODEX>\n",
+        encoding="utf-8",
+    )
+
+    (fake_repo / "scripts").mkdir()
+    shutil.copy(GENERATOR, fake_repo / "scripts" / "generate-codex-skills.sh")
+    os.chmod(fake_repo / "scripts" / "generate-codex-skills.sh", 0o755)
+
+    r = subprocess.run(
+        ["bash", str(fake_repo / "scripts" / "generate-codex-skills.sh"), "--force"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert r.returncode == 0, f"generator exited {r.returncode}\n{r.stdout}\n{r.stderr}"
+
+    repaired = target.read_text(encoding="utf-8")
+    fm_text = repaired.split("---", 2)[1]
+    fm = yaml.safe_load(fm_text)
+    assert fm["name"] == "vg-yamlrepair"
+    assert fm["description"] == 'Source says "quoted phrase" safely'
+    assert "Curated content must remain." in repaired
+    assert "<HARD-GATE-CODEX>" in repaired
+    assert "Source body that should not replace curated content." not in repaired
+    assert "Repaired invalid YAML frontmatter" in r.stdout


### PR DESCRIPTION
## Summary
- detect invalid SKILL.md YAML frontmatter before curated-content skip logic
- repair only frontmatter when target is curated, preserving HARD-GATE-CODEX/manual content
- add deep generator lifecycle regression matrix for no-force, --force, curated guard, mark-step heuristic, overwrite opt-in, and idempotent reruns

## Tests
- pytest tests/test_v3_6_2_followup.py tests/test_v3_6_1_skill_yaml_validity.py tests/test_codex_marker_coverage.py tests/test_v3_6_codex_telemetry_parity.py
- bash -n scripts/generate-codex-skills.sh
- git diff --check