### PR TITLE
Fix global VG config resolution

### DIFF
--- a/.claude/commands/vg/_shared/config-loader.md
+++ b/.claude/commands/vg/_shared/config-loader.md
@@ -32,6 +32,23 @@ fi
 VG_TMP="${TMPDIR:-/tmp}"
 mkdir -p "$VG_TMP" 2>/dev/null
 
+# --- Config path (v3 global-only layout first, legacy fallback) ---
+if [ -z "${VG_CONFIG_PATH:-}" ]; then
+  VG_CONFIG_PATH=""
+  for candidate in ".vg/config.md" ".claude/vg.config.md" "vg.config.md"; do
+    if [ -f "$candidate" ]; then
+      VG_CONFIG_PATH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$VG_CONFIG_PATH" ]; then
+  echo "⛔ CONFIG ERROR: neither .vg/config.md nor .claude/vg.config.md found."
+  echo "  Run /vg:init to generate config."
+  exit 1
+fi
+export VG_CONFIG_PATH
+
 # --- Graphify detection (single source of truth) ---
 GRAPHIFY_ENABLED=$(awk '/^graphify:/{f=1; next} f && /^[a-z_]+:/{f=0} f && /enabled:/{print $2; exit}' "${VG_CONFIG_PATH:-.claude/vg.config.md}" 2>/dev/null | tr -d '"\r' || echo "false")
 
@@ -125,31 +142,12 @@ After sourcing: all bash blocks MUST use `${PYTHON_BIN}`, `${VG_TMP}/`, `${REPO_
 
 ## How to Load Config
 
-1. **Resolve config path** — v2.84.0 dual-mode lookup (v3 layout first, legacy fallback):
-   - **NEW v3 layout:** `.vg/config.md` (post `vg-migrate-v3.sh` migration)
-   - **LEGACY:** `.claude/vg.config.md` (v2.x project-local install)
-2. **If neither exists** → STOP: "Config not found. Run `/vg:init` to create config."
+1. **Resolve config path** — prefer `.vg/config.md`, fallback `.claude/vg.config.md`, then legacy root `vg.config.md`.
+2. **If file missing** → STOP: "Config not found. Run `/vg:init` to create config."
 
 ### BOM Strip + Required Field Validation
 
 ```bash
-# v2.84.0 Stage 7 critical: dual-mode config path resolution.
-# Post `vg-migrate-v3.sh` migration, vg.config.md moves to .vg/config.md
-# (vg. prefix dropped inside .vg/ — see resolve_vg_doc()). Legacy projects
-# still have .claude/vg.config.md. Probe both, prefer new layout.
-VG_CONFIG_PATH=""
-for candidate in ".vg/config.md" ".claude/vg.config.md"; do
-  if [ -f "$candidate" ]; then
-    VG_CONFIG_PATH="$candidate"
-    break
-  fi
-done
-if [ -z "$VG_CONFIG_PATH" ]; then
-  echo "⛔ CONFIG ERROR: neither .vg/config.md nor .claude/vg.config.md found."
-  echo "  Run /vg:init to generate config."
-  exit 1
-fi
-
 # Strip BOM + CRLF (Windows editors may add UTF-8 BOM and CR line endings)
 # — tightened 2026-04-17, CR strip added 2026-05-02 (Issue #88).
 # Write stripped content to a clean temp file so downstream parsers can use it.
@@ -497,7 +495,7 @@ their `.claude/vg.config.md`.
 **Read pattern (used by every inject site + reflector trigger):**
 
 ```bash
-META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "${VG_CONFIG_PATH:-.claude/vg.config.md}" 2>/dev/null \
+META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null \
                    | awk '{print $2}' | tr -d '"\r' || echo "disabled")
 # Defaults to disabled when key absent — fail-safe.
 ```

--- a/.claude/commands/vg/_shared/deploy/execute.md
+++ b/.claude/commands/vg/_shared/deploy/execute.md
@@ -35,14 +35,24 @@ try:
 except Exception:
   print('')" 2>/dev/null)
 
-  read_cmd() { ${PYTHON_BIN:-python3} -c "
-import re
-text = open('.claude/vg.config.md', encoding='utf-8').read()
-em = re.search(r'^[[:space:]]+${env}:[[:space:]]*\$', text, re.M)
-if not em: print(''); exit()
-section = text[em.end():em.end()+5000]
-m = re.search(r'^[[:space:]]+$1:[[:space:]]*\"([^\"]*)\"', section, re.M)
-print(m.group(1) if m else '')" 2>/dev/null; }
+  read_cmd() {
+    VG_DEPLOY_ENV="$env" VG_DEPLOY_KEY="$1" ${PYTHON_BIN:-python3} <<'PY' 2>/dev/null
+import os, re
+cfg = os.environ['VG_CONFIG_PATH']
+env = os.environ.get('VG_DEPLOY_ENV', '')
+key = os.environ.get('VG_DEPLOY_KEY', '')
+text = open(cfg, encoding='utf-8').read()
+em = re.search(r'^[ \t]+%s:[ \t]*$' % re.escape(env), text, re.M)
+if not em:
+    print('')
+    raise SystemExit
+tail = text[em.end():]
+nm = re.search(r'^[ \t]{2}[A-Za-z0-9_-]+:[ \t]*$', tail, re.M)
+section = tail[:nm.start()] if nm else tail
+m = re.search(r'^[ \t]+%s:[ \t]*["\']?([^"\'\n]*)' % re.escape(key), section, re.M)
+print(m.group(1).strip() if m else '')
+PY
+  }
 
   PRE_CMD=$(read_cmd "pre")
   BUILD_CMD=$(read_cmd "build")
@@ -65,7 +75,7 @@ open('${DEPLOY_RESULTS_JSON}', 'w').write(json.dumps(d))"
   # Loads deploy-specific procedural+declarative rules and exposes them via
   # BOOTSTRAP_RULES_BLOCK env var so the vg-deploy-executor capsule can read
   # them. Gated by vg.config.md::meta_memory_mode (default OFF — disabled).
-  META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" vg.config.md 2>/dev/null | awk '{print $2}' || echo "disabled")
+  META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null | awk '{print $2}' || echo "disabled")
   BOOTSTRAP_RULES_BLOCK=""
   if [ "$META_MEMORY_MODE" = "inject-as-advice" ] || [ "$META_MEMORY_MODE" = "default" ]; then
     HAS_DOCKERFILE=$([ -f Dockerfile ] && echo "true" || echo "false")

--- a/.claude/commands/vg/_shared/deploy/persist-and-close.md
+++ b/.claude/commands/vg/_shared/deploy/persist-and-close.md
@@ -39,7 +39,7 @@ After `phase.deploy_completed` emits, spawn vg-reflector subagent IF
 
 ```bash
 # Check rollout flag
-META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" vg.config.md 2>/dev/null | awk '{print $2}' || echo "disabled")
+META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null | awk '{print $2}' || echo "disabled")
 
 if [ "$META_MEMORY_MODE" != "disabled" ] && [ "$EVENT_TYPE" = "phase.deploy_completed" ]; then
   # Narrate spawn (orchestrator UX baseline R2)

--- a/.claude/commands/vg/_shared/deploy/preflight.md
+++ b/.claude/commands/vg/_shared/deploy/preflight.md
@@ -18,6 +18,24 @@ if [ -z "$PHASE_DIR" ] || [ ! -d "$PHASE_DIR" ]; then
   exit 1
 fi
 
+# Resolve project config. Global-only installs keep project data in .vg/config.md;
+# legacy project-local installs used .claude/vg.config.md.
+VG_CONFIG_PATH="${VG_CONFIG_PATH:-}"
+if [ -z "$VG_CONFIG_PATH" ]; then
+  for candidate in ".vg/config.md" ".claude/vg.config.md" "vg.config.md"; do
+    if [ -f "$candidate" ]; then
+      VG_CONFIG_PATH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$VG_CONFIG_PATH" ]; then
+  echo "⛔ Config not found. Expected .vg/config.md or legacy .claude/vg.config.md."
+  echo "   Run /vg:init or /vg:update --repair to restore project config."
+  exit 1
+fi
+export VG_CONFIG_PATH
+
 # Build-complete check (override: --allow-build-incomplete)
 BUILD_STATUS=$(${PYTHON_BIN:-python3} -c "
 import json
@@ -120,13 +138,15 @@ if [[ "$ARGUMENTS" =~ --envs=([a-z,]+) ]]; then
   SELECTED_ENVS="${BASH_REMATCH[1]}"
 elif [[ "$ARGUMENTS" =~ --all-envs ]]; then
   SELECTED_ENVS=$(${PYTHON_BIN:-python3} -c "
-import re
-text = open('.claude/vg.config.md', encoding='utf-8').read()
-m = re.search(r'^environments:\s*\$', text, re.M)
+import os, re
+text = open(os.environ['VG_CONFIG_PATH'], encoding='utf-8').read()
+m = re.search(r'^environments:\s*$', text, re.M)
 if not m: print(''); exit()
-section = text[m.end():m.end()+10000]
+tail = text[m.end():]
+end = re.search(r'^[A-Za-z_][A-Za-z0-9_-]*:\s*', tail, re.M)
+section = tail[:end.start()] if end else tail
 envs = []
-for em in re.finditer(r'^\s+(local|sandbox|staging|prod):\s*\$', section, re.M):
+for em in re.finditer(r'^[ \t]{2}([A-Za-z0-9_-]+):\s*$', section, re.M):
   if em.group(1) != 'local':
     envs.append(em.group(1))
 print(','.join(envs))")
@@ -161,7 +181,7 @@ fi
 
 # Validate each env exists in config
 for env in $(echo "$SELECTED_ENVS" | tr ',' ' '); do
-  if ! grep -qE "^[[:space:]]+${env}:[[:space:]]*\$" .claude/vg.config.md; then
+  if ! grep -qE "^[[:space:]]+${env}:[[:space:]]*\$" "$VG_CONFIG_PATH"; then
     echo "⛔ Env '${env}' not found in vg.config.md environments — abort"
     exit 1
   fi

--- a/.claude/scripts/lib/codex_vg_env.py
+++ b/.claude/scripts/lib/codex_vg_env.py
@@ -81,6 +81,13 @@ def load_config(config_path: Path) -> dict[str, Any]:
             stack.append((indent, child))
     return root
 
+def resolve_config_path(root: Path) -> Path:
+    for rel in (".vg/config.md", ".claude/vg.config.md", "vg.config.md"):
+        candidate = root / rel
+        if candidate.exists():
+            return candidate
+    return root / ".vg" / "config.md"
+
 
 def cfg_get(config: dict[str, Any], dotted: str, default: Any = "") -> Any:
     cur: Any = config
@@ -214,7 +221,7 @@ class VGEnv:
 
 def build_env(phase: str, start: Path | None = None) -> VGEnv:
     root = repo_root(start)
-    config_path = root / ".claude" / "vg.config.md"
+    config_path = resolve_config_path(root)
     config = load_config(config_path)
     planning_rel = cfg_get(config, "paths.planning_dir", cfg_get(config, "paths.planning", ".vg"))
     phases_rel = cfg_get(config, "paths.phases_dir", cfg_get(config, "paths.phases", f"{planning_rel}/phases"))

--- a/.claude/scripts/vg_deploy_aggregator.py
+++ b/.claude/scripts/vg_deploy_aggregator.py
@@ -39,7 +39,16 @@ for _stream in (sys.stdout, sys.stderr):
 
 VG_ROOT = Path(".vg")
 PHASES_DIR = VG_ROOT / "phases"
-CONFIG_PATH = Path(".claude") / "vg.config.md"
+
+def resolve_config_path(root: Path = Path(".")) -> Path | None:
+    """Return project VG config path, preferring v3 global-only layout."""
+    for rel in (".vg/config.md", ".claude/vg.config.md", "vg.config.md"):
+        candidate = root / rel
+        if candidate.exists():
+            return candidate
+    return None
+
+CONFIG_PATH = resolve_config_path()
 
 
 def _load_sandbox_runtime_keys() -> tuple[str, str]:
@@ -57,7 +66,7 @@ def _load_sandbox_runtime_keys() -> tuple[str, str]:
     """
     # INTENTIONAL_HARDCODE: docstring example + helper fallback (Phase K1 register §4)
     fallback_alias, fallback_path = "vollx", "/home/vollx/vollxssp"
-    if not CONFIG_PATH.exists():
+    if CONFIG_PATH is None or not CONFIG_PATH.exists():
         return fallback_alias, fallback_path
     try:
         text = CONFIG_PATH.read_text(encoding="utf-8", errors="replace")

--- a/.claude/scripts/vg_deploy_runbook_drafter.py
+++ b/.claude/scripts/vg_deploy_runbook_drafter.py
@@ -35,7 +35,15 @@ for _stream in (sys.stdout, sys.stderr):
             pass
 
 
-CONFIG_PATH = Path(".claude") / "vg.config.md"
+def resolve_config_path(root: Path = Path(".")) -> Path | None:
+    """Return project VG config path, preferring v3 global-only layout."""
+    for rel in (".vg/config.md", ".claude/vg.config.md", "vg.config.md"):
+        candidate = root / rel
+        if candidate.exists():
+            return candidate
+    return None
+
+CONFIG_PATH = resolve_config_path()
 
 
 def _load_sandbox_runtime_keys() -> tuple[str, str]:
@@ -55,7 +63,7 @@ def _load_sandbox_runtime_keys() -> tuple[str, str]:
     """
     # INTENTIONAL_HARDCODE: helper fallback (Phase K1 register §4)
     fallback_prefix, fallback_path = "ssh vollx", "/home/vollx/vollxssp"
-    if not CONFIG_PATH.exists():
+    if CONFIG_PATH is None or not CONFIG_PATH.exists():
         return fallback_prefix, fallback_path
     try:
         text = CONFIG_PATH.read_text(encoding="utf-8", errors="replace")

--- a/.claude/scripts/vg_uninstall.py
+++ b/.claude/scripts/vg_uninstall.py
@@ -74,6 +74,9 @@ ROOT_FILES = (
     "vg-ext",
 )
 
+LEGACY_CONFIG = ".claude/vg.config.md"
+MODERN_CONFIG = ".vg/config.md"
+
 
 def _read_json(path: Path) -> dict | None:
     try:
@@ -174,8 +177,32 @@ def _remove_agent_entries_from_toml(config_path: Path, *, apply: bool) -> bool:
     return changed
 
 
-def _collect_paths(root: Path, purge_state: bool) -> list[Path]:
+def _same_file_bytes(left: Path, right: Path) -> bool:
+    try:
+        return left.read_bytes() == right.read_bytes()
+    except OSError:
+        return False
+
+
+def _plan_config_migration(root: Path, purge_state: bool) -> tuple[str, Path | None, Path | None]:
+    """Plan legacy config migration for global-only project cleanup."""
+    if purge_state:
+        return ("none", None, None)
+
+    legacy = root / LEGACY_CONFIG
+    modern = root / MODERN_CONFIG
+    if not legacy.exists():
+        return ("none", None, None)
+    if not modern.exists():
+        return ("migrate", legacy, modern)
+    if _same_file_bytes(legacy, modern):
+        return ("remove_legacy", legacy, modern)
+    return ("conflict", legacy, modern)
+
+
+def _collect_paths(root: Path, purge_state: bool, extra_paths: Iterable[Path] = ()) -> list[Path]:
     paths = [root / rel for rel in (*CLAUDE_PATHS, *CODEX_PATHS, *ROOT_FILES)]
+    paths.extend(extra_paths)
 
     claude_skills = root / ".claude" / "skills"
     if claude_skills.exists():
@@ -267,7 +294,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         if path.exists() and _remove_agent_entries_from_toml(path, apply=args.apply):
             changed_toml.append(path)
 
-    remove_paths = _collect_paths(root, args.purge_state)
+    config_action, legacy_config, modern_config = _plan_config_migration(root, args.purge_state)
+    extra_remove_paths: list[Path] = []
+    if config_action in {"migrate", "remove_legacy"} and legacy_config is not None:
+        extra_remove_paths.append(legacy_config)
+    remove_paths = _collect_paths(root, args.purge_state, extra_remove_paths)
     backup_root = root / ".vgflow-uninstall-backup" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     print("VGFlow uninstall")
@@ -281,6 +312,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"PRUNE hooks: {path}")
     for path in changed_toml:
         print(f"PRUNE codex config: {path}")
+    if config_action == "migrate" and legacy_config is not None and modern_config is not None:
+        print(f"MIGRATE config: {legacy_config} -> {modern_config}")
+    elif config_action == "remove_legacy" and legacy_config is not None and modern_config is not None:
+        print(f"REMOVE duplicate legacy config: {legacy_config} (canonical: {modern_config})")
+    elif config_action == "conflict" and legacy_config is not None and modern_config is not None:
+        print(f"KEEP legacy config: {legacy_config} differs from {modern_config}")
     for path in remove_paths:
         print(f"REMOVE: {path}")
 
@@ -288,6 +325,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("")
         print("Dry-run only. Re-run with --apply to remove. Add --purge-state to remove .vg/.planning data.")
         return 0
+
+    if config_action == "migrate" and legacy_config is not None and modern_config is not None:
+        modern_config.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(legacy_config, modern_config)
 
     for path in remove_paths:
         if path.exists():

--- a/commands/vg/_shared/config-loader.md
+++ b/commands/vg/_shared/config-loader.md
@@ -32,6 +32,23 @@ fi
 VG_TMP="${TMPDIR:-/tmp}"
 mkdir -p "$VG_TMP" 2>/dev/null
 
+# --- Config path (v3 global-only layout first, legacy fallback) ---
+if [ -z "${VG_CONFIG_PATH:-}" ]; then
+  VG_CONFIG_PATH=""
+  for candidate in ".vg/config.md" ".claude/vg.config.md" "vg.config.md"; do
+    if [ -f "$candidate" ]; then
+      VG_CONFIG_PATH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$VG_CONFIG_PATH" ]; then
+  echo "⛔ CONFIG ERROR: neither .vg/config.md nor .claude/vg.config.md found."
+  echo "  Run /vg:init to generate config."
+  exit 1
+fi
+export VG_CONFIG_PATH
+
 # --- Graphify detection (single source of truth) ---
 GRAPHIFY_ENABLED=$(awk '/^graphify:/{f=1; next} f && /^[a-z_]+:/{f=0} f && /enabled:/{print $2; exit}' "${VG_CONFIG_PATH:-.claude/vg.config.md}" 2>/dev/null | tr -d '"\r' || echo "false")
 
@@ -125,31 +142,12 @@ After sourcing: all bash blocks MUST use `${PYTHON_BIN}`, `${VG_TMP}/`, `${REPO_
 
 ## How to Load Config
 
-1. **Resolve config path** — v2.84.0 dual-mode lookup (v3 layout first, legacy fallback):
-   - **NEW v3 layout:** `.vg/config.md` (post `vg-migrate-v3.sh` migration)
-   - **LEGACY:** `.claude/vg.config.md` (v2.x project-local install)
-2. **If neither exists** → STOP: "Config not found. Run `/vg:init` to create config."
+1. **Resolve config path** — prefer `.vg/config.md`, fallback `.claude/vg.config.md`, then legacy root `vg.config.md`.
+2. **If file missing** → STOP: "Config not found. Run `/vg:init` to create config."
 
 ### BOM Strip + Required Field Validation
 
 ```bash
-# v2.84.0 Stage 7 critical: dual-mode config path resolution.
-# Post `vg-migrate-v3.sh` migration, vg.config.md moves to .vg/config.md
-# (vg. prefix dropped inside .vg/ — see resolve_vg_doc()). Legacy projects
-# still have .claude/vg.config.md. Probe both, prefer new layout.
-VG_CONFIG_PATH=""
-for candidate in ".vg/config.md" ".claude/vg.config.md"; do
-  if [ -f "$candidate" ]; then
-    VG_CONFIG_PATH="$candidate"
-    break
-  fi
-done
-if [ -z "$VG_CONFIG_PATH" ]; then
-  echo "⛔ CONFIG ERROR: neither .vg/config.md nor .claude/vg.config.md found."
-  echo "  Run /vg:init to generate config."
-  exit 1
-fi
-
 # Strip BOM + CRLF (Windows editors may add UTF-8 BOM and CR line endings)
 # — tightened 2026-04-17, CR strip added 2026-05-02 (Issue #88).
 # Write stripped content to a clean temp file so downstream parsers can use it.
@@ -497,7 +495,7 @@ their `.claude/vg.config.md`.
 **Read pattern (used by every inject site + reflector trigger):**
 
 ```bash
-META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "${VG_CONFIG_PATH:-.claude/vg.config.md}" 2>/dev/null \
+META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null \
                    | awk '{print $2}' | tr -d '"\r' || echo "disabled")
 # Defaults to disabled when key absent — fail-safe.
 ```

--- a/commands/vg/_shared/deploy/execute.md
+++ b/commands/vg/_shared/deploy/execute.md
@@ -35,14 +35,24 @@ try:
 except Exception:
   print('')" 2>/dev/null)
 
-  read_cmd() { ${PYTHON_BIN:-python3} -c "
-import re
-text = open('.claude/vg.config.md', encoding='utf-8').read()
-em = re.search(r'^[[:space:]]+${env}:[[:space:]]*\$', text, re.M)
-if not em: print(''); exit()
-section = text[em.end():em.end()+5000]
-m = re.search(r'^[[:space:]]+$1:[[:space:]]*\"([^\"]*)\"', section, re.M)
-print(m.group(1) if m else '')" 2>/dev/null; }
+  read_cmd() {
+    VG_DEPLOY_ENV="$env" VG_DEPLOY_KEY="$1" ${PYTHON_BIN:-python3} <<'PY' 2>/dev/null
+import os, re
+cfg = os.environ['VG_CONFIG_PATH']
+env = os.environ.get('VG_DEPLOY_ENV', '')
+key = os.environ.get('VG_DEPLOY_KEY', '')
+text = open(cfg, encoding='utf-8').read()
+em = re.search(r'^[ \t]+%s:[ \t]*$' % re.escape(env), text, re.M)
+if not em:
+    print('')
+    raise SystemExit
+tail = text[em.end():]
+nm = re.search(r'^[ \t]{2}[A-Za-z0-9_-]+:[ \t]*$', tail, re.M)
+section = tail[:nm.start()] if nm else tail
+m = re.search(r'^[ \t]+%s:[ \t]*["\']?([^"\'\n]*)' % re.escape(key), section, re.M)
+print(m.group(1).strip() if m else '')
+PY
+  }
 
   PRE_CMD=$(read_cmd "pre")
   BUILD_CMD=$(read_cmd "build")
@@ -65,7 +75,7 @@ open('${DEPLOY_RESULTS_JSON}', 'w').write(json.dumps(d))"
   # Loads deploy-specific procedural+declarative rules and exposes them via
   # BOOTSTRAP_RULES_BLOCK env var so the vg-deploy-executor capsule can read
   # them. Gated by vg.config.md::meta_memory_mode (default OFF — disabled).
-  META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" vg.config.md 2>/dev/null | awk '{print $2}' || echo "disabled")
+  META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null | awk '{print $2}' || echo "disabled")
   BOOTSTRAP_RULES_BLOCK=""
   if [ "$META_MEMORY_MODE" = "inject-as-advice" ] || [ "$META_MEMORY_MODE" = "default" ]; then
     HAS_DOCKERFILE=$([ -f Dockerfile ] && echo "true" || echo "false")

--- a/commands/vg/_shared/deploy/persist-and-close.md
+++ b/commands/vg/_shared/deploy/persist-and-close.md
@@ -39,7 +39,7 @@ After `phase.deploy_completed` emits, spawn vg-reflector subagent IF
 
 ```bash
 # Check rollout flag
-META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" vg.config.md 2>/dev/null | awk '{print $2}' || echo "disabled")
+META_MEMORY_MODE=$(grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH" 2>/dev/null | awk '{print $2}' || echo "disabled")
 
 if [ "$META_MEMORY_MODE" != "disabled" ] && [ "$EVENT_TYPE" = "phase.deploy_completed" ]; then
   # Narrate spawn (orchestrator UX baseline R2)

--- a/commands/vg/_shared/deploy/preflight.md
+++ b/commands/vg/_shared/deploy/preflight.md
@@ -18,6 +18,24 @@ if [ -z "$PHASE_DIR" ] || [ ! -d "$PHASE_DIR" ]; then
   exit 1
 fi
 
+# Resolve project config. Global-only installs keep project data in .vg/config.md;
+# legacy project-local installs used .claude/vg.config.md.
+VG_CONFIG_PATH="${VG_CONFIG_PATH:-}"
+if [ -z "$VG_CONFIG_PATH" ]; then
+  for candidate in ".vg/config.md" ".claude/vg.config.md" "vg.config.md"; do
+    if [ -f "$candidate" ]; then
+      VG_CONFIG_PATH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$VG_CONFIG_PATH" ]; then
+  echo "⛔ Config not found. Expected .vg/config.md or legacy .claude/vg.config.md."
+  echo "   Run /vg:init or /vg:update --repair to restore project config."
+  exit 1
+fi
+export VG_CONFIG_PATH
+
 # Build-complete check (override: --allow-build-incomplete)
 BUILD_STATUS=$(${PYTHON_BIN:-python3} -c "
 import json
@@ -120,13 +138,15 @@ if [[ "$ARGUMENTS" =~ --envs=([a-z,]+) ]]; then
   SELECTED_ENVS="${BASH_REMATCH[1]}"
 elif [[ "$ARGUMENTS" =~ --all-envs ]]; then
   SELECTED_ENVS=$(${PYTHON_BIN:-python3} -c "
-import re
-text = open('.claude/vg.config.md', encoding='utf-8').read()
-m = re.search(r'^environments:\s*\$', text, re.M)
+import os, re
+text = open(os.environ['VG_CONFIG_PATH'], encoding='utf-8').read()
+m = re.search(r'^environments:\s*$', text, re.M)
 if not m: print(''); exit()
-section = text[m.end():m.end()+10000]
+tail = text[m.end():]
+end = re.search(r'^[A-Za-z_][A-Za-z0-9_-]*:\s*', tail, re.M)
+section = tail[:end.start()] if end else tail
 envs = []
-for em in re.finditer(r'^\s+(local|sandbox|staging|prod):\s*\$', section, re.M):
+for em in re.finditer(r'^[ \t]{2}([A-Za-z0-9_-]+):\s*$', section, re.M):
   if em.group(1) != 'local':
     envs.append(em.group(1))
 print(','.join(envs))")
@@ -161,7 +181,7 @@ fi
 
 # Validate each env exists in config
 for env in $(echo "$SELECTED_ENVS" | tr ',' ' '); do
-  if ! grep -qE "^[[:space:]]+${env}:[[:space:]]*\$" .claude/vg.config.md; then
+  if ! grep -qE "^[[:space:]]+${env}:[[:space:]]*\$" "$VG_CONFIG_PATH"; then
     echo "⛔ Env '${env}' not found in vg.config.md environments — abort"
     exit 1
   fi

--- a/scripts/tests/test_vg_uninstall.py
+++ b/scripts/tests/test_vg_uninstall.py
@@ -117,6 +117,64 @@ def test_uninstall_apply_moves_vg_surfaces_to_backup(tmp_path: Path) -> None:
     assert list(backups[0].rglob("build.md"))
 
 
+def test_uninstall_migrates_legacy_config_before_pruning(tmp_path: Path) -> None:
+    (tmp_path / ".claude" / "commands" / "vg").mkdir(parents=True)
+    (tmp_path / ".claude" / "commands" / "vg" / "build.md").write_text("x", encoding="utf-8")
+    (tmp_path / ".claude" / "vg.config.md").write_text("project_name: legacy\n", encoding="utf-8")
+
+    rc = vg_uninstall.cmd_run(
+        type(
+            "Args",
+            (),
+            {"root": str(tmp_path), "apply": True, "purge_state": False},
+        )()
+    )
+
+    assert rc == 0
+    assert (tmp_path / ".vg" / "config.md").read_text(encoding="utf-8") == "project_name: legacy\n"
+    assert not (tmp_path / ".claude" / "vg.config.md").exists()
+    backups = list((tmp_path / ".vgflow-uninstall-backup").glob("*"))
+    assert list(backups[0].rglob("vg.config.md"))
+
+
+def test_uninstall_removes_duplicate_legacy_config_when_modern_matches(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir(parents=True)
+    (tmp_path / ".vg").mkdir(parents=True)
+    (tmp_path / ".claude" / "vg.config.md").write_text("project_name: same\n", encoding="utf-8")
+    (tmp_path / ".vg" / "config.md").write_text("project_name: same\n", encoding="utf-8")
+
+    rc = vg_uninstall.cmd_run(
+        type(
+            "Args",
+            (),
+            {"root": str(tmp_path), "apply": True, "purge_state": False},
+        )()
+    )
+
+    assert rc == 0
+    assert (tmp_path / ".vg" / "config.md").read_text(encoding="utf-8") == "project_name: same\n"
+    assert not (tmp_path / ".claude" / "vg.config.md").exists()
+
+
+def test_uninstall_keeps_divergent_legacy_config(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir(parents=True)
+    (tmp_path / ".vg").mkdir(parents=True)
+    (tmp_path / ".claude" / "vg.config.md").write_text("project_name: legacy\n", encoding="utf-8")
+    (tmp_path / ".vg" / "config.md").write_text("project_name: modern\n", encoding="utf-8")
+
+    rc = vg_uninstall.cmd_run(
+        type(
+            "Args",
+            (),
+            {"root": str(tmp_path), "apply": True, "purge_state": False},
+        )()
+    )
+
+    assert rc == 0
+    assert (tmp_path / ".claude" / "vg.config.md").read_text(encoding="utf-8") == "project_name: legacy\n"
+    assert (tmp_path / ".vg" / "config.md").read_text(encoding="utf-8") == "project_name: modern\n"
+
+
 def test_uninstall_does_not_touch_global_codex_config(tmp_path: Path, monkeypatch) -> None:
     home = tmp_path / "home"
     global_config = home / ".codex" / "config.toml"

--- a/scripts/vg_deploy_aggregator.py
+++ b/scripts/vg_deploy_aggregator.py
@@ -39,7 +39,16 @@ for _stream in (sys.stdout, sys.stderr):
 
 VG_ROOT = Path(".vg")
 PHASES_DIR = VG_ROOT / "phases"
-CONFIG_PATH = Path(".claude") / "vg.config.md"
+
+def resolve_config_path(root: Path = Path(".")) -> Path | None:
+    """Return project VG config path, preferring v3 global-only layout."""
+    for rel in (".vg/config.md", ".claude/vg.config.md", "vg.config.md"):
+        candidate = root / rel
+        if candidate.exists():
+            return candidate
+    return None
+
+CONFIG_PATH = resolve_config_path()
 
 
 def _load_sandbox_runtime_keys() -> tuple[str, str]:
@@ -57,7 +66,7 @@ def _load_sandbox_runtime_keys() -> tuple[str, str]:
     """
     # INTENTIONAL_HARDCODE: docstring example + helper fallback (Phase K1 register §4)
     fallback_alias, fallback_path = "vollx", "/home/vollx/vollxssp"
-    if not CONFIG_PATH.exists():
+    if CONFIG_PATH is None or not CONFIG_PATH.exists():
         return fallback_alias, fallback_path
     try:
         text = CONFIG_PATH.read_text(encoding="utf-8", errors="replace")

--- a/scripts/vg_deploy_runbook_drafter.py
+++ b/scripts/vg_deploy_runbook_drafter.py
@@ -35,7 +35,15 @@ for _stream in (sys.stdout, sys.stderr):
             pass
 
 
-CONFIG_PATH = Path(".claude") / "vg.config.md"
+def resolve_config_path(root: Path = Path(".")) -> Path | None:
+    """Return project VG config path, preferring v3 global-only layout."""
+    for rel in (".vg/config.md", ".claude/vg.config.md", "vg.config.md"):
+        candidate = root / rel
+        if candidate.exists():
+            return candidate
+    return None
+
+CONFIG_PATH = resolve_config_path()
 
 
 def _load_sandbox_runtime_keys() -> tuple[str, str]:
@@ -55,7 +63,7 @@ def _load_sandbox_runtime_keys() -> tuple[str, str]:
     """
     # INTENTIONAL_HARDCODE: helper fallback (Phase K1 register §4)
     fallback_prefix, fallback_path = "ssh vollx", "/home/vollx/vollxssp"
-    if not CONFIG_PATH.exists():
+    if CONFIG_PATH is None or not CONFIG_PATH.exists():
         return fallback_prefix, fallback_path
     try:
         text = CONFIG_PATH.read_text(encoding="utf-8", errors="replace")

--- a/scripts/vg_uninstall.py
+++ b/scripts/vg_uninstall.py
@@ -74,6 +74,9 @@ ROOT_FILES = (
     "vg-ext",
 )
 
+LEGACY_CONFIG = ".claude/vg.config.md"
+MODERN_CONFIG = ".vg/config.md"
+
 
 def _read_json(path: Path) -> dict | None:
     try:
@@ -174,8 +177,32 @@ def _remove_agent_entries_from_toml(config_path: Path, *, apply: bool) -> bool:
     return changed
 
 
-def _collect_paths(root: Path, purge_state: bool) -> list[Path]:
+def _same_file_bytes(left: Path, right: Path) -> bool:
+    try:
+        return left.read_bytes() == right.read_bytes()
+    except OSError:
+        return False
+
+
+def _plan_config_migration(root: Path, purge_state: bool) -> tuple[str, Path | None, Path | None]:
+    """Plan legacy config migration for global-only project cleanup."""
+    if purge_state:
+        return ("none", None, None)
+
+    legacy = root / LEGACY_CONFIG
+    modern = root / MODERN_CONFIG
+    if not legacy.exists():
+        return ("none", None, None)
+    if not modern.exists():
+        return ("migrate", legacy, modern)
+    if _same_file_bytes(legacy, modern):
+        return ("remove_legacy", legacy, modern)
+    return ("conflict", legacy, modern)
+
+
+def _collect_paths(root: Path, purge_state: bool, extra_paths: Iterable[Path] = ()) -> list[Path]:
     paths = [root / rel for rel in (*CLAUDE_PATHS, *CODEX_PATHS, *ROOT_FILES)]
+    paths.extend(extra_paths)
 
     claude_skills = root / ".claude" / "skills"
     if claude_skills.exists():
@@ -267,7 +294,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         if path.exists() and _remove_agent_entries_from_toml(path, apply=args.apply):
             changed_toml.append(path)
 
-    remove_paths = _collect_paths(root, args.purge_state)
+    config_action, legacy_config, modern_config = _plan_config_migration(root, args.purge_state)
+    extra_remove_paths: list[Path] = []
+    if config_action in {"migrate", "remove_legacy"} and legacy_config is not None:
+        extra_remove_paths.append(legacy_config)
+    remove_paths = _collect_paths(root, args.purge_state, extra_remove_paths)
     backup_root = root / ".vgflow-uninstall-backup" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     print("VGFlow uninstall")
@@ -281,6 +312,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"PRUNE hooks: {path}")
     for path in changed_toml:
         print(f"PRUNE codex config: {path}")
+    if config_action == "migrate" and legacy_config is not None and modern_config is not None:
+        print(f"MIGRATE config: {legacy_config} -> {modern_config}")
+    elif config_action == "remove_legacy" and legacy_config is not None and modern_config is not None:
+        print(f"REMOVE duplicate legacy config: {legacy_config} (canonical: {modern_config})")
+    elif config_action == "conflict" and legacy_config is not None and modern_config is not None:
+        print(f"KEEP legacy config: {legacy_config} differs from {modern_config}")
     for path in remove_paths:
         print(f"REMOVE: {path}")
 
@@ -288,6 +325,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("")
         print("Dry-run only. Re-run with --apply to remove. Add --purge-state to remove .vg/.planning data.")
         return 0
+
+    if config_action == "migrate" and legacy_config is not None and modern_config is not None:
+        modern_config.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(legacy_config, modern_config)
 
     for path in remove_paths:
         if path.exists():

--- a/tests/test_global_config_resolution.py
+++ b/tests/test_global_config_resolution.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_module(name: str, rel: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_deploy_command_prefers_global_only_config_path():
+    preflight = (REPO_ROOT / "commands/vg/_shared/deploy/preflight.md").read_text(encoding="utf-8")
+    execute = (REPO_ROOT / "commands/vg/_shared/deploy/execute.md").read_text(encoding="utf-8")
+    text = preflight + "\n" + execute
+
+    assert 'for candidate in ".vg/config.md" ".claude/vg.config.md" "vg.config.md"' in text
+    assert "export VG_CONFIG_PATH" in text
+    assert r"r'^environments:\s*$'" in text
+    assert "end = re.search(r'^[A-Za-z_][A-Za-z0-9_-]*:\\s*', tail, re.M)" in text
+    assert r"r'^[ \t]+%s:[ \t]*$'" in text
+    assert "open('.claude/vg.config.md'" not in text
+    assert "grep -qE \"^[[:space:]]+${env}:[[:space:]]*\\$\" .claude/vg.config.md" not in text
+    assert 'grep -E "^meta_memory_mode:" "$VG_CONFIG_PATH"' in execute
+
+
+def test_config_loader_uses_resolved_config_before_graphify():
+    text = (REPO_ROOT / "commands/vg/_shared/config-loader.md").read_text(encoding="utf-8")
+
+    resolver_pos = text.index("VG_CONFIG_PATH=\"\"")
+    graphify_pos = text.index("GRAPHIFY_ENABLED=")
+    assert resolver_pos < graphify_pos
+    assert '"${VG_CONFIG_PATH:-.claude/vg.config.md}"' in text
+    assert "sed -e '1s/^\\xEF\\xBB\\xBF//' -e 's/\\r$//' \"$VG_CONFIG_PATH\"" in text
+
+
+def test_deploy_aggregator_config_resolution_prefers_vg_config(tmp_path, monkeypatch):
+    mod = load_module("vg_deploy_aggregator", "scripts/vg_deploy_aggregator.py")
+    (tmp_path / ".vg").mkdir()
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".vg" / "config.md").write_text("project_name: modern\n", encoding="utf-8")
+    (tmp_path / ".claude" / "vg.config.md").write_text("project_name: legacy\n", encoding="utf-8")
+
+    assert mod.resolve_config_path(tmp_path) == tmp_path / ".vg" / "config.md"
+
+
+def test_deploy_runbook_drafter_config_resolution_falls_back_to_legacy(tmp_path):
+    mod = load_module("vg_deploy_runbook_drafter", "scripts/vg_deploy_runbook_drafter.py")
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "vg.config.md").write_text("project_name: legacy\n", encoding="utf-8")
+
+    assert mod.resolve_config_path(tmp_path) == tmp_path / ".claude" / "vg.config.md"
+
+
+def test_codex_env_config_resolution_prefers_vg_config(tmp_path):
+    mod = load_module("codex_vg_env", ".claude/scripts/lib/codex_vg_env.py")
+    (tmp_path / ".vg").mkdir()
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".vg" / "config.md").write_text("profile: web-fullstack\n", encoding="utf-8")
+    (tmp_path / ".claude" / "vg.config.md").write_text("profile: legacy\n", encoding="utf-8")
+
+    assert mod.resolve_config_path(tmp_path) == tmp_path / ".vg" / "config.md"


### PR DESCRIPTION
## Summary
- Resolve VG config from .vg/config.md first, with legacy .claude/vg.config.md and root vg.config.md fallback.
- Update vg:deploy env parsing and deploy helper scripts to use VG_CONFIG_PATH instead of hardcoded .claude/vg.config.md.
- Sync Claude/Codex generated deploy skill mirrors and add regression tests for global-only config lookup.

## Why
Global-only install/update prunes project-local .claude files. Deploy and config helpers still hardcoded .claude/vg.config.md, so migrated projects with .vg/config.md were falsely reported as missing config.

## Tests
- pytest -q tests/test_global_config_resolution.py tests/test_deploy_decision.py tests/test_deploy_pre_test_mode.py tests/test_deploy_tasklist_enforcement.py
- rg guard: no deploy-layer direct open/grep against .claude/vg.config.md
- manual parse against Printway .vg/config.md: --all-envs resolves sandbox only; deploy fields resolve restart/health/run_prefix