### PR TITLE
fix(sync): enforce global-only VGFlow refresh

### DIFF
--- a/.claude/commands/vg/sync.md
+++ b/.claude/commands/vg/sync.md
@@ -1,7 +1,7 @@
 ---
 name: vg:sync
-description: Sync VG workflow from canonical vgflow-repo into Claude/Codex installations
-argument-hint: "[--check] [--verify] [--no-global] [--no-source]"
+description: Sync VGFlow global-only workflow for Claude Code and Codex
+argument-hint: "[--check] [--verify] [--no-global] [--global-codex] [--no-source]"
 allowed-tools:
   - Bash
   - Read
@@ -13,35 +13,38 @@ runtime_contract:
 ---
 
 <objective>
-Deploy the canonical VGFlow workflow from `vgflow-repo` into the current project
-and Codex global skill/agent directories.
+Refresh the canonical VGFlow workflow in global-only mode.
 
-Canonical source of truth:
-1. `commands/vg/` -> `.claude/commands/vg/`
-2. `skills/` -> `.claude/skills/`
-3. `scripts/` + `schemas/` + `templates/vg/` -> `.claude/`
-4. `codex-skills/` -> `.codex/skills/` and `~/.codex/skills/`
-5. `templates/codex-agents/` -> `.codex/agents/` and `~/.codex/agents/`
-6. `vg-hooks-install.py` repairs project-local Claude hooks in `.claude/settings.local.json`
+Single source of truth:
+1. VGFlow source: `~/.vgflow` (or the developer clone that owns `sync.sh`).
+2. Claude Code hooks: `~/.claude/settings.json`, with commands pointing at `$HOME/.vgflow/scripts/hooks`.
+3. Codex skills/agents: `~/.codex/skills` and `~/.codex/agents`.
+4. Codex hooks: `~/.codex/hooks.json`, with `codex_hooks = true` in `~/.codex/config.toml`.
+5. Current project: cleanup target only. Project-local VG-owned `.claude/` and `.codex/` workflow surfaces are pruned, then `.vg/.install-target=global` is written.
 
-`--no-source` is accepted only for backward compatibility. It is a no-op
-because this repository is now the source of truth; RTB/.claude source probing
-is intentionally removed.
+`/vg:sync` MUST NOT copy `commands/vg`, `skills`, `scripts`, `schemas`,
+`templates/vg`, `codex-skills`, or Codex agents into the current project.
+
+Deprecated flags are accepted only for compatibility:
+- `--no-global` is a no-op; global deploy is mandatory.
+- `--global-codex` is a no-op; global Codex deploy is mandatory.
+- `--no-source` is a no-op; this repository/global install is the source.
 </objective>
 
 <process>
 
 <step name="0_detect">
 
-Resolve `vgflow-repo/sync.sh`:
+Resolve `sync.sh` from the global/source VGFlow install:
 
 ```bash
 SYNC_SH=""
 for candidate in \
   "${VGFLOW_REPO:-}/sync.sh" \
+  "${VG_HOME:-}/sync.sh" \
+  "${HOME}/.vgflow/sync.sh" \
   "../vgflow-repo/sync.sh" \
   "../../vgflow-repo/sync.sh" \
-  "${HOME}/Workspace/Messi/Code/vgflow-repo/sync.sh" \
   "vgflow/sync.sh"; do
   if [ -f "$candidate" ]; then
     SYNC_SH="$candidate"
@@ -50,8 +53,8 @@ for candidate in \
 done
 
 if [ -z "$SYNC_SH" ]; then
-  echo "vgflow-repo sync.sh not found."
-  echo "Set VGFLOW_REPO=/path/to/vgflow-repo or clone it beside this project."
+  echo "VGFlow sync.sh not found."
+  echo "Set VGFLOW_REPO=/path/to/vgflow or install global VGFlow at ~/.vgflow."
   exit 1
 fi
 
@@ -63,36 +66,39 @@ echo "Using sync script: $SYNC_SH"
 <step name="1_run">
 
 Parse args:
-- `--check`: dry-run, no writes, exits 1 if drift exists
-- `--verify`: short-circuit and run functional Codex mirror equivalence
-- `--no-global`: skip `~/.codex` deploy
-- `--no-source`: deprecated no-op, passed through for compatibility
+- `--check`: dry-run, no writes; exits 1 if global hooks/skills are missing or project-local VG surfaces remain
+- `--verify`: run functional Codex mirror equivalence and exit
+- `--no-global`: deprecated no-op
+- `--global-codex`: deprecated no-op
+- `--no-source`: deprecated no-op
 
 ```bash
-bash "$SYNC_SH" $ARGUMENTS
+bash "$SYNC_SH" ${ARGUMENTS}
 ```
 
-`--verify` delegates to `scripts/verify-codex-mirror-equivalence.py` inside
-`vgflow-repo`. Installed projects receive the same script at
-`.claude/scripts/verify-codex-mirror-equivalence.py`.
+`sync.sh` regenerates `codex-skills` from canonical `commands/vg` and support
+skills before installing global surfaces. Then it delegates to:
 
-The script regenerates `codex-skills` from `commands/vg` and support skills
-before deployment unless `--check` is set.
+```bash
+VG_HOME="<sync-source-root>" bash "<sync-source-root>/bin/vg-cli-dispatcher.sh" install --global
+```
 
-It also installs/repairs Claude Code enforcement hooks after copying scripts:
-- `UserPromptSubmit`: pre-seeds `vg-orchestrator run-start`.
-- `Stop`: verifies `runtime_contract` evidence before the agent can claim done.
-- `PostToolUse` edit warning: warns when VG command/skill files were edited in-session.
-- `PostToolUse` Bash step tracker: writes step activity telemetry into `.vg/events.db`.
+The dispatcher is responsible for:
+- refreshing global Codex skills/agents
+- installing Codex hooks at `~/.codex/hooks.json`
+- installing Claude Code hooks at `~/.claude/settings.json`
+- pruning project-local VG-owned `.claude/` and `.codex/` files with backup
+- writing `.vg/.install-target=global`
 </step>
 
 <step name="2_report">
 
 Surface:
-- files changed or would change
-- target project path
-- whether global Codex deploy was skipped
-- functional Codex mirror check result
+- source root used for sync
+- target project used for cleanup/marker
+- stale project-local VG surfaces, if any
+- global Claude/Codex hook locations
+- functional Codex mirror result, when `--verify` is used
 
 If `--check` reports drift, suggest:
 
@@ -100,21 +106,22 @@ If `--check` reports drift, suggest:
 /vg:sync
 ```
 
-or:
+or direct source invocation:
 
 ```bash
-/vg:sync --no-global
+DEV_ROOT=/path/to/project bash ~/.vgflow/sync.sh
 ```
 </step>
 
 </process>
 
 <success_criteria>
-- Project `.claude/commands/vg` matches `vgflow-repo/commands/vg`.
-- Project `.claude/skills`, `.claude/scripts`, `.claude/schemas`, and `.claude/templates/vg` match repo source.
-- Project `.codex/skills` matches `vgflow-repo/codex-skills`.
-- Project `.codex/agents` contains VGFlow Codex agent templates.
-- If not `--no-global`, `~/.codex/skills` and `~/.codex/agents` are refreshed.
-- Project `.claude/settings.local.json` contains VG enforcement hooks for `UserPromptSubmit`, `Stop`, and both `PostToolUse` paths.
+- `~/.vgflow` exists and is the active VGFlow source.
+- `~/.claude/settings.json` contains VG hook entries that point at `$HOME/.vgflow/scripts/hooks`.
+- `~/.codex/skills` contains generated VGFlow Codex skills.
+- `~/.codex/agents` contains VGFlow Codex agent templates.
+- `~/.codex/hooks.json` contains VGFlow hook entries and `~/.codex/config.toml` has `codex_hooks = true`.
+- Project-local VG-owned `.claude/commands/vg`, `.claude/scripts`, `.claude/skills/vg-*`, `.claude/agents/vg-*`, `.codex/skills/vg-*`, and `.codex/agents/vgflow-*` are absent after sync.
+- Project `.vg/.install-target` is `global` when sync is run from a git project or a project with an existing marker.
 - `/vg:sync --verify` reports zero functional drift between command sources and Codex skill mirrors after adapter stripping.
 </success_criteria>

--- a/codex-skills/vg-field-test/SKILL.md
+++ b/codex-skills/vg-field-test/SKILL.md
@@ -157,6 +157,33 @@ process that cannot see browser tools.
 Invoke this skill as `$vg-field-test`. Treat all user text after the skill name as arguments.
 </codex_skill_adapter>
 
+<HARD-GATE-CODEX>
+Codex has no Claude PreToolUse/PostToolUse hook substrate. Claude hooks may
+auto-emit step markers, but Codex MUST emit the same hard markers explicitly
+after each matching STEP primary action.
+
+Use global VGFlow paths so global-only installs work without project-local
+`.claude/scripts` or `.claude/commands`:
+
+```bash
+VG_HOME="${VG_HOME:-$HOME/.vgflow}"
+VG_SCRIPT_ROOT="${VG_SCRIPT_ROOT:-${VG_HOME}/scripts}"
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 0_preflight
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 1_resolve_config
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 2_launch_browser
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 3_inject_overlay
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 4_wait_start
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 5_capture_loop
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 6_stop_finalize
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test 7_analyze
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step field-test complete
+```
+
+Hook/spawn mechanics may differ by provider, but marker names, order, gates,
+must-write artifacts, and telemetry contract stay identical to the Claude
+command source.
+</HARD-GATE-CODEX>
+
 
 
 <HARD-GATE>

--- a/codex-skills/vg-specs/SKILL.md
+++ b/codex-skills/vg-specs/SKILL.md
@@ -157,6 +157,32 @@ process that cannot see browser tools.
 Invoke this skill as `$vg-specs`. Treat all user text after the skill name as arguments.
 </codex_skill_adapter>
 
+<HARD-GATE-CODEX>
+Codex has no Claude PreToolUse/PostToolUse hook substrate. Claude hooks may
+auto-emit step markers, but Codex MUST emit the same hard markers explicitly
+after each matching STEP primary action.
+
+Use global VGFlow paths so global-only installs work without project-local
+`.claude/scripts` or `.claude/commands`:
+
+```bash
+VG_HOME="${VG_HOME:-$HOME/.vgflow}"
+VG_SCRIPT_ROOT="${VG_SCRIPT_ROOT:-${VG_HOME}/scripts}"
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs parse_args
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs create_task_tracker
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs check_existing
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs choose_mode
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs generate_draft
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs write_specs
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs write_interface_standards
+"${PYTHON_BIN:-python3}" "${VG_SCRIPT_ROOT}/vg-orchestrator" mark-step specs commit_and_next
+```
+
+Hook/spawn mechanics may differ by provider, but marker names, order, gates,
+must-write artifacts, and telemetry contract stay identical to the Claude
+command source.
+</HARD-GATE-CODEX>
+
 
 
 <objective>

--- a/codex-skills/vg-sync/SKILL.md
+++ b/codex-skills/vg-sync/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: "vg-sync"
-description: "Sync VG workflow from canonical vgflow-repo into Claude/Codex installations"
+description: "Sync VGFlow global-only workflow for Claude Code and Codex"
 metadata:
-  short-description: "Sync VG workflow from canonical vgflow-repo into Claude/Codex installations"
+  short-description: "Sync VGFlow global-only workflow for Claude Code and Codex"
 ---
 
 <codex_skill_adapter>
@@ -160,35 +160,38 @@ Invoke this skill as `$vg-sync`. Treat all user text after the skill name as arg
 
 
 <objective>
-Deploy the canonical VGFlow workflow from `vgflow-repo` into the current project
-and Codex global skill/agent directories.
+Refresh the canonical VGFlow workflow in global-only mode.
 
-Canonical source of truth:
-1. `commands/vg/` -> `.claude/commands/vg/`
-2. `skills/` -> `.claude/skills/`
-3. `scripts/` + `schemas/` + `templates/vg/` -> `.claude/`
-4. `codex-skills/` -> `.codex/skills/` and `~/.codex/skills/`
-5. `templates/codex-agents/` -> `.codex/agents/` and `~/.codex/agents/`
-6. `vg-hooks-install.py` repairs project-local Claude hooks in `.claude/settings.local.json`
+Single source of truth:
+1. VGFlow source: `~/.vgflow` (or the developer clone that owns `sync.sh`).
+2. Claude Code hooks: `~/.claude/settings.json`, with commands pointing at `$HOME/.vgflow/scripts/hooks`.
+3. Codex skills/agents: `~/.codex/skills` and `~/.codex/agents`.
+4. Codex hooks: `~/.codex/hooks.json`, with `codex_hooks = true` in `~/.codex/config.toml`.
+5. Current project: cleanup target only. Project-local VG-owned `.claude/` and `.codex/` workflow surfaces are pruned, then `.vg/.install-target=global` is written.
 
-`--no-source` is accepted only for backward compatibility. It is a no-op
-because this repository is now the source of truth; RTB/.claude source probing
-is intentionally removed.
+`/vg:sync` MUST NOT copy `commands/vg`, `skills`, `scripts`, `schemas`,
+`templates/vg`, `codex-skills`, or Codex agents into the current project.
+
+Deprecated flags are accepted only for compatibility:
+- `--no-global` is a no-op; global deploy is mandatory.
+- `--global-codex` is a no-op; global Codex deploy is mandatory.
+- `--no-source` is a no-op; this repository/global install is the source.
 </objective>
 
 <process>
 
 <step name="0_detect">
 
-Resolve `vgflow-repo/sync.sh`:
+Resolve `sync.sh` from the global/source VGFlow install:
 
 ```bash
 SYNC_SH=""
 for candidate in \
   "${VGFLOW_REPO:-}/sync.sh" \
+  "${VG_HOME:-}/sync.sh" \
+  "${HOME}/.vgflow/sync.sh" \
   "../vgflow-repo/sync.sh" \
   "../../vgflow-repo/sync.sh" \
-  "${HOME}/Workspace/Messi/Code/vgflow-repo/sync.sh" \
   "vgflow/sync.sh"; do
   if [ -f "$candidate" ]; then
     SYNC_SH="$candidate"
@@ -197,8 +200,8 @@ for candidate in \
 done
 
 if [ -z "$SYNC_SH" ]; then
-  echo "vgflow-repo sync.sh not found."
-  echo "Set VGFLOW_REPO=/path/to/vgflow-repo or clone it beside this project."
+  echo "VGFlow sync.sh not found."
+  echo "Set VGFLOW_REPO=/path/to/vgflow or install global VGFlow at ~/.vgflow."
   exit 1
 fi
 
@@ -210,36 +213,39 @@ echo "Using sync script: $SYNC_SH"
 <step name="1_run">
 
 Parse args:
-- `--check`: dry-run, no writes, exits 1 if drift exists
-- `--verify`: short-circuit and run functional Codex mirror equivalence
-- `--no-global`: skip `~/.codex` deploy
-- `--no-source`: deprecated no-op, passed through for compatibility
+- `--check`: dry-run, no writes; exits 1 if global hooks/skills are missing or project-local VG surfaces remain
+- `--verify`: run functional Codex mirror equivalence and exit
+- `--no-global`: deprecated no-op
+- `--global-codex`: deprecated no-op
+- `--no-source`: deprecated no-op
 
 ```bash
-bash "$SYNC_SH" $ARGUMENTS
+bash "$SYNC_SH" ${ARGUMENTS}
 ```
 
-`--verify` delegates to `scripts/verify-codex-mirror-equivalence.py` inside
-`vgflow-repo`. Installed projects receive the same script at
-`.claude/scripts/verify-codex-mirror-equivalence.py`.
+`sync.sh` regenerates `codex-skills` from canonical `commands/vg` and support
+skills before installing global surfaces. Then it delegates to:
 
-The script regenerates `codex-skills` from `commands/vg` and support skills
-before deployment unless `--check` is set.
+```bash
+VG_HOME="<sync-source-root>" bash "<sync-source-root>/bin/vg-cli-dispatcher.sh" install --global
+```
 
-It also installs/repairs Claude Code enforcement hooks after copying scripts:
-- `UserPromptSubmit`: pre-seeds `vg-orchestrator run-start`.
-- `Stop`: verifies `runtime_contract` evidence before the agent can claim done.
-- `PostToolUse` edit warning: warns when VG command/skill files were edited in-session.
-- `PostToolUse` Bash step tracker: writes step activity telemetry into `.vg/events.db`.
+The dispatcher is responsible for:
+- refreshing global Codex skills/agents
+- installing Codex hooks at `~/.codex/hooks.json`
+- installing Claude Code hooks at `~/.claude/settings.json`
+- pruning project-local VG-owned `.claude/` and `.codex/` files with backup
+- writing `.vg/.install-target=global`
 </step>
 
 <step name="2_report">
 
 Surface:
-- files changed or would change
-- target project path
-- whether global Codex deploy was skipped
-- functional Codex mirror check result
+- source root used for sync
+- target project used for cleanup/marker
+- stale project-local VG surfaces, if any
+- global Claude/Codex hook locations
+- functional Codex mirror result, when `--verify` is used
 
 If `--check` reports drift, suggest:
 
@@ -247,21 +253,22 @@ If `--check` reports drift, suggest:
 /vg:sync
 ```
 
-or:
+or direct source invocation:
 
 ```bash
-/vg:sync --no-global
+DEV_ROOT=/path/to/project bash ~/.vgflow/sync.sh
 ```
 </step>
 
 </process>
 
 <success_criteria>
-- Project `.claude/commands/vg` matches `vgflow-repo/commands/vg`.
-- Project `.claude/skills`, `.claude/scripts`, `.claude/schemas`, and `.claude/templates/vg` match repo source.
-- Project `.codex/skills` matches `vgflow-repo/codex-skills`.
-- Project `.codex/agents` contains VGFlow Codex agent templates.
-- If not `--no-global`, `~/.codex/skills` and `~/.codex/agents` are refreshed.
-- Project `.claude/settings.local.json` contains VG enforcement hooks for `UserPromptSubmit`, `Stop`, and both `PostToolUse` paths.
+- `~/.vgflow` exists and is the active VGFlow source.
+- `~/.claude/settings.json` contains VG hook entries that point at `$HOME/.vgflow/scripts/hooks`.
+- `~/.codex/skills` contains generated VGFlow Codex skills.
+- `~/.codex/agents` contains VGFlow Codex agent templates.
+- `~/.codex/hooks.json` contains VGFlow hook entries and `~/.codex/config.toml` has `codex_hooks = true`.
+- Project-local VG-owned `.claude/commands/vg`, `.claude/scripts`, `.claude/skills/vg-*`, `.claude/agents/vg-*`, `.codex/skills/vg-*`, and `.codex/agents/vgflow-*` are absent after sync.
+- Project `.vg/.install-target` is `global` when sync is run from a git project or a project with an existing marker.
 - `/vg:sync --verify` reports zero functional drift between command sources and Codex skill mirrors after adapter stripping.
 </success_criteria>

--- a/commands/vg/sync.md
+++ b/commands/vg/sync.md
@@ -1,7 +1,7 @@
 ---
 name: vg:sync
-description: Sync VG workflow from canonical vgflow-repo into Claude/Codex installations
-argument-hint: "[--check] [--verify] [--no-global] [--no-source]"
+description: Sync VGFlow global-only workflow for Claude Code and Codex
+argument-hint: "[--check] [--verify] [--no-global] [--global-codex] [--no-source]"
 allowed-tools:
   - Bash
   - Read
@@ -13,35 +13,38 @@ runtime_contract:
 ---
 
 <objective>
-Deploy the canonical VGFlow workflow from `vgflow-repo` into the current project
-and Codex global skill/agent directories.
+Refresh the canonical VGFlow workflow in global-only mode.
 
-Canonical source of truth:
-1. `commands/vg/` -> `.claude/commands/vg/`
-2. `skills/` -> `.claude/skills/`
-3. `scripts/` + `schemas/` + `templates/vg/` -> `.claude/`
-4. `codex-skills/` -> `.codex/skills/` and `~/.codex/skills/`
-5. `templates/codex-agents/` -> `.codex/agents/` and `~/.codex/agents/`
-6. `vg-hooks-install.py` repairs project-local Claude hooks in `.claude/settings.local.json`
+Single source of truth:
+1. VGFlow source: `~/.vgflow` (or the developer clone that owns `sync.sh`).
+2. Claude Code hooks: `~/.claude/settings.json`, with commands pointing at `$HOME/.vgflow/scripts/hooks`.
+3. Codex skills/agents: `~/.codex/skills` and `~/.codex/agents`.
+4. Codex hooks: `~/.codex/hooks.json`, with `codex_hooks = true` in `~/.codex/config.toml`.
+5. Current project: cleanup target only. Project-local VG-owned `.claude/` and `.codex/` workflow surfaces are pruned, then `.vg/.install-target=global` is written.
 
-`--no-source` is accepted only for backward compatibility. It is a no-op
-because this repository is now the source of truth; RTB/.claude source probing
-is intentionally removed.
+`/vg:sync` MUST NOT copy `commands/vg`, `skills`, `scripts`, `schemas`,
+`templates/vg`, `codex-skills`, or Codex agents into the current project.
+
+Deprecated flags are accepted only for compatibility:
+- `--no-global` is a no-op; global deploy is mandatory.
+- `--global-codex` is a no-op; global Codex deploy is mandatory.
+- `--no-source` is a no-op; this repository/global install is the source.
 </objective>
 
 <process>
 
 <step name="0_detect">
 
-Resolve `vgflow-repo/sync.sh`:
+Resolve `sync.sh` from the global/source VGFlow install:
 
 ```bash
 SYNC_SH=""
 for candidate in \
   "${VGFLOW_REPO:-}/sync.sh" \
+  "${VG_HOME:-}/sync.sh" \
+  "${HOME}/.vgflow/sync.sh" \
   "../vgflow-repo/sync.sh" \
   "../../vgflow-repo/sync.sh" \
-  "${HOME}/Workspace/Messi/Code/vgflow-repo/sync.sh" \
   "vgflow/sync.sh"; do
   if [ -f "$candidate" ]; then
     SYNC_SH="$candidate"
@@ -50,8 +53,8 @@ for candidate in \
 done
 
 if [ -z "$SYNC_SH" ]; then
-  echo "vgflow-repo sync.sh not found."
-  echo "Set VGFLOW_REPO=/path/to/vgflow-repo or clone it beside this project."
+  echo "VGFlow sync.sh not found."
+  echo "Set VGFLOW_REPO=/path/to/vgflow or install global VGFlow at ~/.vgflow."
   exit 1
 fi
 
@@ -63,36 +66,39 @@ echo "Using sync script: $SYNC_SH"
 <step name="1_run">
 
 Parse args:
-- `--check`: dry-run, no writes, exits 1 if drift exists
-- `--verify`: short-circuit and run functional Codex mirror equivalence
-- `--no-global`: skip `~/.codex` deploy
-- `--no-source`: deprecated no-op, passed through for compatibility
+- `--check`: dry-run, no writes; exits 1 if global hooks/skills are missing or project-local VG surfaces remain
+- `--verify`: run functional Codex mirror equivalence and exit
+- `--no-global`: deprecated no-op
+- `--global-codex`: deprecated no-op
+- `--no-source`: deprecated no-op
 
 ```bash
-bash "$SYNC_SH" $ARGUMENTS
+bash "$SYNC_SH" ${ARGUMENTS}
 ```
 
-`--verify` delegates to `scripts/verify-codex-mirror-equivalence.py` inside
-`vgflow-repo`. Installed projects receive the same script at
-`.claude/scripts/verify-codex-mirror-equivalence.py`.
+`sync.sh` regenerates `codex-skills` from canonical `commands/vg` and support
+skills before installing global surfaces. Then it delegates to:
 
-The script regenerates `codex-skills` from `commands/vg` and support skills
-before deployment unless `--check` is set.
+```bash
+VG_HOME="<sync-source-root>" bash "<sync-source-root>/bin/vg-cli-dispatcher.sh" install --global
+```
 
-It also installs/repairs Claude Code enforcement hooks after copying scripts:
-- `UserPromptSubmit`: pre-seeds `vg-orchestrator run-start`.
-- `Stop`: verifies `runtime_contract` evidence before the agent can claim done.
-- `PostToolUse` edit warning: warns when VG command/skill files were edited in-session.
-- `PostToolUse` Bash step tracker: writes step activity telemetry into `.vg/events.db`.
+The dispatcher is responsible for:
+- refreshing global Codex skills/agents
+- installing Codex hooks at `~/.codex/hooks.json`
+- installing Claude Code hooks at `~/.claude/settings.json`
+- pruning project-local VG-owned `.claude/` and `.codex/` files with backup
+- writing `.vg/.install-target=global`
 </step>
 
 <step name="2_report">
 
 Surface:
-- files changed or would change
-- target project path
-- whether global Codex deploy was skipped
-- functional Codex mirror check result
+- source root used for sync
+- target project used for cleanup/marker
+- stale project-local VG surfaces, if any
+- global Claude/Codex hook locations
+- functional Codex mirror result, when `--verify` is used
 
 If `--check` reports drift, suggest:
 
@@ -100,21 +106,22 @@ If `--check` reports drift, suggest:
 /vg:sync
 ```
 
-or:
+or direct source invocation:
 
 ```bash
-/vg:sync --no-global
+DEV_ROOT=/path/to/project bash ~/.vgflow/sync.sh
 ```
 </step>
 
 </process>
 
 <success_criteria>
-- Project `.claude/commands/vg` matches `vgflow-repo/commands/vg`.
-- Project `.claude/skills`, `.claude/scripts`, `.claude/schemas`, and `.claude/templates/vg` match repo source.
-- Project `.codex/skills` matches `vgflow-repo/codex-skills`.
-- Project `.codex/agents` contains VGFlow Codex agent templates.
-- If not `--no-global`, `~/.codex/skills` and `~/.codex/agents` are refreshed.
-- Project `.claude/settings.local.json` contains VG enforcement hooks for `UserPromptSubmit`, `Stop`, and both `PostToolUse` paths.
+- `~/.vgflow` exists and is the active VGFlow source.
+- `~/.claude/settings.json` contains VG hook entries that point at `$HOME/.vgflow/scripts/hooks`.
+- `~/.codex/skills` contains generated VGFlow Codex skills.
+- `~/.codex/agents` contains VGFlow Codex agent templates.
+- `~/.codex/hooks.json` contains VGFlow hook entries and `~/.codex/config.toml` has `codex_hooks = true`.
+- Project-local VG-owned `.claude/commands/vg`, `.claude/scripts`, `.claude/skills/vg-*`, `.claude/agents/vg-*`, `.codex/skills/vg-*`, and `.codex/agents/vgflow-*` are absent after sync.
+- Project `.vg/.install-target` is `global` when sync is run from a git project or a project with an existing marker.
 - `/vg:sync --verify` reports zero functional drift between command sources and Codex skill mirrors after adapter stripping.
 </success_criteria>

--- a/scripts/generate-codex-skills.sh
+++ b/scripts/generate-codex-skills.sh
@@ -10,7 +10,7 @@
 #
 # This repo is now the canonical VGFlow source. DEV_ROOT/RTB source probing is
 # intentionally gone; use sync.sh to deploy this repo's generated artifacts to
-# project-local .codex/ and global ~/.codex/.
+# global ~/.codex/ and prune project-local VG-owned .codex/.claude copies.
 
 set -euo pipefail
 

--- a/scripts/tests/test_codex_sync_deploy.py
+++ b/scripts/tests/test_codex_sync_deploy.py
@@ -123,6 +123,14 @@ def _write_project_local_vg_files(target: Path) -> None:
     )
 
 
+def _write_fake_global_surface(fake_home: Path) -> None:
+    (fake_home / ".vgflow").mkdir(parents=True)
+    (fake_home / ".codex" / "skills").mkdir(parents=True)
+    (fake_home / ".codex" / "hooks.json").write_text("{}", encoding="utf-8")
+    (fake_home / ".claude").mkdir(parents=True, exist_ok=True)
+    (fake_home / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
+
+
 def _assert_global_install(fake_home: Path, target: Path) -> None:
     assert len(_skill_names(fake_home)) == _canonical_codex_skill_count()
     assert EXPECTED_SKILLS <= _skill_names(fake_home)
@@ -221,6 +229,7 @@ def test_sync_check_does_not_deploy_project_local_surfaces(tmp_path: Path) -> No
     fake_home = tmp_path / "home"
     target.mkdir()
     fake_home.mkdir()
+    _write_fake_global_surface(fake_home)
 
     result = subprocess.run(
         [
@@ -242,3 +251,71 @@ def test_sync_check_does_not_deploy_project_local_surfaces(tmp_path: Path) -> No
     assert result.returncode == 0, result.stdout + result.stderr
     assert not (target / ".codex").exists()
     assert not (target / ".claude").exists()
+
+
+def test_sync_check_reports_missing_global_surface_without_writes(tmp_path: Path) -> None:
+    bash = _working_bash()
+    if bash is None:
+        pytest.skip("working bash not found")
+
+    target = tmp_path / "target-project"
+    fake_home = tmp_path / "home"
+    target.mkdir()
+    fake_home.mkdir()
+
+    result = subprocess.run(
+        [
+            bash,
+            "-lc",
+            (
+                f"cd {shlex.quote(_bash_path(bash, REPO_ROOT))} && "
+                f"HOME={shlex.quote(_bash_path(bash, fake_home))} "
+                f"DEV_ROOT={shlex.quote(_bash_path(bash, target))} "
+                "bash sync.sh --check"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 1
+    assert "MISSING global source" in result.stdout
+    assert not (target / ".codex").exists()
+    assert not (target / ".claude").exists()
+
+
+def test_sync_check_reports_stale_project_local_surfaces(tmp_path: Path) -> None:
+    bash = _working_bash()
+    if bash is None:
+        pytest.skip("working bash not found")
+
+    target = tmp_path / "target-project"
+    fake_home = tmp_path / "home"
+    target.mkdir()
+    fake_home.mkdir()
+    _write_fake_global_surface(fake_home)
+    _write_project_local_vg_files(target)
+
+    result = subprocess.run(
+        [
+            bash,
+            "-lc",
+            (
+                f"cd {shlex.quote(_bash_path(bash, REPO_ROOT))} && "
+                f"HOME={shlex.quote(_bash_path(bash, fake_home))} "
+                f"DEV_ROOT={shlex.quote(_bash_path(bash, target))} "
+                "bash sync.sh --check"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 1
+    assert "STALE project-local VG surfaces" in result.stdout
+    assert ".claude/commands/vg" in result.stdout
+    assert ".codex/skills/vg-accept" in result.stdout

--- a/sync.sh
+++ b/sync.sh
@@ -1,46 +1,39 @@
 #!/usr/bin/env bash
-# VGFlow sync - deploy this repository's canonical workflow files.
+# VGFlow sync - global-only refresh and project cleanup.
 #
-# This repository is the source of truth. Sync is intentionally one-way:
-#   vgflow-repo/{commands,skills,scripts,codex-skills,templates}
-#     -> $DEV_ROOT/.claude and $DEV_ROOT/.codex
-#     -> ~/.codex (unless --no-global)
+# Source of truth:
+#   commands/vg, skills, scripts, codex-skills, templates live in this repo or
+#   in ~/.vgflow. Sync never deploys VG workflow files into a project-local
+#   .claude or .codex tree.
 #
 # Usage:
-#   ./sync.sh              # apply sync to current repo; global Codex skipped
+#   ./sync.sh                 # regenerate Codex skills, refresh global hooks, prune current project
 #   DEV_ROOT=/project ./sync.sh
-#   ./sync.sh --check      # dry-run, exits 1 if drift exists
-#   ./sync.sh --verify     # run functional Codex mirror equivalence check
-#   ./sync.sh --global-codex  # also deploy ~/.codex skills/agents
-#   ./sync.sh --no-global     # accepted for compatibility; default behavior
+#   ./sync.sh --check         # no writes; exits 1 when stale project VG files remain
+#   ./sync.sh --verify        # run functional Codex mirror equivalence check
+#   ./sync.sh --no-global     # deprecated no-op; global deploy is mandatory
+#   ./sync.sh --global-codex  # deprecated no-op; global deploy is mandatory
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TARGET_ROOT="${DEV_ROOT:-$SCRIPT_DIR}"
+TARGET_ROOT="${DEV_ROOT:-$(pwd)}"
 BASH_BIN="${BASH:-bash}"
-if [ -n "${BASH:-}" ]; then
-  # Windows can resolve `find` to C:\Windows\System32\find.exe when Git Bash
-  # is launched non-login from PowerShell/Codex. Prefer the active Bash toolchain
-  # so sync_tree uses POSIX find/sort/diff/cp/rm consistently.
-  export PATH="$(dirname "$BASH"):$PATH"
-fi
 PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
 MODE_CHECK=false
-SKIP_GLOBAL=true
 VERIFY_ONLY=false
-DEPRECATED_NO_SOURCE=false
+DEPRECATED_FLAGS=()
 
 for arg in "$@"; do
   case "$arg" in
     --check) MODE_CHECK=true ;;
     --verify) VERIFY_ONLY=true ;;
-    --no-global) SKIP_GLOBAL=true ;;
-    --global-codex) SKIP_GLOBAL=false ;;
-    --no-source) DEPRECATED_NO_SOURCE=true ;;
+    --no-global|--global-codex|--no-source)
+      DEPRECATED_FLAGS+=("$arg")
+      ;;
     -h|--help)
-      sed -n '1,18p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '1,16p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -50,614 +43,156 @@ for arg in "$@"; do
   esac
 done
 
+if [ -z "$PYTHON_BIN" ]; then
+  echo "ERROR: python3 or python is required" >&2
+  exit 127
+fi
+
 if [ "$VERIFY_ONLY" = "true" ]; then
-  if [ -z "$PYTHON_BIN" ]; then
-    echo "ERROR: python3 or python is required for --verify" >&2
-    exit 127
-  fi
   "$PYTHON_BIN" "$SCRIPT_DIR/scripts/verify-codex-mirror-equivalence.py"
   exit $?
 fi
 
+for flag in "${DEPRECATED_FLAGS[@]:-}"; do
+  [ -n "$flag" ] || continue
+  echo "VGFlow sync: ${flag} is deprecated; global deploy is mandatory in global-only mode."
+done
+
+is_source_repo_target() {
+  local source_real target_real
+  source_real="$(cd "$SCRIPT_DIR" && pwd -P)"
+  target_real="$(cd "$TARGET_ROOT" 2>/dev/null && pwd -P || true)"
+  [ -n "$target_real" ] || return 1
+  [ "$source_real" = "$target_real" ] || return 1
+  [ -d "$SCRIPT_DIR/commands/vg" ] && [ -d "$SCRIPT_DIR/codex-skills" ]
+}
+
+owned_skill_name() {
+  case "$1" in
+    vg-*|flow-*|test-*|api-contract|sandbox-test|write-test-spec) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+collect_project_local_vg_surfaces() {
+  local root="$1"
+  local rel
+  for rel in \
+    ".claude/commands/vg" \
+    ".claude/scripts" \
+    ".claude/schemas" \
+    ".claude/templates/vg" \
+    ".claude/catalog" \
+    ".claude/vgflow-ancestor" \
+    ".claude/vgflow-patches" \
+    ".claude/VGFLOW-VERSION" \
+    ".codex/config.template.toml"; do
+    [ -e "$root/$rel" ] && printf '%s\n' "$rel"
+  done
+
+  if [ -d "$root/.claude/skills" ]; then
+    while IFS= read -r dir; do
+      owned_skill_name "$(basename "$dir")" && printf '%s\n' "${dir#$root/}"
+    done < <(find "$root/.claude/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+  fi
+
+  if [ -d "$root/.claude/agents" ]; then
+    while IFS= read -r file; do
+      printf '%s\n' "${file#$root/}"
+    done < <(find "$root/.claude/agents" -maxdepth 1 -type f \( -name 'vg-*.md' -o -name 'vgflow-*.md' \) 2>/dev/null | sort)
+  fi
+
+  if [ -d "$root/.codex/skills" ]; then
+    while IFS= read -r dir; do
+      owned_skill_name "$(basename "$dir")" && printf '%s\n' "${dir#$root/}"
+    done < <(find "$root/.codex/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+  fi
+
+  if [ -d "$root/.codex/agents" ]; then
+    while IFS= read -r file; do
+      printf '%s\n' "${file#$root/}"
+    done < <(find "$root/.codex/agents" -maxdepth 1 -type f -name 'vgflow-*.toml' 2>/dev/null | sort)
+  fi
+}
+
+check_global_surface() {
+  local missing=0
+  [ -d "$HOME/.vgflow" ] || { echo "MISSING global source: ~/.vgflow"; missing=1; }
+  [ -d "$HOME/.codex/skills" ] || { echo "MISSING global Codex skills: ~/.codex/skills"; missing=1; }
+  [ -f "$HOME/.codex/hooks.json" ] || { echo "MISSING global Codex hooks: ~/.codex/hooks.json"; missing=1; }
+  [ -f "$HOME/.claude/settings.json" ] || { echo "MISSING global Claude hooks: ~/.claude/settings.json"; missing=1; }
+  return "$missing"
+}
+
 if [ "$MODE_CHECK" = "true" ]; then
-  echo "VGFlow sync check: global-only mode; project-local .claude/.codex deploy disabled."
-  echo "Source: $SCRIPT_DIR"
-  echo "Target cleanup root: $TARGET_ROOT"
+  echo "VGFlow sync check: global-only mode"
+  echo "  source: $SCRIPT_DIR"
+  echo "  target project: $TARGET_ROOT"
+  echo ""
+
+  failed=0
+  if ! check_global_surface; then
+    failed=1
+  fi
+
+  if ! is_source_repo_target; then
+    stale="$(collect_project_local_vg_surfaces "$TARGET_ROOT" || true)"
+    if [ -n "$stale" ]; then
+      echo "STALE project-local VG surfaces:"
+      printf '%s\n' "$stale" | sed 's/^/  - /'
+      failed=1
+    else
+      echo "Project cleanup: clean"
+    fi
+  else
+    echo "Project cleanup: skipped for VGFlow source repo target"
+  fi
+
+  if [ "$failed" -ne 0 ]; then
+    echo ""
+    echo "Fix: run 'vg sync' or 'DEV_ROOT=/path/to/project bash sync.sh'."
+    exit 1
+  fi
+
+  echo "Global sync check: clean"
   exit 0
 fi
 
 echo "VGFlow sync: global-only mode"
 echo "  source: $SCRIPT_DIR"
-echo "  target project for cleanup/marker: $TARGET_ROOT"
+echo "  target project: $TARGET_ROOT"
 echo ""
-"$BASH_BIN" "$SCRIPT_DIR/scripts/generate-codex-skills.sh" --force >/tmp/vgflow-codex-generate.log
-tail -5 /tmp/vgflow-codex-generate.log || true
+
+GEN_LOG="$(mktemp "${TMPDIR:-/tmp}/vgflow-codex-generate.XXXXXX.log")"
+"$BASH_BIN" "$SCRIPT_DIR/scripts/generate-codex-skills.sh" --force >"$GEN_LOG"
+tail -5 "$GEN_LOG" || true
+
+RUN_ROOT="$TARGET_ROOT"
+if is_source_repo_target; then
+  RUN_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vgflow-sync.XXXXXX")"
+  echo "VGFlow source repo detected as cwd; project cleanup skipped unless DEV_ROOT is set."
+fi
+
 (
-  cd "$TARGET_ROOT"
-  VG_HOME="$SCRIPT_DIR" bash "$SCRIPT_DIR/bin/vg-cli-dispatcher.sh" install --global
+  cd "$RUN_ROOT"
+  VG_HOME="$SCRIPT_DIR" "$BASH_BIN" "$SCRIPT_DIR/bin/vg-cli-dispatcher.sh" install --global
 )
-exit $?
 
-SUMMARY=()
-CHANGED=0
-MISSING=0
-MCP_FAILED=false
-
-note() {
-  SUMMARY+=("$1")
-}
-
-compare() {
-  local src="$1"
-  local dst="$2"
-  local label="$3"
-
-  if [ ! -f "$src" ]; then
-    note "MISSING source: $label ($src)"
-    MISSING=$((MISSING + 1))
-    return
+if ! is_source_repo_target; then
+  stale_after="$(collect_project_local_vg_surfaces "$TARGET_ROOT" || true)"
+  if [ -n "$stale_after" ]; then
+    echo "ERROR: project-local VG surfaces remain after sync:" >&2
+    printf '%s\n' "$stale_after" | sed 's/^/  - /' >&2
+    exit 1
   fi
+fi
 
-  if [ ! -f "$dst" ]; then
-    note "NEW: $label -> $dst"
-    CHANGED=$((CHANGED + 1))
-    if [ "$MODE_CHECK" = "false" ]; then
-      mkdir -p "$(dirname "$dst")"
-      cp "$src" "$dst"
-    fi
-    return
-  fi
-
-  if ! diff -q "$src" "$dst" >/dev/null 2>&1; then
-    note "UPDATED: $label"
-    CHANGED=$((CHANGED + 1))
-    if [ "$MODE_CHECK" = "false" ]; then
-      cp "$src" "$dst"
-    fi
-  fi
-}
-
-sync_tree() {
-  local src_dir="$1"
-  local dst_dir="$2"
-  local label="$3"
-
-  [ -d "$src_dir" ] || return
-
-  while IFS= read -r src_file; do
-    local rel="${src_file#$src_dir/}"
-    compare "$src_file" "$dst_dir/$rel" "$label:$rel"
-  done < <(find "$src_dir" -type f \
-    ! -path '*/__pycache__/*' \
-    ! -name '*.pyc' 2>/dev/null | sort)
-}
-
-sync_codex_agents() {
-  local dst_root="$1"
-  [ -d "$SCRIPT_DIR/templates/codex-agents" ] || return
-  sync_tree "$SCRIPT_DIR/templates/codex-agents" "$dst_root/agents" "codex-agent"
-}
-
-sync_codex_skills_exact() {
-  local dst_root="$1"
-  local label="$2"
-  [ -d "$SCRIPT_DIR/codex-skills" ] || return
-  mkdir -p "$dst_root/skills"
-
-  while IFS= read -r skill_dir; do
-    [ -f "$skill_dir/SKILL.md" ] || continue
-    local skill
-    skill="$(basename "$skill_dir")"
-    local dst_dir="$dst_root/skills/$skill"
-    if [ "$MODE_CHECK" = "false" ]; then
-      rm -rf "$dst_dir"
-    fi
-    sync_tree "$skill_dir" "$dst_dir" "$label:$skill"
-  done < <(find "$SCRIPT_DIR/codex-skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
-}
-
-# v3.6.1 — prune duplicate Codex skills when global + project both populated.
-#
-# Bug: Codex picker reads BOTH ~/.codex/skills/ AND <project>/.codex/skills/.
-# When sync deployed to both (--global-codex previously, then default project
-# sync), every vg-* skill shows up twice in the picker. Users can't tell which
-# is current.
-#
-# Fix: when both have the same skill name, prune one. Resolution rule:
-#   - If $TARGET_ROOT/.vg/.install-target == "global" → prune project copy (~/.codex wins)
-#   - If $TARGET_ROOT/.vg/.install-target == "project" → prune global copy if it matches our codex-skills/ source list
-#   - No marker → prune project copy (default: prefer global, matches v3.0.0 architecture)
-prune_duplicate_codex_skills() {
-  local target_root="$1"
-  local home_codex="$HOME/.codex/skills"
-  local proj_codex="$target_root/.codex/skills"
-  local marker_file="$target_root/.vg/.install-target"
-  local install_target=""
-  [ -f "$marker_file" ] && install_target="$(tr -d '[:space:]' < "$marker_file" 2>/dev/null || true)"
-
-  [ -d "$home_codex" ] || [ -d "$proj_codex" ] || return 0
-  if [ "$MODE_CHECK" = "true" ]; then
-    return 0
-  fi
-
-  local pruned=0
-  local prune_target=""
-  case "$install_target" in
-    project)
-      # Project install — global ~/.codex skill that overlaps our deployed list is stale
-      prune_target="$home_codex"
-      ;;
-    global|"")
-      # Global install (or unmarked legacy) — prune project copy
-      prune_target="$proj_codex"
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-
-  # Build list of skills WE own (canonical names from $SCRIPT_DIR/codex-skills)
-  while IFS= read -r src_skill_dir; do
-    [ -d "$src_skill_dir" ] || continue
-    local skill_name
-    skill_name="$(basename "$src_skill_dir")"
-    local dup_dir="$prune_target/$skill_name"
-    if [ -d "$dup_dir" ] && [ "$prune_target" != "$home_codex" ] || \
-       { [ "$prune_target" = "$home_codex" ] && [ -d "$dup_dir" ] && [ -d "$proj_codex/$skill_name" ]; }; then
-      rm -rf "$dup_dir" 2>/dev/null && pruned=$((pruned + 1))
-    fi
-  done < <(find "$SCRIPT_DIR/codex-skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
-
-  if [ "$pruned" -gt 0 ]; then
-    note "PRUNED ${pruned} duplicate Codex skill dirs from ${prune_target} (install_target=${install_target:-unset})"
-    CHANGED=$((CHANGED + 1))
-  fi
-}
-
-codex_config_path() {
-  local path="$1"
-  if command -v cygpath >/dev/null 2>&1; then
-    cygpath -m "$path"
-  else
-    printf '%s\n' "$path"
-  fi
-}
-
-register_global_codex_agents() {
-  local config="$HOME/.codex/config.toml"
-  touch "$config"
-
-  register_one() {
-    local name="$1"
-    local desc="$2"
-    local config_file
-    config_file="$(codex_config_path "$HOME/.codex/agents/${name}.toml")"
-    if ! grep -q "^\[agents\.${name}\]" "$config" 2>/dev/null; then
-      cat >> "$config" <<EOF
-
-[agents.${name}]
-description = "${desc}"
-config_file = "${config_file}"
-EOF
-      note "REGISTERED global Codex agent: $name"
-      CHANGED=$((CHANGED + 1))
-    fi
-  }
-
-  register_one "vgflow-orchestrator" "VGFlow phase orchestrator for Codex. Coordinates VG skills, gates, and artifact writes."
-  register_one "vgflow-executor" "VGFlow bounded code executor for Codex child tasks."
-  register_one "vgflow-classifier" "VGFlow cheap classifier/scanner for read-only summaries and triage."
-}
-
-disable_legacy_codex_hooks() {
-  local root="$1"
-  local label="$2"
-
-  [ -d "$root/.codex" ] || return
-  if [ -z "$PYTHON_BIN" ]; then
-    note "MISSING python: cannot disable legacy Codex hooks for $label"
-    MISSING=$((MISSING + 1))
-    return
-  fi
-
-  local result
-  result="$("$PYTHON_BIN" - "$root" "$MODE_CHECK" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-root = Path(sys.argv[1])
-check = sys.argv[2] == "true"
-changed = False
-
-def vg_owned_command(cmd: str) -> bool:
-    return (
-        ".claude/scripts/codex-hooks/" in cmd
-        or ("VG_RUNTIME=codex" in cmd and ".claude/scripts/vg-entry-hook.py" in cmd)
-    )
-
-hooks_path = root / ".codex" / "hooks.json"
-if hooks_path.exists():
-    try:
-        data = json.loads(hooks_path.read_text(encoding="utf-8"))
-    except Exception:
-        data = None
-    if isinstance(data, dict) and isinstance(data.get("hooks"), dict):
-        new_hooks = {}
-        for event, entries in data["hooks"].items():
-            if not isinstance(entries, list):
-                new_hooks[event] = entries
-                continue
-            kept_entries = []
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    kept_entries.append(entry)
-                    continue
-                hook_list = entry.get("hooks")
-                if not isinstance(hook_list, list):
-                    kept_entries.append(entry)
-                    continue
-                kept_hooks = [
-                    h for h in hook_list
-                    if not (isinstance(h, dict) and vg_owned_command(str(h.get("command", ""))))
-                ]
-                if kept_hooks:
-                    updated = dict(entry)
-                    updated["hooks"] = kept_hooks
-                    kept_entries.append(updated)
-            if kept_entries:
-                new_hooks[event] = kept_entries
-        if new_hooks != data["hooks"]:
-            changed = True
-            if not check:
-                if new_hooks:
-                    hooks_path.write_text(json.dumps({"hooks": new_hooks}, indent=2) + "\n", encoding="utf-8")
-                else:
-                    hooks_path.unlink()
-
-config_path = root / ".codex" / "config.toml"
-if config_path.exists():
-    lines = config_path.read_text(encoding="utf-8").splitlines()
-    filtered = [line for line in lines if not line.strip().startswith("codex_hooks")]
-    if filtered != lines:
-        changed = True
-        if not check:
-            text = "\n".join(filtered).strip()
-            if text in ("", "[features]"):
-                config_path.unlink()
-            else:
-                config_path.write_text(text + "\n", encoding="utf-8")
-
-print("changed" if changed else "clean")
-PY
-)"
-  if [ "$result" = "changed" ]; then
-    note "UPDATED: $label legacy Codex hooks disabled"
-    CHANGED=$((CHANGED + 1))
-    if [ "$MODE_CHECK" = "false" ]; then
-      echo "  OK: legacy Codex hooks disabled for $label"
-    fi
-  fi
-}
-
-prune_legacy_claude_local_hooks() {
-  local root="$1"
-  local settings="$root/.claude/settings.local.json"
-
-  [ -f "$settings" ] || return 0
-  if [ -z "$PYTHON_BIN" ]; then
-    note "MISSING python: cannot prune legacy Claude local hooks"
-    MISSING=$((MISSING + 1))
-    return
-  fi
-
-  local result
-  result="$("$PYTHON_BIN" - "$settings" "$MODE_CHECK" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-settings_path = Path(sys.argv[1])
-check = sys.argv[2] == "true"
-
-legacy_scripts = (
-    "vg-verify-claim.py",
-    "vg-edit-warn.py",
-    "vg-entry-hook.py",
-    "vg-step-tracker.py",
-    "vg-agent-spawn-guard.py",
-)
-hook_runner_markers = (
-    "vg-run-bash-hook.py",
-    "vg-user-prompt-submit.sh",
-    "vg-session-start.sh",
-    "vg-pre-tool-use-bash.sh",
-    "vg-pre-tool-use-write.sh",
-    "vg-pre-tool-use-agent.sh",
-    "vg-post-tool-use-todowrite.sh",
-    "vg-stop.sh",
-    ".claude/scripts/hooks/",
-)
-vg_hook_markers = (*legacy_scripts, *hook_runner_markers)
-
-try:
-    data = json.loads(settings_path.read_text(encoding="utf-8"))
-except Exception:
-    print("unreadable")
-    raise SystemExit(0)
-
-hooks = data.get("hooks")
-if not isinstance(hooks, dict):
-    print("clean")
-    raise SystemExit(0)
-
-changed = False
-new_hooks = {}
-for event, entries in hooks.items():
-    if not isinstance(entries, list):
-        new_hooks[event] = entries
-        continue
-    kept_entries = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            kept_entries.append(entry)
-            continue
-        hook_list = entry.get("hooks")
-        if not isinstance(hook_list, list):
-            kept_entries.append(entry)
-            continue
-        kept_hook_list = []
-        for hook in hook_list:
-            command = str(hook.get("command", "")) if isinstance(hook, dict) else ""
-            is_legacy_vg = any(marker in command for marker in vg_hook_markers)
-            if is_legacy_vg:
-                changed = True
-            else:
-                kept_hook_list.append(hook)
-        if kept_hook_list:
-            updated = dict(entry)
-            updated["hooks"] = kept_hook_list
-            kept_entries.append(updated)
-        elif hook_list:
-            changed = True
-    if kept_entries:
-        new_hooks[event] = kept_entries
-    elif entries:
-        changed = True
-
-if not changed:
-    print("clean")
-    raise SystemExit(0)
-
-if not check:
-    if new_hooks:
-        data["hooks"] = new_hooks
-    else:
-        data.pop("hooks", None)
-    settings_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-print("changed")
-PY
-)"
-
-  case "$result" in
-    changed)
-      note "UPDATED: claude-hooks:.claude/settings.local.json VG hooks pruned"
-      CHANGED=$((CHANGED + 1))
-      if [ "$MODE_CHECK" = "false" ]; then
-        echo "  OK: VG hooks pruned from .claude/settings.local.json"
-      fi
-      ;;
-    unreadable)
-      note "WARN: cannot parse .claude/settings.local.json for legacy hook pruning"
-      ;;
-  esac
-}
-
-echo "VGFlow sync"
-echo "  source: $SCRIPT_DIR"
-echo "  target: $TARGET_ROOT"
 echo ""
-
-if [ "$DEPRECATED_NO_SOURCE" = "true" ]; then
-  note "INFO: --no-source is deprecated and ignored; vgflow-repo is now canonical"
-fi
-
-if [ "$MODE_CHECK" = "false" ]; then
-  echo "1. Regenerate Codex skills"
-  "$BASH_BIN" "$SCRIPT_DIR/scripts/generate-codex-skills.sh" --force >/tmp/vgflow-codex-generate.log
-  tail -5 /tmp/vgflow-codex-generate.log
-  chmod +x "$SCRIPT_DIR/scripts/generate-codex-skills.sh" 2>/dev/null || true
-  chmod +x "$SCRIPT_DIR/commands/vg/_shared/lib/"*.sh 2>/dev/null || true
-  echo ""
-else
-  echo "1. Check mode: skip regeneration; run without --check to refresh codex-skills"
-  echo ""
-fi
-
-echo "2. Deploy Claude workflow to target project"
-sync_tree "$SCRIPT_DIR/commands/vg" "$TARGET_ROOT/.claude/commands/vg" "claude-command"
-sync_tree "$SCRIPT_DIR/skills" "$TARGET_ROOT/.claude/skills" "claude-skill"
-sync_tree "$SCRIPT_DIR/scripts" "$TARGET_ROOT/.claude/scripts" "claude-script"
-sync_tree "$SCRIPT_DIR/schemas" "$TARGET_ROOT/.claude/schemas" "claude-schema"
-sync_tree "$SCRIPT_DIR/templates/vg" "$TARGET_ROOT/.claude/templates/vg" "claude-template"
-# RFC v9 PR-research-augment: catalog/ holds the local edge-case pattern store
-# consumed by scripts/runtime/pattern_catalog.py. Skip silently when source
-# absent (older vgflow versions don't ship it).
-[ -d "$SCRIPT_DIR/catalog" ] && \
-  sync_tree "$SCRIPT_DIR/catalog" "$TARGET_ROOT/.claude/catalog" "claude-catalog"
-compare "$SCRIPT_DIR/VGFLOW-VERSION" "$TARGET_ROOT/.claude/VGFLOW-VERSION" "claude-version"
-if [ "$MODE_CHECK" = "false" ]; then
-  chmod +x "$TARGET_ROOT/.claude/commands/vg/_shared/lib/"*.sh 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/commands/vg/_shared/lib/test-runners/"*.sh 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/"*.py 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/"*.sh 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/validators/"*.py 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/vg-orchestrator/"*.py 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/lib/"*.py 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/templates/vg/commit-msg" 2>/dev/null || true
-  find "$TARGET_ROOT/.claude/scripts" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
-  find "$TARGET_ROOT/.claude/scripts" -type f -name '*.pyc' -delete 2>/dev/null || true
-fi
+echo "VGFlow sync complete."
+echo "  global source: ~/.vgflow"
+echo "  Claude hooks:  ~/.claude/settings.json"
+echo "  Codex skills:  ~/.codex/skills"
+echo "  Codex hooks:   ~/.codex/hooks.json"
+echo "  project:       ${TARGET_ROOT}"
 echo ""
-
-echo "2b. Remove legacy Claude local hooks"
-prune_legacy_claude_local_hooks "$TARGET_ROOT"
-if [ "$MODE_CHECK" = "false" ]; then
-  find "$TARGET_ROOT/.claude/scripts" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
-  find "$TARGET_ROOT/.claude/scripts" -type f -name '*.pyc' -delete 2>/dev/null || true
-fi
-echo ""
-
-# R1a pilot: sync custom subagents + install R1a enforcement hooks into settings.json
-echo "2b-r1a. Sync R1a subagents + install R1a hooks"
-if [ -d "$SCRIPT_DIR/agents" ]; then
-  sync_tree "$SCRIPT_DIR/agents" "$TARGET_ROOT/.claude/agents" "claude-agent"
-fi
-# v3.6.1 — chmod +x for .claude/scripts/hooks/*.sh ALWAYS runs (was previously
-# nested under agents/ existence check, which left hooks non-executable on
-# fresh installs). Stop hook on Mac/Linux fails with `Permission denied` if
-# this is skipped because Claude Code falls back to /bin/sh + the script
-# isn't marked +x.
-if [ "$MODE_CHECK" = "false" ]; then
-  chmod +x "$TARGET_ROOT/.claude/scripts/hooks/"*.sh 2>/dev/null || true
-  chmod +x "$TARGET_ROOT/.claude/scripts/hooks/"*.py 2>/dev/null || true
-fi
-# Install R1a hooks into .claude/settings.json (idempotent merge).
-# Disable with VG_INSTALL_HOOKS=0 if user manages settings.json manually.
-if [ "${VG_INSTALL_HOOKS:-1}" = "1" ] && [ "$MODE_CHECK" = "false" ] \
-    && [ -f "$SCRIPT_DIR/scripts/hooks/install-hooks.sh" ]; then
-  if VG_PLUGIN_ROOT="$SCRIPT_DIR" bash "$SCRIPT_DIR/scripts/hooks/install-hooks.sh" \
-        --target "$TARGET_ROOT/.claude/settings.json" \
-        >/tmp/vgflow-r1a-hooks-install.log 2>&1; then
-    echo "  OK: R1a hooks merged into .claude/settings.json"
-  else
-    note "FAILED: R1a hook install; see /tmp/vgflow-r1a-hooks-install.log"
-  fi
-fi
-echo ""
-
-echo "2c. Ensure Playwright MCP workers"
-MCP_VALIDATOR="$SCRIPT_DIR/scripts/validators/verify-playwright-mcp-config.py"
-if [ -z "$PYTHON_BIN" ]; then
-  note "MISSING python: cannot verify Playwright MCP config"
-  MISSING=$((MISSING + 1))
-elif [ -f "$MCP_VALIDATOR" ]; then
-  if [ "$MODE_CHECK" = "true" ]; then
-    if ! "$PYTHON_BIN" "$MCP_VALIDATOR" --quiet >/dev/null 2>&1; then
-      note "UPDATED: playwright-mcp-config:~/.claude + ~/.codex"
-      CHANGED=$((CHANGED + 1))
-    fi
-  else
-    if "$PYTHON_BIN" "$MCP_VALIDATOR" --repair --quiet \
-        --lock-source "$SCRIPT_DIR/playwright-locks/playwright-lock.sh"; then
-      echo "  OK: playwright1-5 configured for Claude/Codex"
-    else
-      note "FAILED: Playwright MCP config; run $PYTHON_BIN $MCP_VALIDATOR --repair"
-      MISSING=$((MISSING + 1))
-      MCP_FAILED=true
-    fi
-  fi
-else
-  note "MISSING source validator: scripts/validators/verify-playwright-mcp-config.py"
-  MISSING=$((MISSING + 1))
-  MCP_FAILED=true
-fi
-echo ""
-
-echo "2d. Ensure Graphify"
-GRAPHIFY_HELPER="$SCRIPT_DIR/scripts/ensure-graphify.py"
-if [ "${VGFLOW_SKIP_GRAPHIFY_INSTALL:-false}" = "true" ]; then
-  echo "  skipped by VGFLOW_SKIP_GRAPHIFY_INSTALL=true"
-elif [ -z "$PYTHON_BIN" ]; then
-  note "MISSING python: cannot verify/install Graphify"
-  MISSING=$((MISSING + 1))
-elif [ -f "$GRAPHIFY_HELPER" ]; then
-  if [ "$MODE_CHECK" = "true" ]; then
-    if ! "$PYTHON_BIN" "$GRAPHIFY_HELPER" --target "$TARGET_ROOT" --quiet >/dev/null 2>&1; then
-      note "UPDATED: graphify-install:${TARGET_ROOT}"
-      CHANGED=$((CHANGED + 1))
-    fi
-  else
-    if "$PYTHON_BIN" "$GRAPHIFY_HELPER" --target "$TARGET_ROOT" --repair --quiet; then
-      echo "  OK: graphify installed/configured or intentionally disabled"
-    else
-      note "FAILED: Graphify setup; run $PYTHON_BIN $GRAPHIFY_HELPER --target $TARGET_ROOT --repair"
-    fi
-  fi
-else
-  note "MISSING source helper: scripts/ensure-graphify.py"
-  MISSING=$((MISSING + 1))
-fi
-echo ""
-
-echo "3. Deploy Codex workflow to target project"
-sync_codex_skills_exact "$TARGET_ROOT/.codex" "codex-skill"
-sync_codex_agents "$TARGET_ROOT/.codex"
-sync_tree "$SCRIPT_DIR/templates/codex" "$TARGET_ROOT/.codex" "codex-template"
-disable_legacy_codex_hooks "$TARGET_ROOT" "project-codex"
-echo ""
-
-if [ "$SKIP_GLOBAL" = "false" ] && [ -d "$HOME/.codex" ]; then
-  echo "4. Deploy global Codex skills/agents"
-  sync_codex_skills_exact "$HOME/.codex" "global-codex-skill"
-  sync_codex_agents "$HOME/.codex"
-  if [ "$MODE_CHECK" = "false" ]; then
-    register_global_codex_agents
-  fi
-  echo ""
-else
-  echo "4. Global Codex deploy skipped (default; pass --global-codex to opt in)"
-  echo ""
-fi
-
-# v3.6.1 — dedupe Codex skills if both global + project populated.
-# Codex picker reads both dirs and shows duplicate entries; this removes
-# the duplicate copy per .vg/.install-target marker (or default to pruning
-# project copy when marker absent / global install).
-echo "4b. Dedupe Codex skills (global vs project)"
-prune_duplicate_codex_skills "$TARGET_ROOT"
-echo ""
-
-echo "5. Functional Codex mirror check"
-if [ -z "$PYTHON_BIN" ]; then
-  echo "ERROR: python3 or python is required for functional mirror check" >&2
-  exit 127
-fi
-VERIFY_JSON="$(mktemp)"
-if "$PYTHON_BIN" "$SCRIPT_DIR/scripts/verify-codex-mirror-equivalence.py" --json >"$VERIFY_JSON"; then
-  CHECKED="$("$PYTHON_BIN" - "$VERIFY_JSON" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as fh:
-    print(json.load(fh)["checked"])
-PY
-)"
-  echo "  OK: ${CHECKED} source/mirror pairs equivalent"
-else
-  cat "$VERIFY_JSON"
-  exit 1
-fi
-rm -f "$VERIFY_JSON"
-echo ""
-
-echo "Summary"
-if [ "${#SUMMARY[@]}" -eq 0 ]; then
-  echo "  All in sync."
-else
-  printf '  %s\n' "${SUMMARY[@]}"
-  echo ""
-  echo "  Changed: $CHANGED"
-  echo "  Missing sources: $MISSING"
-fi
-
-if [ "$MODE_CHECK" = "true" ]; then
-  echo ""
-  echo "Dry run only. Re-run without --check to apply."
-  [ "$CHANGED" -gt 0 ] && exit 1 || exit 0
-fi
-
-if [ "$MCP_FAILED" = "true" ]; then
-  exit 1
-fi
+echo "Restart Claude Code / Codex session to load refreshed global workflow."

--- a/tests/test_v3_6_1_sync_fixes.py
+++ b/tests/test_v3_6_1_sync_fixes.py
@@ -1,17 +1,8 @@
-"""v3.6.1 — sync.sh fixes for chmod + Codex skill dedupe.
+"""sync.sh must stay global-only.
 
-Bugs fixed:
-1. chmod +x on .claude/scripts/hooks/*.sh was nested under
-   `if [ -d agents ]` — left hooks non-executable on installs without
-   custom agents/, causing macOS Stop hook `Permission denied` errors.
-2. Codex picker showed every vg-* skill twice when both ~/.codex/skills/
-   AND <project>/.codex/skills/ were populated (sync.sh deployed both
-   when --global-codex flag was used previously).
-
-Tests:
-- chmod block in sync.sh runs unconditionally (outside agents check)
-- prune_duplicate_codex_skills function exists with marker-aware logic
-- Step 4b (dedupe) wired into main flow
+Older sync.sh versions copied VG workflow files into project-local .claude and
+.codex trees, then tried to dedupe Codex skills after the fact. Global-only
+VGFlow must do the opposite: refresh global surfaces and prune project copies.
 """
 from __future__ import annotations
 
@@ -26,86 +17,62 @@ def _read_sync() -> str:
     return SYNC.read_text(encoding="utf-8")
 
 
-def test_chmod_hooks_unconditional():
+def test_sync_global_only_invokes_dispatcher_install_global():
     body = _read_sync()
-    # Find the chmod hook block
-    m = re.search(
-        r'if \[ "\$MODE_CHECK" = "false" \]; then\s*\n'
-        r'\s*chmod \+x "\$TARGET_ROOT/\.claude/scripts/hooks/"\*\.sh',
-        body,
-    )
-    assert m, "chmod +x .claude/scripts/hooks/*.sh must run when MODE_CHECK=false"
-    # Verify it's NOT nested under agents existence (look at preceding 30 lines)
-    chmod_pos = body.find('chmod +x "$TARGET_ROOT/.claude/scripts/hooks/"*.sh')
-    assert chmod_pos > 0
-    preceding = body[max(0, chmod_pos - 600):chmod_pos]
-    # The IMMEDIATELY-preceding `if` must be MODE_CHECK, not agents.
-    last_if = preceding.rfind("if [")
-    assert last_if >= 0
-    last_if_line = preceding[last_if:last_if + 80]
-    assert "MODE_CHECK" in last_if_line, (
-        f"chmod hooks block must be guarded by MODE_CHECK, found: {last_if_line!r}"
-    )
+    assert "VGFlow sync: global-only mode" in body
+    assert 'bin/vg-cli-dispatcher.sh" install --global' in body
+    assert "refresh global hooks" in body
+    assert "prune current project" in body
 
 
-def test_chmod_includes_python_hooks():
+def test_sync_has_no_legacy_project_copy_pipeline():
     body = _read_sync()
-    assert 'chmod +x "$TARGET_ROOT/.claude/scripts/hooks/"*.py' in body, (
-        "v3.6.1 must also chmod +x *.py hook files (vg-run-bash-hook.py etc)"
-    )
+    assert "sync_tree()" not in body
+    assert "compare()" not in body
+    assert "prune_duplicate_codex_skills()" not in body
+    assert 'chmod +x "$TARGET_ROOT/.claude/scripts/hooks/' not in body
+    assert "settings.local.json VG hooks pruned" not in body
 
 
-def test_prune_function_exists():
+def test_sync_deprecated_flags_are_noops():
     body = _read_sync()
-    assert "prune_duplicate_codex_skills()" in body, (
-        "sync.sh must declare prune_duplicate_codex_skills function"
-    )
-    assert "install-target" in body
-    assert "HOME/.codex" in body
+    for flag in ("--no-global", "--global-codex", "--no-source"):
+        assert flag in body
+    assert "global deploy is mandatory" in body
+    assert "SKIP_GLOBAL" not in body
 
 
-def test_prune_step_wired_into_main():
+def test_sync_check_detects_global_and_project_drift():
     body = _read_sync()
-    assert "4b. Dedupe Codex skills" in body
-    # Function called at top-level
-    assert re.search(r'^prune_duplicate_codex_skills "\$TARGET_ROOT"', body, re.M), (
-        "prune_duplicate_codex_skills must be invoked from main script body"
-    )
+    assert "check_global_surface()" in body
+    assert "collect_project_local_vg_surfaces()" in body
+    assert "STALE project-local VG surfaces" in body
+    assert "MISSING global Claude hooks" in body
+    assert "MISSING global Codex hooks" in body
 
 
-def test_prune_respects_install_target_marker():
-    """When marker says project, prune global; when global/unset, prune project."""
+def test_sync_does_not_prune_source_repo_by_default():
     body = _read_sync()
-    # Find function body
-    m = re.search(r'prune_duplicate_codex_skills\(\) \{(.+?)^\}', body, re.M | re.S)
-    assert m, "function body parse failed"
-    fn = m.group(1)
-    # Both branches present
-    assert 'project)' in fn, "project branch missing"
-    assert 'global|"")' in fn or 'global)' in fn, "global branch missing"
-    # Reads marker from .vg/.install-target
-    assert ".vg/.install-target" in fn
+    assert "is_source_repo_target()" in body
+    assert "VGFlow source repo detected as cwd" in body
+    assert "mktemp -d" in body
+    assert "project cleanup skipped unless DEV_ROOT is set" in body
 
 
 def test_lifecycle_md_uses_single_quote_for_embedded_phrase():
-    """Source LIFECYCLE.md must not have unescaped `"X"` inside the description."""
+    """Source LIFECYCLE.md must not have unescaped quotes in description."""
     src = (REPO_ROOT / "commands" / "vg" / "LIFECYCLE.md").read_text(encoding="utf-8")
     m = re.search(r"^description:\s*(.+)$", src, re.M)
     assert m, "description line not found"
     desc = m.group(1)
-    # Description is unquoted plain scalar; must not contain `"` (Codex CLI
-    # rejects when generator wraps unescaped value into "..." YAML scalar)
-    # OR may contain only escaped variants. We use single-quoted phrase here.
-    # Acceptable forms: 'X', \"X\", or no quoted phrase at all.
-    assert '"' not in desc.replace("\\\"", ""), (
-        f"LIFECYCLE.md description has unescaped `\"`: {desc}"
+    assert '"' not in desc.replace('\\"', ""), (
+        f'LIFECYCLE.md description has unescaped ": {desc}'
     )
 
 
 def test_generator_escapes_double_quote_in_description():
     body = (REPO_ROOT / "scripts" / "generate-codex-skills.sh").read_text(encoding="utf-8")
     assert "description_yaml" in body
-    # Escape pattern present
     assert 'description//\\\\' in body and 'description_yaml//\\"' in body, (
-        "generator must do bash parameter-expansion escape for both \\ and \" before YAML emission"
+        'generator must escape both backslash and " before YAML emission'
     )


### PR DESCRIPTION
## Summary
- Rewrite sync.sh as a global-only refresh path: regenerate Codex skills, install global Claude/Codex hooks, prune project-local VG files, and write .vg/.install-target=global.
- Update /vg:sync and Codex vg-sync docs so Claude Code and Codex share the same global-only contract.
- Add regression tests for sync --check, stale project-local VG surfaces, deprecated no-op flags, and source-repo self-prune protection.
- Include generated Codex HARD-GATE-CODEX marker blocks for specs/field-test so full sync regeneration is clean.

## Verification
- PATH="/tmp/vgflow-pytest-venv312/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/dzungnguyen/.codex/tmp/arg0/codex-arg0PSv8d1:/Users/dzungnguyen/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/dzungnguyen/.npm-global/bin:/Users/dzungnguyen/.bun/bin:/Users/dzungnguyen/Library/pnpm:/Users/dzungnguyen/.antigravity/antigravity/bin:/Users/dzungnguyen/.local/bin:/opt/homebrew/opt/python@3.12/libexec/bin:/opt/homebrew/sbin:/Users/dzungnguyen/.local/bin" /tmp/vgflow-pytest-venv312/bin/python -m pytest tests/ -q --tb=short --timeout=90 --timeout-method=thread --durations=20
- PATH="/tmp/vgflow-pytest-venv312/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/dzungnguyen/.codex/tmp/arg0/codex-arg0PSv8d1:/Users/dzungnguyen/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/dzungnguyen/.npm-global/bin:/Users/dzungnguyen/.bun/bin:/Users/dzungnguyen/Library/pnpm:/Users/dzungnguyen/.antigravity/antigravity/bin:/Users/dzungnguyen/.local/bin:/opt/homebrew/opt/python@3.12/libexec/bin:/opt/homebrew/sbin:/Users/dzungnguyen/.local/bin" /tmp/vgflow-pytest-venv312/bin/python -m pytest tests/test_v3_6_1_sync_fixes.py scripts/tests/test_codex_sync_deploy.py tests/test_vg_cli_dispatcher.py tests/test_vg_install_skill.py tests/test_v3_6_4_vg_update_codex_dedupe.py tests/test_codex_global_hooks_install.py -q
- bash sync.sh --verify
- bash sync.sh --check
- DEV_ROOT="/Users/dzungnguyen/Vibe Code/Code/PrintwayV3" bash sync.sh
- bash /Users/dzungnguyen/Vibe\ Code/Code/vgflow-bugfix/sync.sh --check from PrintwayV3

Note: full scripts/tests/ is not used as a whole here because it has pre-existing path/root assumptions that fail outside its legacy harness; the touched scripts/tests/test_codex_sync_deploy.py target passes.