### PR TITLE
fix(stop-hook): probe --check-contract before invoking removed flag

### DIFF
--- a/.claude/scripts/hooks/vg-stop.sh
+++ b/.claude/scripts/hooks/vg-stop.sh
@@ -61,11 +61,17 @@ if [ -x "$sm_validator" ] && [ -f "$db" ]; then
 fi
 
 # 3. Contract verify (delegated to existing vg-orchestrator if present).
+# Note: legacy `run-status --check-contract <run_id>` was removed in v4.x.
+# The real spawn-count / wave-completion checks moved into `wave-complete`
+# (see vg-orchestrator/__main__.py near line 1966). Probe with --help so this
+# stays a no-op until/unless a runtime-contract subcommand is reintroduced.
 if command -v vg-orchestrator >/dev/null 2>&1; then
-  if ! vg-orchestrator run-status --check-contract "$run_id" >/tmp/contract-err.$$ 2>&1; then
-    failures+=("CONTRACT: $(cat /tmp/contract-err.$$)")
+  if vg-orchestrator run-status --help 2>/dev/null | grep -q -- '--check-contract'; then
+    if ! vg-orchestrator run-status --check-contract "$run_id" >/tmp/contract-err.$$ 2>&1; then
+      failures+=("CONTRACT: $(cat /tmp/contract-err.$$)")
+    fi
+    rm -f /tmp/contract-err.$$
   fi
-  rm -f /tmp/contract-err.$$
 fi
 
 if [ "${#failures[@]}" -gt 0 ]; then

--- a/scripts/hooks/vg-stop.sh
+++ b/scripts/hooks/vg-stop.sh
@@ -61,11 +61,17 @@ if [ -x "$sm_validator" ] && [ -f "$db" ]; then
 fi
 
 # 3. Contract verify (delegated to existing vg-orchestrator if present).
+# Note: legacy `run-status --check-contract <run_id>` was removed in v4.x.
+# The real spawn-count / wave-completion checks moved into `wave-complete`
+# (see vg-orchestrator/__main__.py near line 1966). Probe with --help so this
+# stays a no-op until/unless a runtime-contract subcommand is reintroduced.
 if command -v vg-orchestrator >/dev/null 2>&1; then
-  if ! vg-orchestrator run-status --check-contract "$run_id" >/tmp/contract-err.$$ 2>&1; then
-    failures+=("CONTRACT: $(cat /tmp/contract-err.$$)")
+  if vg-orchestrator run-status --help 2>/dev/null | grep -q -- '--check-contract'; then
+    if ! vg-orchestrator run-status --check-contract "$run_id" >/tmp/contract-err.$$ 2>&1; then
+      failures+=("CONTRACT: $(cat /tmp/contract-err.$$)")
+    fi
+    rm -f /tmp/contract-err.$$
   fi
-  rm -f /tmp/contract-err.$$
 fi
 
 if [ "${#failures[@]}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- `vg-orchestrator run-status --check-contract <run_id>` was removed in v4.x when the spawn-count / wave-completion check moved into `wave-complete` (code comment in `scripts/vg-orchestrator/__main__.py` near line 1966 still notes the Stop hook only delegated `--check-contract`).
- `scripts/hooks/vg-stop.sh:65` still invokes the legacy flag, so every Stop fired with an active-run row hits `unrecognized arguments: --check-contract <run_id>` → records a `CONTRACT:` failure → spurious `Stop-runtime-contract` block.
- Probe `run-status --help` for the flag before invoking. If the flag is reintroduced (or backported), the contract check resumes automatically; until then it stays a no-op.
- Patches both `scripts/hooks/vg-stop.sh` (canonical) and `.claude/scripts/hooks/vg-stop.sh` (mirror copied by `install.sh`).

## Reproduction

1. `/vg:update` against v4.17.1 (or any v4.x build).
2. Trigger Stop while an active-run JSON exists under `.vg/active-runs/`.
3. Stop hook produces:

```
Stop-runtime-contract: 1 failure(s) for run <uuid> (<command>)
CONTRACT: vg-orchestrator: error: unrecognized arguments: --check-contract <uuid>
```

After this patch the contract check is skipped silently while the legacy flag is absent.

## Test plan

- [x] `vg-orchestrator run-status --help` does **not** list `--check-contract` on v4.17.1 → hook block taken as no-op (verified by manual inspection of the helper output).
- [x] Diff applied to both copies of `vg-stop.sh`; identical bodies post-patch.
- [ ] Re-run `/vg:update` from a project after this lands → Stop fires without `Stop-runtime-contract` failure.
- [ ] Future reintroduction of `--check-contract` re-activates the call without further hook changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)