### PR TITLE
fix(v4.69.6): B105.1 probe nested tool_response.task.id

### DIFF
--- a/.claude/scripts/hooks/_vg_tasklist_evidence_payload.py
+++ b/.claude/scripts/hooks/_vg_tasklist_evidence_payload.py
@@ -79,6 +79,18 @@ def _resolve_tool_response_task_id(tool_response, kind: str) -> str:
             value = tool_response.get(key)
             if value:
                 return str(value)
+        # B105.1 (#198 follow-up): on the Claude Code runtime observed in
+        # PrintwayV3 dogfood 2026-05-22, the TaskCreate tool_response
+        # nests the id under a `task` object — e.g.
+        #   {"task": {"id": "61", "subject": "…"}}
+        # Probe that shape too so the create row carries a stable id
+        # without falling through to the regex fallback.
+        nested_task = tool_response.get("task")
+        if isinstance(nested_task, dict):
+            for key in ("id", "taskId", "task_id"):
+                value = nested_task.get(key)
+                if value:
+                    return str(value)
         content = tool_response.get("content")
         if isinstance(content, list):
             for entry in content:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,16 @@ probes, in this order:
 
 1. Flat dict keys `taskId` → `task_id` → `id` → `toolUseId`
    (preserves B80 invariant — camelCase still wins).
-2. `tool_response.content[*].text` regex parse:
+2. Nested `tool_response.task.{id,taskId,task_id}` — the actual shape
+   observed on the Claude Code runtime in the PrintwayV3 dogfood
+   (`{"task": {"id": "61", "subject": "…"}}`). Added in B105.1 follow-up
+   after second-pass instrumentation confirmed the id never landed on a
+   flat key.
+3. `tool_response.content[*].text` regex parse:
    `Task #(\d+) created` for the create path,
    `task #(\d+)` for the update path.
-3. Other text-bearing dict keys (`output` / `text` / `result` / `message`).
-4. `tool_response` itself when it is a plain string.
+4. Other text-bearing dict keys (`output` / `text` / `result` / `message`).
+5. `tool_response` itself when it is a plain string.
 
 `TaskUpdate` branch additionally falls back to the same resolver when
 `tool_input.taskId` is empty — some runtimes echo the id in the
@@ -41,10 +46,13 @@ working — regression bound covered by
 
 ## Tests
 
-`tests/test_b105_taskid_text_fallback.py` — 6 cases:
+`tests/test_b105_taskid_text_fallback.py` — 8 cases:
 
 - `test_b105_content_list_text_yields_taskid` — array-of-text response shape.
 - `test_b105_plain_string_response_yields_taskid` — bare string response.
+- `test_b105_1_nested_task_id_probed` — `tool_response.task.id` shape
+  (the actual Claude Code runtime payload).
+- `test_b105_1_nested_taskid_camelcase` — `tool_response.task.taskId`.
 - `test_b105_camelcase_still_wins_over_text` — probe order invariant.
 - `test_b105_taskupdate_text_fallback_pairs_status` — end-to-end
   create→update pairing with both ids in text only.

--- a/scripts/hooks/_vg_tasklist_evidence_payload.py
+++ b/scripts/hooks/_vg_tasklist_evidence_payload.py
@@ -79,6 +79,18 @@ def _resolve_tool_response_task_id(tool_response, kind: str) -> str:
             value = tool_response.get(key)
             if value:
                 return str(value)
+        # B105.1 (#198 follow-up): on the Claude Code runtime observed in
+        # PrintwayV3 dogfood 2026-05-22, the TaskCreate tool_response
+        # nests the id under a `task` object — e.g.
+        #   {"task": {"id": "61", "subject": "…"}}
+        # Probe that shape too so the create row carries a stable id
+        # without falling through to the regex fallback.
+        nested_task = tool_response.get("task")
+        if isinstance(nested_task, dict):
+            for key in ("id", "taskId", "task_id"):
+                value = nested_task.get(key)
+                if value:
+                    return str(value)
         content = tool_response.get("content")
         if isinstance(content, list):
             for entry in content:

--- a/tests/test_b105_taskid_text_fallback.py
+++ b/tests/test_b105_taskid_text_fallback.py
@@ -94,6 +94,61 @@ def test_b105_plain_string_response_yields_taskid(tmp_path: Path) -> None:
     assert rec["task_id"] == "42"
 
 
+def test_b105_1_nested_task_id_probed(tmp_path: Path) -> None:
+    """B105.1 (#198 follow-up): tool_response.task.id is probed.
+
+    PrintwayV3 dogfood 2026-05-22 second-pass investigation showed the
+    Claude Code runtime nests the id under a `task` object — the flat
+    keys + text regex were not enough. Probe the nested shape too.
+    """
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps({"checklists": [], "projection_items": []}),
+                             encoding="utf-8")
+    (tmp_path / ".vg" / "runs" / "test-run").mkdir(parents=True)
+
+    hook_input = {
+        "tool_name": "TaskCreate",
+        "tool_input": {"subject": "Nested"},
+        "tool_response": {"task": {"id": "61", "subject": "Nested"}},
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HELPER), str(contract_path), "test-run"],
+        cwd=tmp_path,
+        env={**os.environ, "VG_HOOK_INPUT": json.dumps(hook_input)},
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    trace = tmp_path / ".vg" / "runs" / "test-run" / ".taskcreate-trace.jsonl"
+    rec = json.loads(trace.read_text(encoding="utf-8").strip())
+    assert rec["task_id"] == "61", (
+        f"nested tool_response.task.id should be picked up; got {rec['task_id']!r}"
+    )
+
+
+def test_b105_1_nested_taskid_camelcase(tmp_path: Path) -> None:
+    """Nested probe accepts both ``id`` and ``taskId`` inside ``task``."""
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(json.dumps({"checklists": [], "projection_items": []}),
+                             encoding="utf-8")
+    (tmp_path / ".vg" / "runs" / "test-run").mkdir(parents=True)
+
+    hook_input = {
+        "tool_name": "TaskCreate",
+        "tool_input": {"subject": "Nested camel"},
+        "tool_response": {"task": {"taskId": "T-nest-7"}},
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HELPER), str(contract_path), "test-run"],
+        cwd=tmp_path,
+        env={**os.environ, "VG_HOOK_INPUT": json.dumps(hook_input)},
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    trace = tmp_path / ".vg" / "runs" / "test-run" / ".taskcreate-trace.jsonl"
+    rec = json.loads(trace.read_text(encoding="utf-8").strip())
+    assert rec["task_id"] == "T-nest-7"
+
+
 def test_b105_camelcase_still_wins_over_text(tmp_path: Path) -> None:
     """Flat camelCase ``taskId`` MUST still be probed before the regex fallback."""
     contract_path = tmp_path / "contract.json"


### PR DESCRIPTION
## Summary

Follow-up to #205 (B105). After applying the initial fallback chain to the TaskCreate evidence helper, PrintwayV3 dogfood instrumentation showed the trace STILL recorded `task_id=\"\"` on every create row. Dumping the actual ``VG_HOOK_INPUT`` payload Claude Code passes through revealed the id is NESTED under a `task` object:

\`\`\`json
{
  \"tool_name\": \"TaskCreate\",
  \"tool_input\": {\"subject\": \"…\"},
  \"tool_response\": {\"task\": {\"id\": \"61\", \"subject\": \"…\"}}
}
\`\`\`

Neither the flat keys (B80 + initial B105) nor the text-regex fallback (B105) cover this shape — the response has no human-readable confirmation text in this format either, so every TaskCreate landed in `items_no_id` and TaskUpdate could not pair.

## Fix

`_resolve_tool_response_task_id` gains a nested probe between the flat-key step and the text-regex step:

\`\`\`python
nested_task = tool_response.get(\"task\")
if isinstance(nested_task, dict):
    for key in (\"id\", \"taskId\", \"task_id\"):
        value = nested_task.get(key)
        if value:
            return str(value)
\`\`\`

This is verified live against the same Claude Code runtime where #205 was insufficient — the next TaskCreate trace row carried `task_id=\"62\"` correctly, the `tasklist-projected` gate cleared, and `/vg:build 8.2.2` STEP 1 preflight completed for the first time.

## Tests

`tests/test_b105_taskid_text_fallback.py` gains:

- `test_b105_1_nested_task_id_probed` — exact shape from the Claude Code dogfood payload.
- `test_b105_1_nested_taskid_camelcase` — accepts both `id` and `taskId` inside the nested object.

All 16 B80 + B105 tests PASS locally.

## Test plan

- [x] \`pytest tests/test_b105_taskid_text_fallback.py\` — 8/8 PASS
- [x] \`pytest tests/test_batch80_taskid_and_threshold.py\` — 8/8 PASS
- [x] Mirror byte-identical between \`scripts/\` and \`.claude/scripts/\`
- [x] Live dogfood — \`/vg:build 8.2.2\` STEP 1.6 \`create_task_tracker\` gate cleared
- [ ] CI Test workflow — pending push

Refs: #198, follows #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)