### PR TITLE
fix(tasklist-trace): persist TaskUpdate subject + handle delete action

### DIFF
--- a/scripts/hooks/_vg_tasklist_evidence_payload.py
+++ b/scripts/hooks/_vg_tasklist_evidence_payload.py
@@ -178,14 +178,31 @@ def main() -> int:
             )
             upd_id = _resolve_tool_response_task_id(tr_upd, "update")
         upd_status = str(tool_input.get("status") or "")
-        if upd_id and upd_status and trace_path.exists():
+        upd_subject = (tool_input.get("subject") or "").strip()
+        # B113b fix: previously TaskUpdate only persisted `status` to trace,
+        # losing subject renames + delete events. Symptom: tasklist coverage
+        # check stays unresolved forever when AI renames a group title or
+        # deletes a task (e.g., delete+recreate to match contract titles).
+        # Now: status="deleted" → action="delete" (reader removes row);
+        # subject present → action="update" with subject (reader overwrites).
+        if upd_id and trace_path.exists():
             trace_path.parent.mkdir(parents=True, exist_ok=True)
             with trace_path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps({
-                    "action": "update",
-                    "task_id": upd_id,
-                    "status": upd_status,
-                }) + "\n")
+                if upd_status == "deleted":
+                    f.write(json.dumps({
+                        "action": "delete",
+                        "task_id": upd_id,
+                    }) + "\n")
+                elif upd_status or upd_subject:
+                    record: dict = {
+                        "action": "update",
+                        "task_id": upd_id,
+                    }
+                    if upd_status:
+                        record["status"] = upd_status
+                    if upd_subject:
+                        record["subject"] = upd_subject
+                    f.write(json.dumps(record) + "\n")
     # else: unknown tool — leave trace untouched
 
     # Reconstruct todos[] from trace when this is a TaskCreate/TaskUpdate
@@ -214,8 +231,17 @@ def main() -> int:
                     else:
                         items_no_id.append(entry)
                 elif act == "update":
-                    if tid in items_by_id and rec.get("status"):
-                        items_by_id[tid]["status"] = rec["status"]
+                    if tid in items_by_id:
+                        if rec.get("status"):
+                            items_by_id[tid]["status"] = rec["status"]
+                        # B113b fix: apply subject rename so coverage check
+                        # sees the latest title matching contract checklist.
+                        if rec.get("subject"):
+                            items_by_id[tid]["content"] = rec["subject"]
+                elif act == "delete":
+                    # B113b fix: drop deleted task so snapshot doesn't carry
+                    # dangling unresolved entries forever.
+                    items_by_id.pop(tid, None)
         todos = list(items_by_id.values()) + items_no_id
 
     checklists = contract.get("checklists", [])

--- a/scripts/hooks/_vg_tasklist_snapshot_input.py
+++ b/scripts/hooks/_vg_tasklist_snapshot_input.py
@@ -137,8 +137,25 @@ def main() -> int:
                     else:
                         items_no_id.append(entry)
                 elif act == "update":
-                    if tid in items_by_id and rec.get("status"):
-                        items_by_id[tid]["status"] = rec["status"]
+                    if tid in items_by_id:
+                        if rec.get("status"):
+                            items_by_id[tid]["status"] = rec["status"]
+                        # B113b fix: apply subject rename + re-resolve
+                        # step_id/match_class against contract so the new
+                        # title (e.g. corrected to match checklist) lands
+                        # in the snapshot, not the stale create-time label.
+                        if rec.get("subject"):
+                            new_subject = rec["subject"]
+                            new_id, new_class = _resolve_label(
+                                new_subject, tid
+                            )
+                            items_by_id[tid]["content"] = new_subject
+                            items_by_id[tid]["id"] = new_id
+                            items_by_id[tid]["match_class"] = new_class
+                elif act == "delete":
+                    # B113b fix: drop deleted task so coverage check
+                    # doesn't carry dangling unresolved IDs forever.
+                    items_by_id.pop(tid, None)
             todos = list(items_by_id.values()) + items_no_id
 
     if not todos:


### PR DESCRIPTION
## Summary
- `.taskcreate-trace.jsonl` was missing two action paths: subject renames and deletes
- TaskUpdate handler now writes subject changes and emits `{action: delete, task_id}` for `status=deleted`
- Snapshot/evidence readers handle both new branches (overwrite content + re-resolve step_id on rename; pop on delete)

## Bug
Repro: in any vg workflow (scope/blueprint/build), rename a task group header to match the contract checklist title, OR delete + recreate a task. Then run `vg-orchestrator tasklist-projected`.

Symptom:
- Subject rename never reaches snapshot → coverage check reports `unresolved` group entries with the OLD title forever.
- Delete leaves the original entry in `items_by_id` → snapshot grows past contract size with stale rows.

Both symptoms produced the persistent `PreToolUse-tasklist: tasklist coverage incomplete — missing=...` block. Hit live during /vg:scope 7.17.1 — 5 consecutive blocks on the same gate, no recovery path possible via vg-orchestrator alone. User had to bypass and write CONTEXT.md manually.

## Fix
**`scripts/hooks/_vg_tasklist_evidence_payload.py`** (lines 166-203):
- TaskUpdate writer: branch on `status=='deleted'` → write `{action: delete}`. Otherwise include `subject` in update record when `tool_input.subject` non-empty.
- Reader: apply `subject` overwrite on `update`; new `delete` branch removes from `items_by_id`.

**`scripts/hooks/_vg_tasklist_snapshot_input.py`** (lines 139-159):
- Mirror reader logic. On subject rename, also re-resolve `id` + `match_class` against the contract so the new label maps to its proper checklist step_id (instead of staying `unresolved` with the old normalized id).

## Test plan
- [x] Repro live during /vg:blueprint 7.17.1 prep on Phase 7.17.1 fork
- [x] After fix, TaskUpdate subject "Blueprint Preflight (smoke-test marker)" → revert → snapshot has `content: "Blueprint Preflight"` + `id: blueprint_preflight` + `match_class: normalized` (was `unresolved` before)
- [x] TaskCreate `__TEST_DELETE_ME__` → TaskUpdate status=deleted → trace records `{action: delete, task_id: 90}` → snapshot drops the row
- [x] Python `ast.parse` on both modified files
- [x] Schema additive: legacy update records without subject still treated as status-only; existing traces remain readable

## Non-goals
- Group title resolver fuzz match (short titles like "Plan" not matching long contract title "Plan" remain unresolved — separate bug, scope keeps the strict normalize+slug approach)
- Schema version bump (additive change, no breaking consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)