### PR TITLE
fix: CrossAI Opus 5 lane, symlink-safe config in --rewrite, dogfound validator fixes

### DIFF
--- a/.claude/commands/vg/_shared/accept/uat/checklist-build/delegation.md
+++ b/.claude/commands/vg/_shared/accept/uat/checklist-build/delegation.md
@@ -44,6 +44,25 @@ Artifact sources (delegated subagent reads):
 | F    | `${PHASE_DIR}/build-state.log` (mobile-*)         | KEEP-FLAT | Latest `mobile-gate-N` per id |
 | F    | `${PHASE_DIR}/mobile-security/report.md`          | KEEP-FLAT | Severity counts (CRITICAL/HIGH/MEDIUM/LOW) |
 
+## Freshness contract (stale-read guard)
+
+READ EVERY ARTIFACT FRESH FROM DISK — never a cached snapshot from earlier in
+the session, and prefer a direct `sed`/`grep` re-read over any pre-warmed
+`vg-load` index if the two disagree. Dogfound P4.7 amend#6 (2026-07-05): the
+builder emitted a checklist scoped to a PRIOR amendment (amend#4 goals G-50..58)
+even though the current CONTEXT/TEST-GOALS/GOAL-COVERAGE-MATRIX on disk carried
+the amend#6 decisions (D-60/61/62) + goals (G-59..68). Guard:
+
+1. First: read TEST-GOALS.md frontmatter `goal_count` + the phase_name/amendment
+   line. Cross-check against the `## G-NN` headings you actually find. If they
+   disagree, RE-READ (the vg-load index may be stale after a fresh amendment).
+2. If the caller's prompt names an amendment/scope (e.g. "Amendment #6, goals
+   G-59..G-68"), the checklist you build MUST cover those ids. If your parse
+   surfaces a different goal range, you read a stale artifact — re-read before
+   emitting.
+3. Section counts in your returned JSON MUST match the sections you actually
+   wrote to disk.
+
 ## Workflow inside subagent
 
 1. Read input capsule (env vars set by main agent in prompt).

--- a/.claude/commands/vg/_shared/crossai-invoke.md
+++ b/.claude/commands/vg/_shared/crossai-invoke.md
@@ -91,8 +91,8 @@ mkdir -p "$OUTPUT_DIR"
 # Read CLIs from config
 # config.crossai_clis = [
 #   { name: "codex", command: "codex exec --skip-git-repo-check --config sandbox_mode=read-only {prompt}", label: "Codex configured model" },
-#   { name: "gemini", command: "cat '{context}' | gemini -m gemini-2.5-pro -p {prompt} --yolo", label: "Gemini Pro High 3.1" },
-#   { name: "claude", command: "cat '{context}' | claude --model sonnet -p {prompt}", label: "Claude Sonnet 4.6" }
+#   { name: "gemini", command: "cat '{context}' | agy --model \"Gemini 3.1 Pro (High)\" -p {prompt} --print-timeout 10m --dangerously-skip-permissions", label: "Gemini Pro High 3.1" },
+#   { name: "claude", command: "cat '{context}' | claude --model opus -p {prompt}", label: "Claude Opus 5 (1M)" }
 # ]
 #
 # Issue #149 (v2.66.0): {context} is wrapped in single quotes so workspace

--- a/.claude/commands/vg/_shared/project/first-time-rounds.md
+++ b/.claude/commands/vg/_shared/project/first-time-rounds.md
@@ -522,6 +522,25 @@ mv "${CONFIG_FILE}.staged"     "$CONFIG_FILE"
 # Remove draft
 rm -f "$DRAFT_FILE"
 
+# --- Symlink self-heal (v4.73.1) ---
+# preflight.md redirected $CONFIG_FILE to the real file when
+# .claude/vg.config.md is a symlink, so the promote above wrote the canonical
+# target and the link should be untouched. Verify, and rebuild the link if any
+# writer replaced it with a plain file — otherwise the dual-config drift the
+# symlink prevents would silently return.
+if [ -n "${CONFIG_LINK_PATH:-}" ] && [ "$CONFIG_LINK_PATH" != "$CONFIG_FILE" ]; then
+  if [ ! -L "$CONFIG_LINK_PATH" ]; then
+    LINK_TARGET=$(${PYTHON_BIN} -c "
+import os, sys
+print(os.path.relpath(os.path.abspath(sys.argv[1]), os.path.dirname(os.path.abspath(sys.argv[2]))))
+" "$CONFIG_FILE" "$CONFIG_LINK_PATH")
+    rm -f "$CONFIG_LINK_PATH"
+    ln -s "$LINK_TARGET" "$CONFIG_LINK_PATH"
+    echo "🔗 Rebuilt config symlink: ${CONFIG_LINK_PATH} -> ${LINK_TARGET}"
+  fi
+  git add "$CONFIG_LINK_PATH"
+fi
+
 # Commit
 git add "$PROJECT_FILE" "$FOUNDATION_FILE" "$CONFIG_FILE"
 [ -f "$STP_FILE" ] && git add "$STP_FILE"

--- a/.claude/commands/vg/_shared/project/preflight.md
+++ b/.claude/commands/vg/_shared/project/preflight.md
@@ -10,6 +10,41 @@ DRAFT_FILE="${PLANNING_DIR}/.project-draft.json"
 ARCHIVE_DIR="${PLANNING_DIR}/.archive"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 
+# --- Symlink-safe config path (v4.73.1) ---
+# A project may consolidate the dual config layout (.vg/config.md +
+# .claude/vg.config.md) into ONE real file plus a symlink, e.g.
+#   .claude/vg.config.md -> ../.vg/config.md
+# Two writers downstream would otherwise act on the SYMLINK, not its target:
+#   * update-modes.md      → mv "$CONFIG_FILE" "$BACKUP_DIR/vg.config.md.pre-rewrite"
+#   * first-time-rounds.md → mv "${CONFIG_FILE}.staged" "$CONFIG_FILE"
+# The first moves the link away; the second then drops a plain file in its
+# place. Net effect: symlink gone, and the dual-config drift it existed to
+# prevent silently returns. Resolve to the real path up front so every write
+# lands on the canonical file and the link survives --rewrite.
+CONFIG_LINK_PATH=""
+if [ -L "$CONFIG_FILE" ]; then
+  CONFIG_LINK_PATH="$CONFIG_FILE"
+  # os.path.realpath resolves even a dangling link, so this is safe to call
+  # before we know whether the target exists.
+  CONFIG_REAL=$(${PYTHON_BIN} -c "
+import os, sys
+real = os.path.realpath(sys.argv[1])
+# realpath (not abspath) on the root too: on macOS /tmp is itself a symlink to
+# /private/tmp, and mixing the two forms makes relpath escape with '..'.
+root = os.path.realpath(sys.argv[2])
+rel = os.path.relpath(real, root)
+# Stay repo-relative when possible so downstream 'git add' remains in-repo.
+print(real if rel.startswith(os.pardir) else rel)
+" "$CONFIG_FILE" "${REPO_ROOT:-$(pwd)}" 2>/dev/null)
+  if [ -n "$CONFIG_REAL" ]; then
+    CONFIG_FILE="$CONFIG_REAL"
+    echo "🔗 .claude/vg.config.md is a symlink — config writes redirected to: ${CONFIG_FILE}"
+  else
+    echo "⚠ .claude/vg.config.md is a symlink but its target could not be resolved."
+    echo "  Continuing with the link path; verify the symlink after this command."
+  fi
+fi
+
 mkdir -p "$PLANNING_DIR"
 
 # Mode flags (mutually exclusive)

--- a/.claude/commands/vg/_shared/roam/spawn-executors.md
+++ b/.claude/commands/vg/_shared/roam/spawn-executors.md
@@ -100,7 +100,7 @@ if [ "$ROAM_MODE" = "spawn" ]; then
   # Resolve CLI command per model
   declare -A CLI_CMD_FOR_MODEL
   CLI_CMD_FOR_MODEL[codex]='cat "{brief}" | codex exec --full-auto'
-  CLI_CMD_FOR_MODEL[gemini]='cat "{brief}" | gemini -m gemini-2.5-pro -p "follow brief verbatim, output JSONL only" --yolo'
+  CLI_CMD_FOR_MODEL[gemini]='cat "{brief}" | agy --model "Gemini 3.5 Flash (Medium)" -p "follow brief verbatim, output JSONL only" --print-timeout 10m --dangerously-skip-permissions'
 
   declare -a PIDS
   for MODEL_DIR in "${ROAM_MODEL_DIRS[@]}"; do

--- a/.claude/commands/vg/_shared/test/goal-verification/delegation.md
+++ b/.claude/commands/vg/_shared/test/goal-verification/delegation.md
@@ -53,6 +53,25 @@ You are vg-test-goal-verifier. Verify phase ${PHASE_NUMBER} goals and return
 a JSON envelope. Do NOT browse files outside input. Do NOT ask user — input is
 the contract.
 
+<freshness_contract>
+READ EVERY INPUT FRESH FROM DISK before concluding anything — never rely on a
+cached snapshot from earlier in the session. Stale-read guard (dogfound P4.7
+amend#6, 2026-07-05: a verifier reported 10 goals "do not exist" citing an old
+`goal_count`, while its own verdict file said failing_goals:0 — internal
+contradiction from a pre-edit snapshot):
+
+1. First action: read TEST-GOALS.md and note its frontmatter `goal_count` +
+   count the `## G-NN` headings. If they disagree, RE-READ once.
+2. NEVER report a goal as "missing / does not exist" if it is present in
+   TEST-GOALS.md or GOAL-COVERAGE-MATRIX.md on disk. Absence must be verified
+   against a fresh read, not memory.
+3. Your narrative and your `.verdict-computed.json` MUST agree. If you are
+   about to write failing_goals:N while your prose says a different number,
+   STOP and re-derive both from the same fresh read.
+4. If the caller's prompt names goals (e.g. G-59..G-68) that you cannot find,
+   re-read the artifact once; only report absence if it truly is not on disk.
+</freshness_contract>
+
 <inputs>
 @${PHASE_DIR}/TEST-GOALS.md          (goals reference — read-only)
 @${PHASE_DIR}/RUNTIME-MAP.json       (review-discovered paths — read-only)

--- a/.claude/scripts/validators/acceptance-reconciliation.py
+++ b/.claude/scripts/validators/acceptance-reconciliation.py
@@ -276,12 +276,31 @@ def main() -> None:
         decisions = parse_decisions(context)
         if decisions:
             decision_ids = {d["id"] for d in decisions}
+            # Decisions already signed off in a prior accepted {phase}-UAT.md
+            # are settled — an amendment accept must not re-flag them for
+            # scope-branching (dogfound P4.7 amend#6: D-11/30/32/35/53/54 from
+            # earlier cycles re-flagged on incidental words like "choice"/"fork"
+            # even though 4.7-UAT.md accepted them). Only NEW decisions can have
+            # a genuinely-unaddressed branch.
+            accepted_ids: set[str] = set()
+            for uat in phase_dir.glob("*UAT*.md"):
+                try:
+                    utext = uat.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    continue
+                if not re.search(r"verdict:\s*ACCEPTED", utext, re.IGNORECASE):
+                    continue
+                for m in re.finditer(r"\bD-(\d+(?:\.\d+)?)\b", utext):
+                    accepted_ids.add(m.group(1))
             branching_unresolved = []
             for d in decisions:
                 body_lower = d["body"].lower()
                 if not BRANCHING_KW_RE.search(d["body"]):
                     continue
                 if FINALIZED_RE.search(d["body"]):
+                    continue
+                # skip decisions already accepted in a prior UAT sign-off
+                if d["id"] in accepted_ids or d["id"].split(".")[-1] in accepted_ids:
                     continue
                 # Look for sub-decisions D-XX.Y where XX = this decision's id
                 base_id = d["id"].split(".")[0]

--- a/.claude/scripts/validators/goal-coverage.py
+++ b/.claude/scripts/validators/goal-coverage.py
@@ -36,6 +36,12 @@ GOAL_RE = re.compile(
 STRATEGY_RE = re.compile(r"verification_strategy:\s*(\w+)", re.IGNORECASE)
 DEPENDS_RE = re.compile(r"depends_on_phase:\s*(\S+)", re.IGNORECASE)
 TS_BINDING_RE = re.compile(r"binds_to:\s*(TS-\d+(?:,\s*TS-\d+)*)", re.IGNORECASE)
+# vg-test-codegen emits `vg-binding: {phase}.G-NN` markers inside generated
+# .spec.ts files (NOT binds_to:TS-XX which codegen never produces). A goal is
+# covered when a spec file carries a vg-binding marker naming that goal id.
+# Dogfound P4.7 amend#6 (2026-07-05): 64 goals flagged unbound at accept even
+# though 10 real specs existed — validator only knew TS-XX + Implemented-by.
+VG_BINDING_RE = re.compile(r"vg-binding:\s*[\w.]*?\b(G-\d+)\b", re.IGNORECASE)
 # Legacy format: goals declare implementation via "Implemented by:" with .spec.ts filenames
 IMPL_BY_RE = re.compile(r"\*\*Implemented\s+by:\*\*", re.IGNORECASE)
 # Match test artifacts across: *.spec.ts/js, *.test.ts/py, smoke-*.sh
@@ -96,6 +102,27 @@ def find_ts_refs(scan_globs: list[str]) -> set[str]:
     return found
 
 
+def find_vg_binding_goals(scan_globs: list[str]) -> set[str]:
+    """Collect goal ids named by `vg-binding: {phase}.G-NN` markers in specs.
+
+    vg-test-codegen writes these markers into generated .spec.ts files. A goal
+    whose id shows up here has an executable spec bound to it, even without a
+    TS-XX marker or an `Implemented by:` line.
+    """
+    found = set()
+    for gp in scan_globs:
+        for f in Path(REPO_ROOT).glob(gp):
+            if not f.is_file():
+                continue
+            try:
+                text = f.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            for m in VG_BINDING_RE.finditer(text):
+                found.add(m.group(1).upper())
+    return found
+
+
 def phase_in_roadmap(phase: str) -> bool:
     if not ROADMAP.exists():
         return False
@@ -149,6 +176,12 @@ def main() -> None:
             f".vg/phases/{args.phase}-*/SANDBOX-TEST*.md",
         ]
         ts_refs = find_ts_refs(test_globs)
+        # vg-binding markers — scan the same spec globs plus the lifecycle dir
+        # where /vg:test-spec codegen lands per-goal specs.
+        vg_binding_goals = find_vg_binding_goals(test_globs + [
+            "tests/e2e/**/*.spec.ts",
+            "tests/e2e/**/*.ts",
+        ])
         existing_spec_files = set()
         for gp in test_globs + [
             "scripts/**/*.sh",
@@ -176,7 +209,10 @@ def main() -> None:
                     deferred_missing_target.append(f"{g['id']} → {target}")
                 continue
 
-            # automated: must have TS-XX binding covered OR a .spec.ts file that exists
+            # automated: covered by ANY of —
+            #   (1) TS-XX binding + a spec referencing that TS-XX
+            #   (2) legacy `Implemented by:` .spec.ts filename that exists
+            #   (3) vg-binding: {phase}.G-NN marker in a spec (codegen default)
             has_ts_binding = bool(g["binds_to"])
             has_impl_specs = bool(g["impl_specs"])
 
@@ -188,8 +224,9 @@ def main() -> None:
                     spec in existing_spec_files for spec in g["impl_specs"]
                 )
             )
+            covered_by_vg_binding = g["id"].upper() in vg_binding_goals
 
-            if not (covered_by_ts or covered_by_spec):
+            if not (covered_by_ts or covered_by_spec or covered_by_vg_binding):
                 detail = (
                     ",".join(g["binds_to"]) if has_ts_binding
                     else (",".join(g["impl_specs"]) if has_impl_specs
@@ -202,7 +239,7 @@ def main() -> None:
                 type="goal_unbound",
                 message=f"{len(unbound_automated)} automated goals not bound to any test file",
                 actual=", ".join(unbound_automated[:10]),
-                fix_hint="Each automated goal MUST have 'binds_to: TS-XX' + test file references that TS-XX.",
+                fix_hint="Each automated goal MUST be bound: 'binds_to: TS-XX' + spec referencing TS-XX, OR '**Implemented by:** <file>.spec.ts', OR a spec carrying 'vg-binding: {phase}.G-NN' (codegen default).",
             ))
 
         if deferred_missing_target:

--- a/.claude/scripts/validators/verify-api-docs-coverage.py
+++ b/.claude/scripts/validators/verify-api-docs-coverage.py
@@ -81,6 +81,15 @@ def main() -> None:
         sections = parse_contract_sections(contracts_path)
         entries = parse_api_docs_entries(docs_path)
         require_error_handling = _interface_standards_requires_error_handling(docs_path)
+        # Backend-only / 0-endpoint phases (e.g. worker + schema + migration
+        # remediation) legitimately have no HTTP endpoint sections in
+        # API-CONTRACTS.md. When the contract declares zero endpoints there is
+        # nothing to cross-check — the API-DOCS.md narrative stub is sufficient.
+        # Only demand machine-readable entries when the contract actually
+        # declares endpoints to document.
+        if not sections:
+            out.note = "no endpoint sections in API-CONTRACTS.md (backend-only phase) — coverage N/A"
+            emit_and_exit(out)
         if not entries:
             out.add(Evidence(
                 type="api_docs_no_entries",

--- a/.claude/scripts/validators/verify-contract-runtime.py
+++ b/.claude/scripts/validators/verify-contract-runtime.py
@@ -288,6 +288,23 @@ def main() -> None:
 
         endpoints = parse_contract_endpoints(contracts_path)
         if not endpoints:
+            # Backend-only / 0-endpoint phases (worker + schema + migration
+            # remediation) legitimately ship an API-CONTRACTS.md that documents
+            # INTERNAL service/worker interfaces and explicitly declares zero
+            # HTTP endpoints. That is NOT format drift — there is nothing to
+            # phantom-check. Detect the declaration and PASS instead of BLOCK.
+            try:
+                _ctext = contracts_path.read_text(encoding="utf-8", errors="ignore").lower()
+            except OSError:
+                _ctext = ""
+            _declares_no_http = (
+                "no new http api surface" in _ctext
+                or "endpoints noted: 0" in _ctext
+                or "0 endpoints" in _ctext
+                or "web-backend-only" in _ctext
+            )
+            if _declares_no_http:
+                emit_and_exit(out)
             # FAIL CLOSED (v2.45 PR fix/fail-closed-validators): API-CONTRACTS.md
             # exists but no `## METHOD /path` / `### METHOD /path` headers parsed.
             # Previously WARN — passed silently when contract format drifted.

--- a/.claude/scripts/validators/verify-deep-test-specs.py
+++ b/.claude/scripts/validators/verify-deep-test-specs.py
@@ -75,6 +75,14 @@ CREATE_ONLY_STAGES = ("read_before", "create", "read_after_create")
 UPDATE_ONLY_STAGES = ("read_before", "update", "read_after_update")
 DELETE_ONLY_STAGES = ("read_before", "delete", "read_after_delete")
 
+# B-dogfood (PrintwayV3 P9 2026-07-01): read-family stage-sets. MUST mirror
+# generate-lifecycle-specs.py + test_spec_ai_expander.py + verify-lifecycle-spec-depth.py.
+READ_HYDRATE_STAGES = ("read_before", "render_initial", "hydrate_authed", "hydrate_anon", "error_state_4xx", "accessibility")
+READ_SSR_SEO_STAGES = ("read_before", "render_initial", "seo_metadata", "revalidate_signed", "revalidate_tampered", "error_state_4xx")
+INFRA_BOOT_STAGES = ("read_before", "boot_start", "health_check", "idempotent_restart", "graceful_drain")
+NAVIGATION_STAGES = ("read_before", "render_initial", "nav_active_state", "deep_link_reload", "back_restore", "accessibility")
+AUTH_ROUTE_STAGES = ("read_before", "unauth_redirect", "login_returnurl", "authed_access", "logout_clears")
+
 # Map goal_class / goal_type → expected stage set.
 # Lookup order in _expected_stages_for_spec():
 #   1. goal_class (B62-pre dispatch precedence)
@@ -84,6 +92,21 @@ GOAL_CLASS_STAGE_SETS = {
     "feature_chain": FEATURE_CHAIN_STAGES,
     "post_create_cascade": FEATURE_CHAIN_STAGES,  # alias per B62-pre
     "readonly": READONLY_STAGES,
+    # B66 (PrintwayV3 P4.7 dogfood 2026-06-07): generate-lifecycle-specs.py emits
+    # goal_class in {create-only,update-only,delete-only,read-only} for partial-
+    # lifecycle goals (FK-restrict-delete, stale-version PATCH). Validator only
+    # mapped feature_chain/readonly; when goal_type=multi-actor (absent from
+    # GOAL_TYPE_STAGE_SETS) dispatch fell through to default RCRURDR -> false
+    # BLOCK on legit delete-only goals. Mirror the partial sets here.
+    "read-only": READONLY_STAGES,
+    "create-only": CREATE_ONLY_STAGES,
+    "update-only": UPDATE_ONLY_STAGES,
+    "delete-only": DELETE_ONLY_STAGES,
+    "read-hydrate": READ_HYDRATE_STAGES,
+    "read-ssr-seo": READ_SSR_SEO_STAGES,
+    "infra-boot": INFRA_BOOT_STAGES,
+    "navigation": NAVIGATION_STAGES,
+    "auth-route": AUTH_ROUTE_STAGES,
 }
 
 GOAL_TYPE_STAGE_SETS = {
@@ -91,6 +114,11 @@ GOAL_TYPE_STAGE_SETS = {
     "create-only": CREATE_ONLY_STAGES,
     "update-only": UPDATE_ONLY_STAGES,
     "delete-only": DELETE_ONLY_STAGES,
+    "read-hydrate": READ_HYDRATE_STAGES,
+    "read-ssr-seo": READ_SSR_SEO_STAGES,
+    "infra-boot": INFRA_BOOT_STAGES,
+    "navigation": NAVIGATION_STAGES,
+    "auth-route": AUTH_ROUTE_STAGES,
 }
 
 

--- a/.claude/scripts/validators/verify-lifecycle-spec-depth.py
+++ b/.claude/scripts/validators/verify-lifecycle-spec-depth.py
@@ -60,9 +60,13 @@ ARTIFACT_WORD_RE = re.compile(
     re.IGNORECASE,
 )
 
+# B98: `admin` removed — it is a SINGLE role, the opposite of a multi-actor
+# signal. Pre-B98 every admin-only goal ("admin opens page X") tripped this
+# regex and was wrongly required to declare >=2 actors. Genuine multi-actor
+# (admin impersonates merchant) still matches via `impersonat`/`owner`/etc.
 MULTI_ACTOR_WORD_RE = re.compile(
     r"\b("
-    r"multi[-\s]?actor|owner|invitee|inviter|admin|approver|reviewer|"
+    r"multi[-\s]?actor|owner|invitee|inviter|approver|reviewer|"
     r"second\s+user|another\s+user|role\s+switch|impersonat|oauth"
     r")\b",
     re.IGNORECASE,
@@ -219,10 +223,16 @@ REQUIRED_STAGES_BY_CLASS: dict[str, tuple[str, ...]] = {
     "create-only": ("read_before", "create", "read_after_create"),
     "update-only": ("read_before", "update", "read_after_update"),
     "delete-only": ("read_before", "delete", "read_after_delete"),
+    # B-dogfood (PrintwayV3 P9 2026-07-01): read-family min-required subsets.
+    "read-hydrate": ("read_before", "render_initial"),
+    "read-ssr-seo": ("read_before", "render_initial"),
+    "infra-boot":   ("read_before", "boot_start"),
+    "navigation":   ("read_before", "render_initial"),
+    "auth-route":   ("read_before", "unauth_redirect"),
 }
 
 
-def _required_stages_for(goal: dict[str, Any]) -> tuple[str, ...]:
+def _required_stages_for(goal: dict[str, Any], spec: dict[str, Any] | None = None) -> tuple[str, ...]:
     """B97 v4.69.0: explicit goal_class enum dictates required stage subset.
 
     Returns the stage tuple the validator should enforce for `goal`. Falls
@@ -230,6 +240,15 @@ def _required_stages_for(goal: dict[str, Any]) -> tuple[str, ...]:
     mutation-class value.
     """
     gc = str(goal.get("goal_class") or "").lower().strip()
+    # B98: the lifecycle SPEC is the authoritative contract. When the
+    # goal-side goal_class is blank (TEST-GOALS commonly omits it), fall back
+    # to the spec's declared goal_class before defaulting to full RCRURDR.
+    # Pre-B98 read goal-only -> readonly render specs wrongly required
+    # create/update/delete stages.
+    if gc not in REQUIRED_STAGES_BY_CLASS and spec is not None:
+        spec_gc = str(spec.get("goal_class") or "").lower().strip()
+        if spec_gc in REQUIRED_STAGES_BY_CLASS:
+            gc = spec_gc
     if gc in REQUIRED_STAGES_BY_CLASS:
         return REQUIRED_STAGES_BY_CLASS[gc]
     return REQUIRED_STAGES
@@ -436,7 +455,7 @@ def main() -> None:
             # B97 v4.69.0 (issue #201): use per-class required subset when
             # explicit goal_class declares non-mutation. Pre-B97 always used
             # full RCRURDR → false positive on 3-stage create-only goals.
-            required = _required_stages_for(goal)
+            required = _required_stages_for(goal, spec)
             missing = [stage for stage in required if stage not in _stage_names(spec)]
             if missing:
                 gc = str(goal.get("goal_class") or "").lower().strip()

--- a/.claude/scripts/vg_generate_config.py
+++ b/.claude/scripts/vg_generate_config.py
@@ -122,18 +122,18 @@ def _stack_from_framework(fw: str) -> str:
 def render_crossai_clis(team_size: str) -> str:
     if team_size == "solo":
         clis = [
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     elif team_size in ("2-5",):
         clis = [
             ("Codex", 'cat {context} | codex exec "{prompt}"', "Codex configured model"),
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     else:
         clis = [
             ("Codex", 'cat {context} | codex exec "{prompt}"', "Codex configured model"),
-            ("Gemini", 'cat {context} | gemini -m gemini-3.1-pro-preview -p "{prompt}" --yolo', "Gemini Pro High 3.1"),
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Gemini", 'cat {context} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions', "Gemini Pro High 3.1"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     lines = ["crossai_clis:"]
     for name, cmd, label in clis:

--- a/.claude/skills/vg-crossai/SKILL.md
+++ b/.claude/skills/vg-crossai/SKILL.md
@@ -78,7 +78,7 @@ All modes produce output conforming to this schema:
         </finding>
       </findings>
     </cli>
-    <cli source="claude" model="sonnet-4.6">
+    <cli source="claude" model="opus-5">
       <verdict>pass|flag|block</verdict>
       <score>{1-10}</score>
       <findings>
@@ -118,12 +118,12 @@ codex exec "$(cat {context_file})" > {output_path} 2>&1 &
 
 **Gemini (Pro High 3.1):**
 ```bash
-cat {context_file} | gemini -m gemini-2.5-pro -p "{prompt}" --yolo > {output_path} 2>&1 &
+cat {context_file} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions > {output_path} 2>&1 &
 ```
 
 **Claude (Sonnet 4.6):**
 ```bash
-cat {context_file} | claude --model sonnet -p "{prompt}" > {output_path} 2>&1 &
+cat {context_file} | claude --model opus -p "{prompt}" > {output_path} 2>&1 &
 ```
 
 ### Parallel Spawn Pattern
@@ -138,10 +138,10 @@ mkdir -p "$OUTPUT_DIR"
 codex exec "$(cat $CONTEXT_FILE)" > "$OUTPUT_DIR/codex.out" 2>&1 &
 PID_CODEX=$!
 
-cat "$CONTEXT_FILE" | gemini -m gemini-2.5-pro -p "$PROMPT" --yolo > "$OUTPUT_DIR/gemini.out" 2>&1 &
+cat "$CONTEXT_FILE" | agy --model "Gemini 3.1 Pro (High)" -p "$PROMPT" --print-timeout 10m --dangerously-skip-permissions > "$OUTPUT_DIR/gemini.out" 2>&1 &
 PID_GEMINI=$!
 
-cat "$CONTEXT_FILE" | claude --model sonnet -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
+cat "$CONTEXT_FILE" | claude --model opus -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
 PID_CLAUDE=$!
 
 # Wait for all to complete

--- a/.claude/templates/vg/vg.config.template.md
+++ b/.claude/templates/vg/vg.config.template.md
@@ -227,11 +227,11 @@ crossai_clis:
     command: 'cat {context} | codex exec "{prompt}"'
     label: "Codex configured model"
   - name: "Gemini"
-    command: 'cat {context} | gemini -m gemini-3.1-pro-preview -p "{prompt}" --yolo'
+    command: 'cat {context} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions'
     label: "Gemini Pro High 3.1"
   - name: "Claude"
-    command: 'cat {context} | claude --model sonnet -p "{prompt}"'
-    label: "Claude Sonnet 4.6"
+    command: 'cat {context} | claude --model opus -p "{prompt}"'
+    label: "Claude Opus 5 (1M)"
     # ➜ Fable 5 upgrade (when available): change --model to claude-fable-5.
     # Fable 5 (released 2026-06-09) — Mythos-class code-specialist
     # (SWE-Bench Pro 80.3% vs Opus 4.8 69.2%). The CLI-pipe lane accepts the

--- a/codex-skills/vg-crossai/SKILL.md
+++ b/codex-skills/vg-crossai/SKILL.md
@@ -233,7 +233,7 @@ All modes produce output conforming to this schema:
         </finding>
       </findings>
     </cli>
-    <cli source="claude" model="sonnet-4.6">
+    <cli source="claude" model="opus-5">
       <verdict>pass|flag|block</verdict>
       <score>{1-10}</score>
       <findings>
@@ -273,12 +273,12 @@ codex exec "$(cat {context_file})" > {output_path} 2>&1 &
 
 **Gemini (Pro High 3.1):**
 ```bash
-cat {context_file} | gemini -m gemini-2.5-pro -p "{prompt}" --yolo > {output_path} 2>&1 &
+cat {context_file} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions > {output_path} 2>&1 &
 ```
 
 **Claude (Sonnet 4.6):**
 ```bash
-cat {context_file} | claude --model sonnet -p "{prompt}" > {output_path} 2>&1 &
+cat {context_file} | claude --model opus -p "{prompt}" > {output_path} 2>&1 &
 ```
 
 ### Parallel Spawn Pattern
@@ -293,10 +293,10 @@ mkdir -p "$OUTPUT_DIR"
 codex exec "$(cat $CONTEXT_FILE)" > "$OUTPUT_DIR/codex.out" 2>&1 &
 PID_CODEX=$!
 
-cat "$CONTEXT_FILE" | gemini -m gemini-2.5-pro -p "$PROMPT" --yolo > "$OUTPUT_DIR/gemini.out" 2>&1 &
+cat "$CONTEXT_FILE" | agy --model "Gemini 3.1 Pro (High)" -p "$PROMPT" --print-timeout 10m --dangerously-skip-permissions > "$OUTPUT_DIR/gemini.out" 2>&1 &
 PID_GEMINI=$!
 
-cat "$CONTEXT_FILE" | claude --model sonnet -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
+cat "$CONTEXT_FILE" | claude --model opus -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
 PID_CLAUDE=$!
 
 # Wait for all to complete

--- a/commands/vg/_shared/accept/uat/checklist-build/delegation.md
+++ b/commands/vg/_shared/accept/uat/checklist-build/delegation.md
@@ -44,6 +44,25 @@ Artifact sources (delegated subagent reads):
 | F    | `${PHASE_DIR}/build-state.log` (mobile-*)         | KEEP-FLAT | Latest `mobile-gate-N` per id |
 | F    | `${PHASE_DIR}/mobile-security/report.md`          | KEEP-FLAT | Severity counts (CRITICAL/HIGH/MEDIUM/LOW) |
 
+## Freshness contract (stale-read guard)
+
+READ EVERY ARTIFACT FRESH FROM DISK — never a cached snapshot from earlier in
+the session, and prefer a direct `sed`/`grep` re-read over any pre-warmed
+`vg-load` index if the two disagree. Dogfound P4.7 amend#6 (2026-07-05): the
+builder emitted a checklist scoped to a PRIOR amendment (amend#4 goals G-50..58)
+even though the current CONTEXT/TEST-GOALS/GOAL-COVERAGE-MATRIX on disk carried
+the amend#6 decisions (D-60/61/62) + goals (G-59..68). Guard:
+
+1. First: read TEST-GOALS.md frontmatter `goal_count` + the phase_name/amendment
+   line. Cross-check against the `## G-NN` headings you actually find. If they
+   disagree, RE-READ (the vg-load index may be stale after a fresh amendment).
+2. If the caller's prompt names an amendment/scope (e.g. "Amendment #6, goals
+   G-59..G-68"), the checklist you build MUST cover those ids. If your parse
+   surfaces a different goal range, you read a stale artifact — re-read before
+   emitting.
+3. Section counts in your returned JSON MUST match the sections you actually
+   wrote to disk.
+
 ## Workflow inside subagent
 
 1. Read input capsule (env vars set by main agent in prompt).

--- a/commands/vg/_shared/crossai-invoke.md
+++ b/commands/vg/_shared/crossai-invoke.md
@@ -91,8 +91,8 @@ mkdir -p "$OUTPUT_DIR"
 # Read CLIs from config
 # config.crossai_clis = [
 #   { name: "codex", command: "codex exec --skip-git-repo-check --config sandbox_mode=read-only {prompt}", label: "Codex configured model" },
-#   { name: "gemini", command: "cat '{context}' | gemini -m gemini-2.5-pro -p {prompt} --yolo", label: "Gemini Pro High 3.1" },
-#   { name: "claude", command: "cat '{context}' | claude --model sonnet -p {prompt}", label: "Claude Sonnet 4.6" }
+#   { name: "gemini", command: "cat '{context}' | agy --model \"Gemini 3.1 Pro (High)\" -p {prompt} --print-timeout 10m --dangerously-skip-permissions", label: "Gemini Pro High 3.1" },
+#   { name: "claude", command: "cat '{context}' | claude --model opus -p {prompt}", label: "Claude Opus 5 (1M)" }
 # ]
 #
 # Issue #149 (v2.66.0): {context} is wrapped in single quotes so workspace

--- a/commands/vg/_shared/project/first-time-rounds.md
+++ b/commands/vg/_shared/project/first-time-rounds.md
@@ -522,6 +522,25 @@ mv "${CONFIG_FILE}.staged"     "$CONFIG_FILE"
 # Remove draft
 rm -f "$DRAFT_FILE"
 
+# --- Symlink self-heal (v4.73.1) ---
+# preflight.md redirected $CONFIG_FILE to the real file when
+# .claude/vg.config.md is a symlink, so the promote above wrote the canonical
+# target and the link should be untouched. Verify, and rebuild the link if any
+# writer replaced it with a plain file — otherwise the dual-config drift the
+# symlink prevents would silently return.
+if [ -n "${CONFIG_LINK_PATH:-}" ] && [ "$CONFIG_LINK_PATH" != "$CONFIG_FILE" ]; then
+  if [ ! -L "$CONFIG_LINK_PATH" ]; then
+    LINK_TARGET=$(${PYTHON_BIN} -c "
+import os, sys
+print(os.path.relpath(os.path.abspath(sys.argv[1]), os.path.dirname(os.path.abspath(sys.argv[2]))))
+" "$CONFIG_FILE" "$CONFIG_LINK_PATH")
+    rm -f "$CONFIG_LINK_PATH"
+    ln -s "$LINK_TARGET" "$CONFIG_LINK_PATH"
+    echo "🔗 Rebuilt config symlink: ${CONFIG_LINK_PATH} -> ${LINK_TARGET}"
+  fi
+  git add "$CONFIG_LINK_PATH"
+fi
+
 # Commit
 git add "$PROJECT_FILE" "$FOUNDATION_FILE" "$CONFIG_FILE"
 [ -f "$STP_FILE" ] && git add "$STP_FILE"

--- a/commands/vg/_shared/project/preflight.md
+++ b/commands/vg/_shared/project/preflight.md
@@ -10,6 +10,41 @@ DRAFT_FILE="${PLANNING_DIR}/.project-draft.json"
 ARCHIVE_DIR="${PLANNING_DIR}/.archive"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 
+# --- Symlink-safe config path (v4.73.1) ---
+# A project may consolidate the dual config layout (.vg/config.md +
+# .claude/vg.config.md) into ONE real file plus a symlink, e.g.
+#   .claude/vg.config.md -> ../.vg/config.md
+# Two writers downstream would otherwise act on the SYMLINK, not its target:
+#   * update-modes.md      → mv "$CONFIG_FILE" "$BACKUP_DIR/vg.config.md.pre-rewrite"
+#   * first-time-rounds.md → mv "${CONFIG_FILE}.staged" "$CONFIG_FILE"
+# The first moves the link away; the second then drops a plain file in its
+# place. Net effect: symlink gone, and the dual-config drift it existed to
+# prevent silently returns. Resolve to the real path up front so every write
+# lands on the canonical file and the link survives --rewrite.
+CONFIG_LINK_PATH=""
+if [ -L "$CONFIG_FILE" ]; then
+  CONFIG_LINK_PATH="$CONFIG_FILE"
+  # os.path.realpath resolves even a dangling link, so this is safe to call
+  # before we know whether the target exists.
+  CONFIG_REAL=$(${PYTHON_BIN} -c "
+import os, sys
+real = os.path.realpath(sys.argv[1])
+# realpath (not abspath) on the root too: on macOS /tmp is itself a symlink to
+# /private/tmp, and mixing the two forms makes relpath escape with '..'.
+root = os.path.realpath(sys.argv[2])
+rel = os.path.relpath(real, root)
+# Stay repo-relative when possible so downstream 'git add' remains in-repo.
+print(real if rel.startswith(os.pardir) else rel)
+" "$CONFIG_FILE" "${REPO_ROOT:-$(pwd)}" 2>/dev/null)
+  if [ -n "$CONFIG_REAL" ]; then
+    CONFIG_FILE="$CONFIG_REAL"
+    echo "🔗 .claude/vg.config.md is a symlink — config writes redirected to: ${CONFIG_FILE}"
+  else
+    echo "⚠ .claude/vg.config.md is a symlink but its target could not be resolved."
+    echo "  Continuing with the link path; verify the symlink after this command."
+  fi
+fi
+
 mkdir -p "$PLANNING_DIR"
 
 # Mode flags (mutually exclusive)

--- a/commands/vg/_shared/roam/spawn-executors.md
+++ b/commands/vg/_shared/roam/spawn-executors.md
@@ -100,7 +100,7 @@ if [ "$ROAM_MODE" = "spawn" ]; then
   # Resolve CLI command per model
   declare -A CLI_CMD_FOR_MODEL
   CLI_CMD_FOR_MODEL[codex]='cat "{brief}" | codex exec --full-auto'
-  CLI_CMD_FOR_MODEL[gemini]='cat "{brief}" | gemini -m gemini-2.5-pro -p "follow brief verbatim, output JSONL only" --yolo'
+  CLI_CMD_FOR_MODEL[gemini]='cat "{brief}" | agy --model "Gemini 3.5 Flash (Medium)" -p "follow brief verbatim, output JSONL only" --print-timeout 10m --dangerously-skip-permissions'
 
   declare -a PIDS
   for MODEL_DIR in "${ROAM_MODEL_DIRS[@]}"; do

--- a/commands/vg/_shared/test/goal-verification/delegation.md
+++ b/commands/vg/_shared/test/goal-verification/delegation.md
@@ -53,6 +53,25 @@ You are vg-test-goal-verifier. Verify phase ${PHASE_NUMBER} goals and return
 a JSON envelope. Do NOT browse files outside input. Do NOT ask user — input is
 the contract.
 
+<freshness_contract>
+READ EVERY INPUT FRESH FROM DISK before concluding anything — never rely on a
+cached snapshot from earlier in the session. Stale-read guard (dogfound P4.7
+amend#6, 2026-07-05: a verifier reported 10 goals "do not exist" citing an old
+`goal_count`, while its own verdict file said failing_goals:0 — internal
+contradiction from a pre-edit snapshot):
+
+1. First action: read TEST-GOALS.md and note its frontmatter `goal_count` +
+   count the `## G-NN` headings. If they disagree, RE-READ once.
+2. NEVER report a goal as "missing / does not exist" if it is present in
+   TEST-GOALS.md or GOAL-COVERAGE-MATRIX.md on disk. Absence must be verified
+   against a fresh read, not memory.
+3. Your narrative and your `.verdict-computed.json` MUST agree. If you are
+   about to write failing_goals:N while your prose says a different number,
+   STOP and re-derive both from the same fresh read.
+4. If the caller's prompt names goals (e.g. G-59..G-68) that you cannot find,
+   re-read the artifact once; only report absence if it truly is not on disk.
+</freshness_contract>
+
 <inputs>
 @${PHASE_DIR}/TEST-GOALS.md          (goals reference — read-only)
 @${PHASE_DIR}/RUNTIME-MAP.json       (review-discovered paths — read-only)

--- a/scripts/validators/acceptance-reconciliation.py
+++ b/scripts/validators/acceptance-reconciliation.py
@@ -276,12 +276,31 @@ def main() -> None:
         decisions = parse_decisions(context)
         if decisions:
             decision_ids = {d["id"] for d in decisions}
+            # Decisions already signed off in a prior accepted {phase}-UAT.md
+            # are settled — an amendment accept must not re-flag them for
+            # scope-branching (dogfound P4.7 amend#6: D-11/30/32/35/53/54 from
+            # earlier cycles re-flagged on incidental words like "choice"/"fork"
+            # even though 4.7-UAT.md accepted them). Only NEW decisions can have
+            # a genuinely-unaddressed branch.
+            accepted_ids: set[str] = set()
+            for uat in phase_dir.glob("*UAT*.md"):
+                try:
+                    utext = uat.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    continue
+                if not re.search(r"verdict:\s*ACCEPTED", utext, re.IGNORECASE):
+                    continue
+                for m in re.finditer(r"\bD-(\d+(?:\.\d+)?)\b", utext):
+                    accepted_ids.add(m.group(1))
             branching_unresolved = []
             for d in decisions:
                 body_lower = d["body"].lower()
                 if not BRANCHING_KW_RE.search(d["body"]):
                     continue
                 if FINALIZED_RE.search(d["body"]):
+                    continue
+                # skip decisions already accepted in a prior UAT sign-off
+                if d["id"] in accepted_ids or d["id"].split(".")[-1] in accepted_ids:
                     continue
                 # Look for sub-decisions D-XX.Y where XX = this decision's id
                 base_id = d["id"].split(".")[0]

--- a/scripts/validators/goal-coverage.py
+++ b/scripts/validators/goal-coverage.py
@@ -36,6 +36,12 @@ GOAL_RE = re.compile(
 STRATEGY_RE = re.compile(r"verification_strategy:\s*(\w+)", re.IGNORECASE)
 DEPENDS_RE = re.compile(r"depends_on_phase:\s*(\S+)", re.IGNORECASE)
 TS_BINDING_RE = re.compile(r"binds_to:\s*(TS-\d+(?:,\s*TS-\d+)*)", re.IGNORECASE)
+# vg-test-codegen emits `vg-binding: {phase}.G-NN` markers inside generated
+# .spec.ts files (NOT binds_to:TS-XX which codegen never produces). A goal is
+# covered when a spec file carries a vg-binding marker naming that goal id.
+# Dogfound P4.7 amend#6 (2026-07-05): 64 goals flagged unbound at accept even
+# though 10 real specs existed — validator only knew TS-XX + Implemented-by.
+VG_BINDING_RE = re.compile(r"vg-binding:\s*[\w.]*?\b(G-\d+)\b", re.IGNORECASE)
 # Legacy format: goals declare implementation via "Implemented by:" with .spec.ts filenames
 IMPL_BY_RE = re.compile(r"\*\*Implemented\s+by:\*\*", re.IGNORECASE)
 # Match test artifacts across: *.spec.ts/js, *.test.ts/py, smoke-*.sh
@@ -96,6 +102,27 @@ def find_ts_refs(scan_globs: list[str]) -> set[str]:
     return found
 
 
+def find_vg_binding_goals(scan_globs: list[str]) -> set[str]:
+    """Collect goal ids named by `vg-binding: {phase}.G-NN` markers in specs.
+
+    vg-test-codegen writes these markers into generated .spec.ts files. A goal
+    whose id shows up here has an executable spec bound to it, even without a
+    TS-XX marker or an `Implemented by:` line.
+    """
+    found = set()
+    for gp in scan_globs:
+        for f in Path(REPO_ROOT).glob(gp):
+            if not f.is_file():
+                continue
+            try:
+                text = f.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            for m in VG_BINDING_RE.finditer(text):
+                found.add(m.group(1).upper())
+    return found
+
+
 def phase_in_roadmap(phase: str) -> bool:
     if not ROADMAP.exists():
         return False
@@ -149,6 +176,12 @@ def main() -> None:
             f".vg/phases/{args.phase}-*/SANDBOX-TEST*.md",
         ]
         ts_refs = find_ts_refs(test_globs)
+        # vg-binding markers — scan the same spec globs plus the lifecycle dir
+        # where /vg:test-spec codegen lands per-goal specs.
+        vg_binding_goals = find_vg_binding_goals(test_globs + [
+            "tests/e2e/**/*.spec.ts",
+            "tests/e2e/**/*.ts",
+        ])
         existing_spec_files = set()
         for gp in test_globs + [
             "scripts/**/*.sh",
@@ -176,7 +209,10 @@ def main() -> None:
                     deferred_missing_target.append(f"{g['id']} → {target}")
                 continue
 
-            # automated: must have TS-XX binding covered OR a .spec.ts file that exists
+            # automated: covered by ANY of —
+            #   (1) TS-XX binding + a spec referencing that TS-XX
+            #   (2) legacy `Implemented by:` .spec.ts filename that exists
+            #   (3) vg-binding: {phase}.G-NN marker in a spec (codegen default)
             has_ts_binding = bool(g["binds_to"])
             has_impl_specs = bool(g["impl_specs"])
 
@@ -188,8 +224,9 @@ def main() -> None:
                     spec in existing_spec_files for spec in g["impl_specs"]
                 )
             )
+            covered_by_vg_binding = g["id"].upper() in vg_binding_goals
 
-            if not (covered_by_ts or covered_by_spec):
+            if not (covered_by_ts or covered_by_spec or covered_by_vg_binding):
                 detail = (
                     ",".join(g["binds_to"]) if has_ts_binding
                     else (",".join(g["impl_specs"]) if has_impl_specs
@@ -202,7 +239,7 @@ def main() -> None:
                 type="goal_unbound",
                 message=f"{len(unbound_automated)} automated goals not bound to any test file",
                 actual=", ".join(unbound_automated[:10]),
-                fix_hint="Each automated goal MUST have 'binds_to: TS-XX' + test file references that TS-XX.",
+                fix_hint="Each automated goal MUST be bound: 'binds_to: TS-XX' + spec referencing TS-XX, OR '**Implemented by:** <file>.spec.ts', OR a spec carrying 'vg-binding: {phase}.G-NN' (codegen default).",
             ))
 
         if deferred_missing_target:

--- a/scripts/validators/mutation-layers.py
+++ b/scripts/validators/mutation-layers.py
@@ -63,6 +63,10 @@ TOAST_PATTERNS = [
     r"toHaveText\s*\(\s*/(?:success|saved|created)",
     # Config-agnostic role/variant fallback
     r"role\s*=\s*['\"]status['\"]",
+    # page.locator('[role=status], [data-testid*=success], .success-banner')
+    # form (PrintwayV3 dogfound 2026-07-16) — codegen emits CSS-attr locators
+    # not getByRole for the toast/success assertion.
+    r"locator\s*\(\s*['\"`][^'\"`]*(?:role=[\"']?status|data-testid\*?=[\"']?success|success-banner|toast-success)",
 ]
 
 # Layer 2: Network settle — request fully completed before asserting
@@ -74,6 +78,9 @@ NETWORK_PATTERNS = [
     r"await\s+apiCall",
     # Some projects export helpers (keep flexible)
     r"waitForApiSettle\s*\(",
+    # API-contract specs assert the response status directly.
+    r"\.status\(\)\s*\)?\.?(?:toBeLessThan|toBe)\s*\(\s*(?:400|2\d\d)",
+    r"expect\s*\([^)]*\.status\(\)",
 ]
 
 # Layer 3: Persist verify — reload or navigate back, value still present
@@ -86,6 +93,12 @@ PERSIST_PATTERNS = [
     # if spec does initial getByText(X) then clicks edit, the persist
     # layer is the SECOND getByText(X) reading from server-refreshed data
     r"persistVerify\s*\(",
+    # API-contract specs (no rendered UI — discovery-only phases) verify
+    # persistence by RE-READING the server: request.get/fetch after the
+    # mutation. PrintwayV3 dogfound 2026-07-16 (P6.1 API-level lifecycle
+    # specs). Recognize a follow-up GET as the persist layer.
+    r"request\.get\s*\(",
+    r"\.get\s*\(\s*apiUrl",
 ]
 
 
@@ -153,13 +166,39 @@ def _scan_spec(path: Path) -> list[dict]:
         has_network = any(re.search(p, body, re.IGNORECASE) for p in NETWORK_PATTERNS)
         has_persist = any(re.search(p, body, re.IGNORECASE) for p in PERSIST_PATTERNS)
 
+        # API-contract vs DOM-mutation classification (PrintwayV3 dogfound
+        # 2026-07-16). A test that drives the mutation via Playwright's
+        # request context (request.post/put/patch/delete or an apiUrl() call)
+        # and NEVER touches page.click/fill/getByRole is an API-level spec:
+        # there is NO rendered UI, so a DOM "toast" is impossible and MUST NOT
+        # be required. For those, the success feedback layer = asserting the
+        # response status/body, which is already covered by the network layer.
+        # DOM specs keep the full toast+network+persist requirement.
+        # Negative/edge mutation tests (PrintwayV3 dogfound 2026-07-16): a test
+        # that EXPECTS the mutation to be REJECTED (asserts 4xx, an error-code
+        # envelope, or is test.skip) has NO saved state — persist/toast/network
+        # success-layers are semantically N/A. Detect and exempt.
+        is_negative = bool(
+            re.search(r"toBe(?:GreaterThanOrEqual)?\s*\(\s*4\d\d\s*\)", body)
+            or re.search(r"status\(\)\s*\)?\.?toBe\s*\(\s*4\d\d", body)
+            or re.search(r"\b(?:FORBIDDEN|TEAM_DEACTIVATED|STALE_ASSIGNMENT_STATE|STORE_ALREADY_ASSIGNED|MEMBER_INVITED|VALIDATION_FAILED|CONFLICT|_DENIED|NOT_FOUND|UNAUTHORIZED)\b", body)
+            or re.search(r"toBeGreaterThanOrEqual\s*\(\s*400", body)
+            or re.search(r"test\.skip\s*\(\s*true", body)
+        )
+
+        is_api_level = bool(
+            re.search(r"request\.(?:post|put|patch|delete)\s*\(", body, re.IGNORECASE)
+            or re.search(r"\.(?:post|put|patch|delete)\s*\(\s*apiUrl", body, re.IGNORECASE)
+        ) and not re.search(r"page\.(?:click|fill|getByRole|getByText|goto)\s*\(", body, re.IGNORECASE)
+
         missing: list[str] = []
-        if not has_toast:
-            missing.append("toast")
-        if not has_network:
-            missing.append("network")
-        if not has_persist:
-            missing.append("persist")
+        if not is_negative:
+            if not has_toast and not is_api_level:
+                missing.append("toast")
+            if not has_network:
+                missing.append("network")
+            if not has_persist:
+                missing.append("persist")
 
         if missing:
             violations.append({
@@ -171,26 +210,42 @@ def _scan_spec(path: Path) -> list[dict]:
     return violations
 
 
-def _collect_specs(phase_dir: Path | None, cli_override: bool) -> list[Path]:
+def _collect_specs(
+    phase_dir: Path | None,
+    cli_override: bool,
+    phase: str | None = None,
+) -> list[Path]:
     """Look at the phase generated tests dir + e2e dir.
 
-    Priority order:
-      1. PHASE_DIR/generated-tests/ (if exists — codegen output)
-      2. apps/web/e2e/ (standard Playwright location)
-      3. apps/*/e2e/ (monorepo generic)
-      4. tests/e2e/ (fallback)
+    PHASE-SCOPING (PrintwayV3 dogfound 2026-07-16): previously globbed the
+    ENTIRE apps/*/e2e + tests/e2e tree regardless of --phase, so a phase with
+    clean specs was BLOCKed by pre-existing shallow specs from OTHER phases
+    (6.1 blocked by apps/web/e2e/generated/{3.2,6,4.7}). When `phase` is known,
+    restrict e2e candidates to files whose path has a segment == phase, or a
+    `<phase>-`/`<phase>.` filename prefix. Full-tree only when phase is None.
     """
     candidates: list[Path] = []
     if phase_dir:
         gen = phase_dir / "generated-tests"
         if gen.is_dir():
             candidates += list(gen.rglob("*.spec.ts"))
-    # Include e2e dir always — hand-written tests live there
+        candidates += list(phase_dir.rglob("*.spec.ts"))
+
+    def _matches_phase(p: Path) -> bool:
+        if not phase:
+            return True
+        pl = phase.lower()
+        if pl in {s.lower() for s in p.parts}:
+            return True
+        name = p.name.lower()
+        return name.startswith(pl + "-") or name.startswith(pl + ".")
+
     for pat in ("apps/web/e2e", "apps/*/e2e", "tests/e2e"):
         for d in REPO_ROOT.glob(pat):
             if d.is_dir():
-                candidates += list(d.rglob("*.spec.ts"))
-    # Dedupe
+                for f in d.rglob("*.spec.ts"):
+                    if _matches_phase(f):
+                        candidates.append(f)
     seen: set[Path] = set()
     uniq: list[Path] = []
     for c in candidates:
@@ -216,7 +271,7 @@ def main() -> None:
     out = Output(validator="mutation-layers")
     with timer(out):
         phase_dir = find_phase_dir(args.phase)
-        specs = _collect_specs(phase_dir, args.allow_missing)
+        specs = _collect_specs(phase_dir, args.allow_missing, args.phase)
         if not specs:
             emit_and_exit(out)
 

--- a/scripts/validators/verify-api-docs-coverage.py
+++ b/scripts/validators/verify-api-docs-coverage.py
@@ -81,6 +81,15 @@ def main() -> None:
         sections = parse_contract_sections(contracts_path)
         entries = parse_api_docs_entries(docs_path)
         require_error_handling = _interface_standards_requires_error_handling(docs_path)
+        # Backend-only / 0-endpoint phases (e.g. worker + schema + migration
+        # remediation) legitimately have no HTTP endpoint sections in
+        # API-CONTRACTS.md. When the contract declares zero endpoints there is
+        # nothing to cross-check — the API-DOCS.md narrative stub is sufficient.
+        # Only demand machine-readable entries when the contract actually
+        # declares endpoints to document.
+        if not sections:
+            out.note = "no endpoint sections in API-CONTRACTS.md (backend-only phase) — coverage N/A"
+            emit_and_exit(out)
         if not entries:
             out.add(Evidence(
                 type="api_docs_no_entries",

--- a/scripts/validators/verify-contract-runtime.py
+++ b/scripts/validators/verify-contract-runtime.py
@@ -288,6 +288,23 @@ def main() -> None:
 
         endpoints = parse_contract_endpoints(contracts_path)
         if not endpoints:
+            # Backend-only / 0-endpoint phases (worker + schema + migration
+            # remediation) legitimately ship an API-CONTRACTS.md that documents
+            # INTERNAL service/worker interfaces and explicitly declares zero
+            # HTTP endpoints. That is NOT format drift — there is nothing to
+            # phantom-check. Detect the declaration and PASS instead of BLOCK.
+            try:
+                _ctext = contracts_path.read_text(encoding="utf-8", errors="ignore").lower()
+            except OSError:
+                _ctext = ""
+            _declares_no_http = (
+                "no new http api surface" in _ctext
+                or "endpoints noted: 0" in _ctext
+                or "0 endpoints" in _ctext
+                or "web-backend-only" in _ctext
+            )
+            if _declares_no_http:
+                emit_and_exit(out)
             # FAIL CLOSED (v2.45 PR fix/fail-closed-validators): API-CONTRACTS.md
             # exists but no `## METHOD /path` / `### METHOD /path` headers parsed.
             # Previously WARN — passed silently when contract format drifted.

--- a/scripts/validators/verify-deep-test-specs.py
+++ b/scripts/validators/verify-deep-test-specs.py
@@ -75,6 +75,14 @@ CREATE_ONLY_STAGES = ("read_before", "create", "read_after_create")
 UPDATE_ONLY_STAGES = ("read_before", "update", "read_after_update")
 DELETE_ONLY_STAGES = ("read_before", "delete", "read_after_delete")
 
+# B-dogfood (PrintwayV3 P9 2026-07-01): read-family stage-sets. MUST mirror
+# generate-lifecycle-specs.py + test_spec_ai_expander.py + verify-lifecycle-spec-depth.py.
+READ_HYDRATE_STAGES = ("read_before", "render_initial", "hydrate_authed", "hydrate_anon", "error_state_4xx", "accessibility")
+READ_SSR_SEO_STAGES = ("read_before", "render_initial", "seo_metadata", "revalidate_signed", "revalidate_tampered", "error_state_4xx")
+INFRA_BOOT_STAGES = ("read_before", "boot_start", "health_check", "idempotent_restart", "graceful_drain")
+NAVIGATION_STAGES = ("read_before", "render_initial", "nav_active_state", "deep_link_reload", "back_restore", "accessibility")
+AUTH_ROUTE_STAGES = ("read_before", "unauth_redirect", "login_returnurl", "authed_access", "logout_clears")
+
 # Map goal_class / goal_type → expected stage set.
 # Lookup order in _expected_stages_for_spec():
 #   1. goal_class (B62-pre dispatch precedence)
@@ -84,6 +92,21 @@ GOAL_CLASS_STAGE_SETS = {
     "feature_chain": FEATURE_CHAIN_STAGES,
     "post_create_cascade": FEATURE_CHAIN_STAGES,  # alias per B62-pre
     "readonly": READONLY_STAGES,
+    # B66 (PrintwayV3 P4.7 dogfood 2026-06-07): generate-lifecycle-specs.py emits
+    # goal_class in {create-only,update-only,delete-only,read-only} for partial-
+    # lifecycle goals (FK-restrict-delete, stale-version PATCH). Validator only
+    # mapped feature_chain/readonly; when goal_type=multi-actor (absent from
+    # GOAL_TYPE_STAGE_SETS) dispatch fell through to default RCRURDR -> false
+    # BLOCK on legit delete-only goals. Mirror the partial sets here.
+    "read-only": READONLY_STAGES,
+    "create-only": CREATE_ONLY_STAGES,
+    "update-only": UPDATE_ONLY_STAGES,
+    "delete-only": DELETE_ONLY_STAGES,
+    "read-hydrate": READ_HYDRATE_STAGES,
+    "read-ssr-seo": READ_SSR_SEO_STAGES,
+    "infra-boot": INFRA_BOOT_STAGES,
+    "navigation": NAVIGATION_STAGES,
+    "auth-route": AUTH_ROUTE_STAGES,
 }
 
 GOAL_TYPE_STAGE_SETS = {
@@ -91,6 +114,11 @@ GOAL_TYPE_STAGE_SETS = {
     "create-only": CREATE_ONLY_STAGES,
     "update-only": UPDATE_ONLY_STAGES,
     "delete-only": DELETE_ONLY_STAGES,
+    "read-hydrate": READ_HYDRATE_STAGES,
+    "read-ssr-seo": READ_SSR_SEO_STAGES,
+    "infra-boot": INFRA_BOOT_STAGES,
+    "navigation": NAVIGATION_STAGES,
+    "auth-route": AUTH_ROUTE_STAGES,
 }
 
 

--- a/scripts/validators/verify-lifecycle-spec-depth.py
+++ b/scripts/validators/verify-lifecycle-spec-depth.py
@@ -60,9 +60,13 @@ ARTIFACT_WORD_RE = re.compile(
     re.IGNORECASE,
 )
 
+# B98: `admin` removed — it is a SINGLE role, the opposite of a multi-actor
+# signal. Pre-B98 every admin-only goal ("admin opens page X") tripped this
+# regex and was wrongly required to declare >=2 actors. Genuine multi-actor
+# (admin impersonates merchant) still matches via `impersonat`/`owner`/etc.
 MULTI_ACTOR_WORD_RE = re.compile(
     r"\b("
-    r"multi[-\s]?actor|owner|invitee|inviter|admin|approver|reviewer|"
+    r"multi[-\s]?actor|owner|invitee|inviter|approver|reviewer|"
     r"second\s+user|another\s+user|role\s+switch|impersonat|oauth"
     r")\b",
     re.IGNORECASE,
@@ -219,10 +223,16 @@ REQUIRED_STAGES_BY_CLASS: dict[str, tuple[str, ...]] = {
     "create-only": ("read_before", "create", "read_after_create"),
     "update-only": ("read_before", "update", "read_after_update"),
     "delete-only": ("read_before", "delete", "read_after_delete"),
+    # B-dogfood (PrintwayV3 P9 2026-07-01): read-family min-required subsets.
+    "read-hydrate": ("read_before", "render_initial"),
+    "read-ssr-seo": ("read_before", "render_initial"),
+    "infra-boot":   ("read_before", "boot_start"),
+    "navigation":   ("read_before", "render_initial"),
+    "auth-route":   ("read_before", "unauth_redirect"),
 }
 
 
-def _required_stages_for(goal: dict[str, Any]) -> tuple[str, ...]:
+def _required_stages_for(goal: dict[str, Any], spec: dict[str, Any] | None = None) -> tuple[str, ...]:
     """B97 v4.69.0: explicit goal_class enum dictates required stage subset.
 
     Returns the stage tuple the validator should enforce for `goal`. Falls
@@ -230,6 +240,15 @@ def _required_stages_for(goal: dict[str, Any]) -> tuple[str, ...]:
     mutation-class value.
     """
     gc = str(goal.get("goal_class") or "").lower().strip()
+    # B98: the lifecycle SPEC is the authoritative contract. When the
+    # goal-side goal_class is blank (TEST-GOALS commonly omits it), fall back
+    # to the spec's declared goal_class before defaulting to full RCRURDR.
+    # Pre-B98 read goal-only -> readonly render specs wrongly required
+    # create/update/delete stages.
+    if gc not in REQUIRED_STAGES_BY_CLASS and spec is not None:
+        spec_gc = str(spec.get("goal_class") or "").lower().strip()
+        if spec_gc in REQUIRED_STAGES_BY_CLASS:
+            gc = spec_gc
     if gc in REQUIRED_STAGES_BY_CLASS:
         return REQUIRED_STAGES_BY_CLASS[gc]
     return REQUIRED_STAGES
@@ -436,7 +455,7 @@ def main() -> None:
             # B97 v4.69.0 (issue #201): use per-class required subset when
             # explicit goal_class declares non-mutation. Pre-B97 always used
             # full RCRURDR → false positive on 3-stage create-only goals.
-            required = _required_stages_for(goal)
+            required = _required_stages_for(goal, spec)
             missing = [stage for stage in required if stage not in _stage_names(spec)]
             if missing:
                 gc = str(goal.get("goal_class") or "").lower().strip()

--- a/scripts/vg_generate_config.py
+++ b/scripts/vg_generate_config.py
@@ -122,18 +122,18 @@ def _stack_from_framework(fw: str) -> str:
 def render_crossai_clis(team_size: str) -> str:
     if team_size == "solo":
         clis = [
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     elif team_size in ("2-5",):
         clis = [
             ("Codex", 'cat {context} | codex exec "{prompt}"', "Codex configured model"),
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     else:
         clis = [
             ("Codex", 'cat {context} | codex exec "{prompt}"', "Codex configured model"),
-            ("Gemini", 'cat {context} | gemini -m gemini-3.1-pro-preview -p "{prompt}" --yolo', "Gemini Pro High 3.1"),
-            ("Claude", 'cat {context} | claude --model sonnet -p "{prompt}"', "Claude Sonnet 4.6"),
+            ("Gemini", 'cat {context} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions', "Gemini Pro High 3.1"),
+            ("Claude", 'cat {context} | claude --model opus -p "{prompt}"', "Claude Opus 5 (1M)"),
         ]
     lines = ["crossai_clis:"]
     for name, cmd, label in clis:

--- a/skills/vg-crossai/SKILL.md
+++ b/skills/vg-crossai/SKILL.md
@@ -78,7 +78,7 @@ All modes produce output conforming to this schema:
         </finding>
       </findings>
     </cli>
-    <cli source="claude" model="sonnet-4.6">
+    <cli source="claude" model="opus-5">
       <verdict>pass|flag|block</verdict>
       <score>{1-10}</score>
       <findings>
@@ -118,12 +118,12 @@ codex exec "$(cat {context_file})" > {output_path} 2>&1 &
 
 **Gemini (Pro High 3.1):**
 ```bash
-cat {context_file} | gemini -m gemini-2.5-pro -p "{prompt}" --yolo > {output_path} 2>&1 &
+cat {context_file} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions > {output_path} 2>&1 &
 ```
 
 **Claude (Sonnet 4.6):**
 ```bash
-cat {context_file} | claude --model sonnet -p "{prompt}" > {output_path} 2>&1 &
+cat {context_file} | claude --model opus -p "{prompt}" > {output_path} 2>&1 &
 ```
 
 ### Parallel Spawn Pattern
@@ -138,10 +138,10 @@ mkdir -p "$OUTPUT_DIR"
 codex exec "$(cat $CONTEXT_FILE)" > "$OUTPUT_DIR/codex.out" 2>&1 &
 PID_CODEX=$!
 
-cat "$CONTEXT_FILE" | gemini -m gemini-2.5-pro -p "$PROMPT" --yolo > "$OUTPUT_DIR/gemini.out" 2>&1 &
+cat "$CONTEXT_FILE" | agy --model "Gemini 3.1 Pro (High)" -p "$PROMPT" --print-timeout 10m --dangerously-skip-permissions > "$OUTPUT_DIR/gemini.out" 2>&1 &
 PID_GEMINI=$!
 
-cat "$CONTEXT_FILE" | claude --model sonnet -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
+cat "$CONTEXT_FILE" | claude --model opus -p "$PROMPT" > "$OUTPUT_DIR/claude.out" 2>&1 &
 PID_CLAUDE=$!
 
 # Wait for all to complete

--- a/templates/vg/vg.config.template.md
+++ b/templates/vg/vg.config.template.md
@@ -227,11 +227,11 @@ crossai_clis:
     command: 'cat {context} | codex exec "{prompt}"'
     label: "Codex configured model"
   - name: "Gemini"
-    command: 'cat {context} | gemini -m gemini-3.1-pro-preview -p "{prompt}" --yolo'
+    command: 'cat {context} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions'
     label: "Gemini Pro High 3.1"
   - name: "Claude"
-    command: 'cat {context} | claude --model sonnet -p "{prompt}"'
-    label: "Claude Sonnet 4.6"
+    command: 'cat {context} | claude --model opus -p "{prompt}"'
+    label: "Claude Opus 5 (1M)"
     # ➜ Fable 5 upgrade (when available): change --model to claude-fable-5.
     # Fable 5 (released 2026-06-09) — Mythos-class code-specialist
     # (SWE-Bench Pro 80.3% vs Opus 4.8 69.2%). The CLI-pipe lane accepts the

--- a/vg.config.template.md
+++ b/vg.config.template.md
@@ -105,6 +105,15 @@ models:
   test_codegen: "sonnet"    # test step — generate Playwright from specs
   # Note: scope, accept, review orchestration use parent model (no agent spawn)
   # Note: CrossAI uses external CLIs (crossai_clis section), not this config
+  #
+  # ⚠ Fable 5 / custom model ids: these keys feed `Agent(model=...)` for SPAWNED
+  # subagents. The Claude Code Agent tool enum is currently locked to
+  # sonnet|opus|haiku and REJECTS claude-fable-5 (InputValidationError). So
+  # setting e.g. executor: "claude-fable-5" here will BREAK build (every wave
+  # spawn fails) until the harness opens the enum. To use Fable 5 on
+  # code-heavy work TODAY, run the whole session on Fable 5 (parent model) —
+  # scope, blueprint orchestration, narrative, review run on the parent.
+  # See docs/guides/fable-5-integration.md.
 
 # === Worktree Port Offsets ===
 # Each worktree uses base_port + offset to avoid collisions
@@ -223,6 +232,15 @@ crossai_clis:
   - name: "Claude"
     command: 'cat {context} | claude --model opus -p "{prompt}"'
     label: "Claude Opus 5 (1M)"
+    # ➜ Fable 5 upgrade (when available): change --model to claude-fable-5.
+    # Fable 5 (released 2026-06-09) — Mythos-class code-specialist
+    # (SWE-Bench Pro 80.3% vs Opus 4.8 69.2%). The CLI-pipe lane accepts the
+    # full API model id (NOT enum-locked like the Agent-tool spawn path), so
+    # the only gate here is whether your `claude` CLI + account resolve the id.
+    # VERIFY FIRST before switching — a CLI without access fails this lane on
+    # every CrossAI run:
+    #   echo ping | claude --model claude-fable-5 -p "reply OK"
+    # If that returns OK, set: command: 'cat {context} | claude --model claude-fable-5 -p "{prompt}"'
 
 # === Budget floor (v2.68.0 C6) ===
 # Per-phase cost cap in USD. When the budget tracker (scripts/vg-budget-tracker.py)

--- a/vg.config.template.md
+++ b/vg.config.template.md
@@ -218,11 +218,11 @@ crossai_clis:
     command: 'cat {context} | codex exec "{prompt}"'
     label: "Codex configured model"
   - name: "Gemini"
-    command: 'cat {context} | gemini -m gemini-3.1-pro-preview -p "{prompt}" --yolo'
+    command: 'cat {context} | agy --model "Gemini 3.1 Pro (High)" -p "{prompt}" --print-timeout 10m --dangerously-skip-permissions'
     label: "Gemini Pro High 3.1"
   - name: "Claude"
-    command: 'cat {context} | claude --model sonnet -p "{prompt}"'
-    label: "Claude Sonnet 4.6"
+    command: 'cat {context} | claude --model opus -p "{prompt}"'
+    label: "Claude Opus 5 (1M)"
 
 # === Budget floor (v2.68.0 C6) ===
 # Per-phase cost cap in USD. When the budget tracker (scripts/vg-budget-tracker.py)


### PR DESCRIPTION
Five commits found while dogfooding VGFlow on a real project (PrintwayV3).

## 1. `feat(crossai)` — Claude council lane Sonnet 4.6 → Opus 5

The 3-lane CrossAI council still pinned `claude --model sonnet` while the other two lanes had moved on. The `opus` alias resolves `cc/claude-opus-5[1m]`, verified end-to-end by round-tripping the model id through `crossai-runner.py` (exit=0, returned the id).

Also syncs two lanes that had drifted out of the generator but were already fixed in project configs: the Gemini lane still invoked the `gemini` CLI (retired 2026-06-18; `agy` is the only path), and `scripts/vg_generate_config.py` had kept that retired invocation while its `.claude` mirror was updated.

**Cost note:** the Claude lane is now ~5x Sonnet's input price ($15/M vs $3/M), so CrossAI-heavy phases reach `min_budget_floor_usd` sooner.

## 2. `fix(project)` — `/vg:project --rewrite` destroyed a consolidated config symlink

A project may collapse the dual config layout (`.vg/config.md` + `.claude/vg.config.md`) into one real file plus a symlink. Two writers acted on the **link** rather than its target:

- `update-modes.md:96` — `mv "$CONFIG_FILE" "$BACKUP_DIR/…pre-rewrite"` moved the link away
- `first-time-rounds.md:519` — `mv "${CONFIG_FILE}.staged" "$CONFIG_FILE"` then dropped a plain file in its place

Net effect: `--rewrite` silently destroyed the symlink and resurrected the dual-config drift it existed to prevent. (In our case that drift had already caused four real misconfigurations, including a `planner_max_lines` cap that silently overrode a deliberate raise.)

`preflight.md` now resolves `$CONFIG_FILE` to the real path when `[ -L ]` is true, so every downstream write lands on the canonical file. It uses `os.path.realpath` on **both** sides — realpath, not abspath, on the repo root, because on macOS `/tmp` is itself a symlink to `/private/tmp` and mixing the forms makes `relpath` escape with `..` — and keeps the result repo-relative so downstream `git add` stays in-repo. `first-time-rounds.md` adds a self-heal that rebuilds the link if another writer still replaces it.

Verified in throwaway repos across three layouts:

| Layout | Result |
|---|---|
| symlink | survives backup + promote; both paths read the regenerated config |
| plain (no symlink) | behaviour byte-for-byte unchanged, self-heal correctly skipped |
| dangling link | `CONFIG_EXISTS=false` triggers regen, link heals into the target |

## 3. `fix(validators)` — dogfound gate fixes + mirror parity

- `goal-coverage.py`: recognize the `vg-binding: {phase}.G-NN` markers `vg-test-codegen` actually emits. It only understood `TS-XX` and `Implemented by:`, so P4.7 amend#6 flagged 64 goals unbound at accept despite 10 real spec files existing.
- Matching corrections in `acceptance-reconciliation.py`, `verify-api-docs-coverage.py`, `verify-contract-runtime.py`, `verify-deep-test-specs.py`, `verify-lifecycle-spec-depth.py`.
- accept/uat checklist-build + test/goal-verification delegation docs: subagent stale-read guard (verdicts can be false-negative against an out-of-date snapshot; on-disk state wins).
- Restores canonical/`.claude` mirror parity — six validators had been edited on only one side, which was failing three mirror-parity tests (batch65b, batch97, lifecycle_spec_workflow_wiring).

## 4. `fix(validator)` — mutation-layers phase-scoped + API-spec/negative-test aware

## 5. `fix(template)` — root `vg.config.template.md` synced with the `.claude` mirror

v4.74.0 (9dfc40e) added the Fable 5 guidance blocks to `templates/vg/…` and `.claude/templates/vg/…` but not to the root `vg.config.template.md`, which `test_h4_idempotency_default_off::test_mirror_config` asserts is byte-identical to the mirror. That test **fails on current main**; this fixes it.

Note the Fable 5 comment blocks from 9dfc40e are preserved verbatim on top of the Opus lane — the rebase conflict was resolved to keep both.

## Testing

Rebased onto `origin/main` (9dfc40e). Full suite: **6 failed / 3488 passed / 7 skipped**.

Baseline measured at `origin/main` in a clean worktree is **7 failed**. This branch is one *better* — commit 5 fixes `test_h4_idempotency_default_off::test_mirror_config`. The remaining 6 are pre-existing and unrelated (evidence run-id binding ×3, block-handled counter, tasklist adapter check, override-resolve yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
